### PR TITLE
Fixed notification types

### DIFF
--- a/common/src/main/scala/models/Notification.scala
+++ b/common/src/main/scala/models/Notification.scala
@@ -28,7 +28,7 @@ object Notification {
       json \ "type" match {
         case JsDefined(JsString("news")) => BreakingNewsNotification.jf.reads(json)
         case JsDefined(JsString("content")) => ContentNotification.jf.reads(json)
-        case JsDefined(JsString("goalAlert")) => GoalAlertNotification.jf.reads(json)
+        case JsDefined(JsString("goal")) => GoalAlertNotification.jf.reads(json)
         case _ => JsError("Unknown notification type")
       }
     }

--- a/common/src/main/scala/models/NotificationType.scala
+++ b/common/src/main/scala/models/NotificationType.scala
@@ -13,8 +13,8 @@ object NotificationType {
 
   val fromRep: Map[String, NotificationType] = Map(
     "news" -> BreakingNews,
-    "content" -> Content,
-    "goalAlert" -> GoalAlert
+    "content" -> Content, //TODO maybe it should be tag?
+    "goal" -> GoalAlert
   )
 
   val toRep: Map[NotificationType, String] = fromRep.map(_.swap)

--- a/common/src/main/scala/models/NotificationType.scala
+++ b/common/src/main/scala/models/NotificationType.scala
@@ -13,7 +13,7 @@ object NotificationType {
 
   val fromRep: Map[String, NotificationType] = Map(
     "news" -> BreakingNews,
-    "content" -> Content, //TODO see if this should be tag?
+    "content" -> Content, 
     "goal" -> GoalAlert
   )
 

--- a/common/src/main/scala/models/NotificationType.scala
+++ b/common/src/main/scala/models/NotificationType.scala
@@ -13,7 +13,7 @@ object NotificationType {
 
   val fromRep: Map[String, NotificationType] = Map(
     "news" -> BreakingNews,
-    "content" -> Content, //TODO maybe it should be tag?
+    "content" -> Content, //TODO see if this should be tag?
     "goal" -> GoalAlert
   )
 

--- a/common/src/test/scala/models/NotificationSpec.scala
+++ b/common/src/test/scala/models/NotificationSpec.scala
@@ -135,7 +135,7 @@ class NotificationSpec extends Specification {
        """
          |{
          |  "id" : "3e0bc788-a27c-4864-bb71-77a80aadcce4",
-         |  "type" : "goalAlert",
+         |  "type" : "goal",
          |  "title" : "The Guardian",
          |  "message" : "Leicester 2-1 Watford\nDeeney 75min",
          |  "sender" : "test",

--- a/notification/app/notification/models/azure/Notification.scala
+++ b/notification/app/notification/models/azure/Notification.scala
@@ -28,7 +28,7 @@ object Notification {
       json \ "type" match {
         case JsDefined(JsString("news")) => BreakingNewsNotification.jf.reads(json)
         case JsDefined(JsString("content")) => ContentNotification.jf.reads(json)
-        case JsDefined(JsString("goalAlert")) => GoalAlertNotification.jf.reads(json)
+        case JsDefined(JsString("goal")) => GoalAlertNotification.jf.reads(json)
         case _ => JsError("Unknown notification type")
       }
     }

--- a/notification/test/notification/models/azure/NotificationSpec.scala
+++ b/notification/test/notification/models/azure/NotificationSpec.scala
@@ -126,7 +126,7 @@ class NotificationSpec extends Specification {
       """
         |{
         |  "id" : "3e0bc788-a27c-4864-bb71-77a80aadcce4",
-        |  "type" : "goalAlert",
+        |  "type" : "goal",
         |  "title" : "The Guardian",
         |  "message" : "Leicester 2-1 Watford\nDeeney 75min",
         |  "goalType" : "Penalty",


### PR DESCRIPTION
Notification type was wrong for goal alerts.
Note that the notification is just a randomly generated UUID in notification-football. In the legacy system this id is derived from match info (score, match minute, things like that) so that we cannot send the same notification twice for the same goal. 

Maybe before merging this we could make sure we generate goal alerts in a deterministic way from match info to preserve the safety of the legacy notifications.

I think this is also an issue for content alerts and no one complained so this might not be a big problem

see https://theguardian.atlassian.net/browse/MAPI-1390