### PR TITLE
Update sbt-riffraff-artifact and change build.sbt to build all artefacts

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,10 +2,9 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.2")
 
-addSbtPlugin("com.gu" % "riffraff-artifact" % "0.6.1")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.4")
 
 addSbtPlugin("com.teambytes.sbt" % "sbt-dynamodb" % "1.1")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0" excludeAll(
-  ExclusionRule(organization = "com.danieltrinh")))
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0" excludeAll ExclusionRule(organization = "com.danieltrinh"))
 libraryDependencies += "org.scalariform" %% "scalariform" % "0.1.7"


### PR DESCRIPTION
Updates sbt-riffraff-artefacts plugin to the latest version and change build.sbt to build the 4 artefacts on one go.