### PR TITLE
MAPI-1394 - topic encoded in Base16 are sent as separate hub request

### DIFF
--- a/common/src/main/scala/azure/Tags.scala
+++ b/common/src/main/scala/azure/Tags.scala
@@ -48,10 +48,8 @@ object Tags {
 
   def fromStrings(tags: Set[String]): Tags = Tags(tags.map(Tag(_)))
 
-  def fromTopics(topics: Set[Topic]): Tags = Tags(
-    topics flatMap {
-      t => Set(Tag.fromTopic(t), Tag.fromTopicBase16(t))
-    }
+  def fromTopics(topicEncoder: Topic => Tag)(topics: Set[Topic]): Tags = Tags(
+    topics map { topicEncoder(_) }
   )
 
   def fromUserId(u: UserId): Tags = Tags(Set(Tag.fromUserId(u)))

--- a/notification/app/notification/services/frontend/FrontendAlerts.scala
+++ b/notification/app/notification/services/frontend/FrontendAlerts.scala
@@ -1,6 +1,5 @@
 package notification.services.frontend
 
-import error.NotificationsError
 import models.{SenderReport, BreakingNewsNotification}
 import notification.models.Push
 import notification.services.{Senders, SenderError, NotificationRejected, SenderResult, NotificationSender}
@@ -61,6 +60,4 @@ class FrontendAlerts(config: FrontendAlertsConfig, wsClient: WSClient) extends N
 
 case class FrontendAlertsProviderError(reason: String) extends SenderError {
   override def senderName: String = Senders.FrontendAlerts
-
-  override def underlying: Option[NotificationsError] = None
 }

--- a/notification/app/notification/services/package.scala
+++ b/notification/app/notification/services/package.scala
@@ -8,7 +8,6 @@ import scalaz.\/
 package object services {
   trait SenderError extends NotificationsError {
     def senderName: String
-    def underlying: Option[NotificationsError]
   }
 
   case class NotificationRejected(error: Option[SenderError] = None) {

--- a/notification/test/notification/NotificationsFixtures.scala
+++ b/notification/test/notification/NotificationsFixtures.scala
@@ -26,7 +26,7 @@ trait NotificationsFixtures {
     topic = topics
   )
   
-  def breakingNewsPush(importance: Importance = Major): Push = Push(
+  def userTargetedBreakingNewsPush(importance: Importance = Major): Push = Push(
     notification = BreakingNewsNotification(
       id = UUID.randomUUID(),
       title = "",
@@ -41,7 +41,12 @@ trait NotificationsFixtures {
     destination = Right(UserId(UUID.randomUUID()))
   )
 
-  val providerError = new WindowsNotificationSenderError(None)
+  def topicTargetedBreakingNewsPush(notification: Notification): Push = Push(
+    notification = notification,
+    destination = Left(notification.topic)
+  )
+
+  val providerError = new WindowsNotificationSenderError(Seq.empty)
 
   val apiKey = "test"
   val authenticatedRequest = FakeRequest(method = "POST", path = s"?api-key=$apiKey")

--- a/notification/test/notification/services/WindowsNotificationSenderSpec.scala
+++ b/notification/test/notification/services/WindowsNotificationSenderSpec.scala
@@ -1,7 +1,7 @@
 package notification.services
 
 
-import azure.{AzureRawPush, NotificationHubClient}
+import azure.{Tag, AzureRawPush, NotificationHubClient}
 import models._
 import models.Importance.{Minor, Major}
 import notification.{DateTimeFreezed, NotificationsFixtures}
@@ -19,25 +19,46 @@ class WindowsNotificationSenderSpec(implicit ev: ExecutionEnv) extends Specifica
   with Mockito with DateTimeFreezed {
 
   "the notification sender" should {
-    "filter out Minor notifications" in new WNSScope() {
+    "filter out Minor notifications" in new WNSScope {
       override val importance = Minor
       val expectedReport = senderReport(Senders.Windows).right
-      val result = windowsNotificationSender.sendNotification(somePush)
+      val result = windowsNotificationSender.sendNotification(userPush)
 
       result should beEqualTo(expectedReport).await
       there was no(hubClient).sendNotification(any[AzureRawPush])
     }
-    "process a Major notification" in new WNSScope() {
-      val result = windowsNotificationSender.sendNotification(somePush)
 
-      result should beEqualTo(senderReport(Senders.Windows, platformStats = PlatformStatistics(WindowsMobile, 1).some).right).await
-      there was one(hubClient).sendNotification(any[AzureRawPush])
+    "process a Major notification" in {
+      "send two separate with notifications with differently encoded topics when addressed to topic" in new WNSScope {
+        val result = windowsNotificationSender.sendNotification(topicPush)
+
+        result should beEqualTo(senderReport(Senders.Windows, platformStats = PlatformStatistics(WindowsMobile, 2).some).right).await
+        got {
+          one(hubClient).sendNotification(pushConverter(AzureRawPushConverter.topicEncoder).toAzureRawPush(topicPush))
+          one(hubClient).sendNotification(pushConverter(AzureRawPushConverter.backwardCompatibleTopicEncoder).toAzureRawPush(topicPush))
+        }
+      }
+
+      "send only one notification when destination is user so that user do not receive the same message twice" in new WNSScope {
+        val result = windowsNotificationSender.sendNotification(userPush)
+
+        result should beEqualTo(senderReport(Senders.Windows, platformStats = PlatformStatistics(WindowsMobile, 1).some).right).await
+        got {
+          one(hubClient).sendNotification(pushConverter(AzureRawPushConverter.topicEncoder).toAzureRawPush(userPush))
+        }
+      }
     }
   }
 
   trait WNSScope extends Scope with NotificationsFixtures {
     def importance: Importance = Major
-    val somePush = breakingNewsPush(importance)
+    val userPush = userTargetedBreakingNewsPush(importance)
+    val topicPush = topicTargetedBreakingNewsPush(
+      breakingNewsNotification(Set(
+        Topic(TopicTypes.Breaking, "world/religion"),
+        Topic(TopicTypes.Breaking, "world/isis")
+      ))
+    )
 
     val configuration = mock[Configuration].debug returns true
     val hubClient = {
@@ -45,6 +66,15 @@ class WindowsNotificationSenderSpec(implicit ev: ExecutionEnv) extends Specifica
       client.sendNotification(any[AzureRawPush]) returns Future.successful(().right)
       client
     }
-    val windowsNotificationSender = new WindowsNotificationSender(hubClient, configuration, mock[TopicSubscriptionsRepository])
+
+    def pushConverter(topicEncoder: Topic => Tag) = new AzureRawPushConverter(configuration, topicEncoder)
+
+    val topicSubscriptionsRepository = {
+      val m = mock[TopicSubscriptionsRepository]
+      m.count(any[Topic]) returns Future.successful(1.right)
+      m
+    }
+
+    val windowsNotificationSender = new WindowsNotificationSender(hubClient, configuration, topicSubscriptionsRepository)
   }
 }

--- a/notification/test/notification/services/frontend/FrontendAlertsSpec.scala
+++ b/notification/test/notification/services/frontend/FrontendAlertsSpec.scala
@@ -2,7 +2,7 @@ package notification.services.frontend
 
 import java.net.URI
 
-import models.{BreakingNewsNotification}
+import models.BreakingNewsNotification
 import models.Link.External
 import notification.NotificationsFixtures
 import notification.services.NotificationRejected
@@ -22,8 +22,8 @@ import scalaz.syntax.either._
 class FrontendAlertsSpec(implicit ee: ExecutionEnv) extends Specification with Mockito {
   "Frontend alerts notified about notification" should {
     "skip breaking news notification without capi id (i.e. with non-internal Link)" in new FrontendAlertsScope {
-      val push = breakingNewsPush().copy(notification =
-        breakingNewsNotification(validTopics).asInstanceOf[BreakingNewsNotification].copy(link = External("url"))
+      val push = userTargetedBreakingNewsPush().copy(
+        notification = breakingNewsNotification(validTopics).asInstanceOf[BreakingNewsNotification].copy(link = External("url"))
       )
 
       alerts.sendNotification(push) must beEqualTo(NotificationRejected(Some(FrontendAlertsProviderError("Alert could not be created"))).left).await
@@ -39,7 +39,7 @@ class FrontendAlertsSpec(implicit ee: ExecutionEnv) extends Specification with M
       } { implicit port =>
         WsTestClient.withClient { client =>
           val alerts = new FrontendAlerts(config, client)
-          alerts.sendNotification(breakingNewsPush()) map { _.toEither } must beRight.await
+          alerts.sendNotification(userTargetedBreakingNewsPush()) map { _.toEither } must beRight.await
         }
       }
     }


### PR DESCRIPTION
* the same notification is sent twice - one with differently encoded topic
* protection against duplicated messages addressed to user added

cc @alexduf @davidfurey 