### PR TITLE
MAPI-980 - invalid topics filtering

### DIFF
--- a/common/src/main/scala/auditor/AuditorWSClient.scala
+++ b/common/src/main/scala/auditor/AuditorWSClient.scala
@@ -1,0 +1,17 @@
+package auditor
+
+import models.Topic
+import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AuditorWSClient(wsClient: WSClient)(implicit ec: ExecutionContext) {
+  def expiredTopics(auditor: Auditor, topics: Set[Topic]): Future[Set[Topic]] = topics.toList match {
+    case Nil => Future.successful(topics)
+    case tl => wsClient
+      .url(s"${ auditor.host }/expired-topics")
+      .post(Json.toJson(ExpiredTopicsRequest(tl)))
+      .map { _.json.as[ExpiredTopicsResponse].topics.toSet }
+  }
+}

--- a/common/src/main/scala/auditor/package.scala
+++ b/common/src/main/scala/auditor/package.scala
@@ -1,0 +1,29 @@
+import java.net.URL
+
+import models.Topic
+import play.api.libs.json.Json
+
+import scala.concurrent.{ExecutionContext, Future}
+
+package object auditor {
+
+  case class AuditorGroupConfig(hosts: Set[String])
+
+  case class Auditor(host: URL)
+
+  case class AuditorGroup(auditors: Set[Auditor]) {
+    def queryEach[T](query: Auditor => Future[T])(implicit ec: ExecutionContext): Future[Set[T]] =
+      Future.sequence(auditors.map(query(_)))
+  }
+
+  def mkAuditorGroup(config: AuditorGroupConfig): AuditorGroup = AuditorGroup(
+    config.hosts map { host => Auditor(new URL(host)) }
+  )
+
+
+  case class ExpiredTopicsRequest(topics: List[Topic])
+  case class ExpiredTopicsResponse(topics: List[Topic])
+
+  implicit val expiredTopicsRequestFormat = Json.format[ExpiredTopicsRequest]
+  implicit val expiredTopicsResponseFormat = Json.format[ExpiredTopicsResponse]
+}

--- a/common/src/main/scala/auditor/package.scala
+++ b/common/src/main/scala/auditor/package.scala
@@ -13,7 +13,7 @@ package object auditor {
 
   case class AuditorGroup(auditors: Set[Auditor]) {
     def queryEach[T](query: Auditor => Future[T])(implicit ec: ExecutionContext): Future[Set[T]] =
-      Future.sequence(auditors.map(query(_)))
+      Future.sequence(auditors.map(query))
   }
 
   def mkAuditorGroup(config: AuditorGroupConfig): AuditorGroup = AuditorGroup(

--- a/common/src/test/scala/auditor/AuditorWSClientSpec.scala
+++ b/common/src/test/scala/auditor/AuditorWSClientSpec.scala
@@ -23,7 +23,7 @@ class AuditorWSClientSpec(implicit ev: ExecutionEnv) extends Specification with 
         case POST(p"/expired-topics") => Action {
           Results.Ok(Json.toJson(ExpiredTopicsResponse(topics.toList)))
         }
-      } { port =>
+      } { implicit port =>
         WsTestClient.withClient { client =>
           val auditorWSClient = new AuditorWSClient(client)
           val auditor = Auditor(new URL(s"http://localhost:$port"))

--- a/common/src/test/scala/auditor/AuditorWSClientSpec.scala
+++ b/common/src/test/scala/auditor/AuditorWSClientSpec.scala
@@ -1,0 +1,48 @@
+package auditor
+
+import java.net.URL
+
+import models.Topic
+import models.TopicTypes.FootballMatch
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
+import play.api.mvc.{Results, Action}
+import play.api.routing.sird._
+import play.api.test.WsTestClient
+import play.core.server.Server
+
+class AuditorWSClientSpec(implicit ev: ExecutionEnv) extends Specification with Mockito {
+  "Auditor WS Client" should {
+    "query auditor host and return filtered list of topics" in {
+      val topics = Set(Topic(`type` = FootballMatch, name = "barca-chelsea"))
+
+      Server.withRouter() {
+        case POST(p"/expired-topics") => Action {
+          Results.Ok(Json.toJson(ExpiredTopicsResponse(topics.toList)))
+        }
+      } { port =>
+        WsTestClient.withClient { client =>
+          val auditorWSClient = new AuditorWSClient(client)
+          val auditor = Auditor(new URL(s"http://localhost:$port"))
+
+          val filteredTopics = auditorWSClient.expiredTopics(auditor, topics)
+
+          filteredTopics must beEqualTo(topics).await
+        }
+      }
+    }
+
+    "not query web service with empty list" in {
+      val wsClient = mock[WSClient]
+      val auditor = Auditor(new URL(s"http://localhost:9000"))
+      val auditorWSClient = new AuditorWSClient(wsClient)
+
+      auditorWSClient.expiredTopics(auditor, Set.empty)
+
+      there were no(wsClient).url(anyString)
+    }
+  }
+}

--- a/common/src/test/scala/gu/msnotifications/WNSTagSpec.scala
+++ b/common/src/test/scala/gu/msnotifications/WNSTagSpec.scala
@@ -1,6 +1,6 @@
-package models
+package gu.msnotifications
 
-import gu.msnotifications.WNSTag
+import models.Topic
 import models.TopicTypes.FootballMatch
 import org.specs2.mutable.Specification
 

--- a/registration/app/services/Configuration.scala
+++ b/registration/app/services/Configuration.scala
@@ -2,6 +2,7 @@ package services
 
 import javax.inject.Inject
 
+import auditor.AuditorGroupConfig
 import com.gu.conf.ConfigurationFactory
 
 import scala.concurrent.ExecutionContext
@@ -13,7 +14,7 @@ case class NotificationHubConfiguration(
   sharedKeyValue: String
 )
 
-final class Configuration @Inject()()(implicit executionContext: ExecutionContext) {
+class Configuration @Inject()()(implicit executionContext: ExecutionContext) {
 
   private lazy val conf = ConfigurationFactory.getConfiguration(
     applicationName = "registration",
@@ -25,5 +26,12 @@ final class Configuration @Inject()()(implicit executionContext: ExecutionContex
     hubName = conf.getStringProperty("gu.msnotifications.hubname").get,
     sharedKeyName = conf.getStringProperty("gu.msnotifications.sharedKeyName").get,
     sharedKeyValue = conf.getStringProperty("gu.msnotifications.sharedKeyValue").get
+  )
+
+  lazy val auditorConfiguration = AuditorGroupConfig(
+    hosts = Set(
+      conf.getStringProperty("notifications.auditor.content-notifications").get,
+      conf.getStringProperty("notifications.auditor.goal-alerts").get
+    )
   )
 }

--- a/registration/app/services/topic/TopicValidator.scala
+++ b/registration/app/services/topic/TopicValidator.scala
@@ -1,0 +1,43 @@
+package services.topic
+
+import javax.inject.Inject
+
+import auditor.{AuditorWSClient, mkAuditorGroup}
+import com.google.inject.ImplementedBy
+import models.Topic
+import play.api.libs.ws.WSClient
+import services.Configuration
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scalaz.\/
+import scalaz.syntax.either._
+
+@ImplementedBy(classOf[AuditorTopicValidator])
+trait TopicValidator {
+  def removeInvalid(topics: Set[Topic]): Future[TopicValidatorError \/ Set[Topic]]
+
+  trait TopicValidatorError {
+    def reason: String
+  
+    def topicsQueried: Set[Topic]
+  }
+}
+
+final class AuditorTopicValidator(auditorClient: AuditorWSClient, configuration: Configuration)
+  extends TopicValidator {
+
+  @Inject def this(wsClient: WSClient, configuration: Configuration) = this(new AuditorWSClient(wsClient),
+                                                                            configuration)
+
+  override def removeInvalid(topics: Set[Topic]) =
+    mkAuditorGroup(configuration.auditorConfiguration)
+      .queryEach { auditorClient.expiredTopics(_, topics) }
+      .map { _.flatten.right }
+      .recover { case _ => AuditorClientError(topics).left }
+  
+  case class AuditorClientError(topicsQueried: Set[Topic]) extends TopicValidatorError {
+    override def reason: String = "Failed fetching invalid topics from Auditor client"
+  }
+}
+

--- a/registration/test/services/topic/AuditorTopicValidatorSpec.scala
+++ b/registration/test/services/topic/AuditorTopicValidatorSpec.scala
@@ -25,8 +25,8 @@ class AuditorTopicValidatorSpec(implicit ee: ExecutionEnv) extends Specification
         validInA,
         validInB
       )
-      auditorWSClient.expiredTopics(argThat(===(auditorA)), anySetOf[Topic]) returns successful(topics - invalidTopic - validInB)
-      auditorWSClient.expiredTopics(argThat(===(auditorB)), anySetOf[Topic]) returns successful(topics - invalidTopic - validInA)
+      auditorWSClient.expiredTopics(===(auditorA), anySetOf[Topic]) returns successful(topics - invalidTopic - validInB)
+      auditorWSClient.expiredTopics(===(auditorB), anySetOf[Topic]) returns successful(topics - invalidTopic - validInA)
 
       val validTopics = topicValidator.removeInvalid(topics)
 

--- a/registration/test/services/topic/AuditorTopicValidatorSpec.scala
+++ b/registration/test/services/topic/AuditorTopicValidatorSpec.scala
@@ -1,0 +1,42 @@
+package services.topic
+
+import auditor.{AuditorGroupConfig, AuditorWSClient}
+import models.Topic
+import models.TopicTypes.{Content, FootballMatch}
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import services.Configuration
+
+import scala.concurrent.Future.successful
+import scalaz.syntax.either._
+
+class AuditorTopicValidatorSpec(implicit ee: ExecutionEnv) extends Specification with Mockito {
+  "Auditor Topic Validator" should {
+    "return filtered list of topics from both auditors" in new validators {
+      val invalidTopic = Topic(`type` = FootballMatch, name = "invalidFromAuditorA")
+      val validInA = Topic(`type` = Content, name = "validinA")
+      val topics = Set(
+        invalidTopic,
+        validInA,
+        Topic(`type` = Content, name = "validInB")
+      )
+      auditorWSClient.expiredTopics(any, anySetOf[Topic]) returns successful(topics - invalidTopic) thenReturns successful(topics - invalidTopic - validInA)
+
+      val validTopics = topicValidator.removeInvalid(topics)
+
+      validTopics must beEqualTo((topics - invalidTopic).right).await
+    }
+  }
+
+  trait validators extends Scope {
+    val configuration = new Configuration() {
+      override lazy val auditorConfiguration = AuditorGroupConfig(
+        hosts = Set("http://localhost/auditorA", "http://locahost/auditorB")
+      )
+    }
+    val auditorWSClient = mock[AuditorWSClient]
+    val topicValidator = new AuditorTopicValidator(auditorWSClient, configuration)
+  }
+}

--- a/registration/test/services/topic/AuditorTopicValidatorSpec.scala
+++ b/registration/test/services/topic/AuditorTopicValidatorSpec.scala
@@ -1,6 +1,8 @@
 package services.topic
 
-import auditor.{AuditorGroupConfig, AuditorWSClient}
+import java.net.URL
+
+import auditor.{Auditor, AuditorGroupConfig, AuditorWSClient}
 import models.Topic
 import models.TopicTypes.{Content, FootballMatch}
 import org.specs2.concurrent.ExecutionEnv
@@ -17,12 +19,14 @@ class AuditorTopicValidatorSpec(implicit ee: ExecutionEnv) extends Specification
     "return filtered list of topics from both auditors" in new validators {
       val invalidTopic = Topic(`type` = FootballMatch, name = "invalidFromAuditorA")
       val validInA = Topic(`type` = Content, name = "validinA")
+      val validInB = Topic(`type` = Content, name = "validInB")
       val topics = Set(
         invalidTopic,
         validInA,
-        Topic(`type` = Content, name = "validInB")
+        validInB
       )
-      auditorWSClient.expiredTopics(any, anySetOf[Topic]) returns successful(topics - invalidTopic) thenReturns successful(topics - invalidTopic - validInA)
+      auditorWSClient.expiredTopics(argThat(===(auditorA)), anySetOf[Topic]) returns successful(topics - invalidTopic - validInB)
+      auditorWSClient.expiredTopics(argThat(===(auditorB)), anySetOf[Topic]) returns successful(topics - invalidTopic - validInA)
 
       val validTopics = topicValidator.removeInvalid(topics)
 
@@ -31,12 +35,16 @@ class AuditorTopicValidatorSpec(implicit ee: ExecutionEnv) extends Specification
   }
 
   trait validators extends Scope {
-    val configuration = new Configuration() {
-      override lazy val auditorConfiguration = AuditorGroupConfig(
-        hosts = Set("http://localhost/auditorA", "http://locahost/auditorB")
-      )
-    }
     val auditorWSClient = mock[AuditorWSClient]
-    val topicValidator = new AuditorTopicValidator(auditorWSClient, configuration)
+    val auditorA = Auditor(new URL("http://localhost/auditorA"))
+    val auditorB = Auditor(new URL("http://locahost/auditorB"))
+    val topicValidator = {
+      val configuration = new Configuration() {
+        override lazy val auditorConfiguration = AuditorGroupConfig(
+          hosts = Set(auditorA.host, auditorB.host).map(_.toString)
+        )
+      }
+      new AuditorTopicValidator(auditorWSClient, configuration)
+    }
   }
 }


### PR DESCRIPTION
Topics filtered against auditors before sending registration request to provider.

Still to come in next PRs:
- rename WNSTag to Tag
- return list of topics in response
- update README