### PR TITLE
Fix ios notifications

### DIFF
--- a/common/src/main/scala/azure/apns/APS.scala
+++ b/common/src/main/scala/azure/apns/APS.scala
@@ -2,8 +2,10 @@ package azure.apns
 
 import play.api.libs.json._
 
+import models.JsonUtils._
+
 case class APS(
-  alert: Option[Alert] = None,
+  alert: Option[Either[Alert, String]] = None,
   badge: Option[Int] = None,
   sound: Option[String] = None,
   `content-available`: Option[Int] = None,

--- a/notification/app/notification/models/ios/Notification.scala
+++ b/notification/app/notification/models/ios/Notification.scala
@@ -27,7 +27,9 @@ case class BreakingNewsNotification(
   def payload: Body = Body(
     aps = APS(
       category = Some(category),
-      alert = Some(Right(message))
+      alert = Some(Right(message)),
+      `content-available` = Some(1),
+      sound = Some("default")
     ),
     customProperties = Map(
       Keys.MessageType -> `type`,
@@ -54,7 +56,9 @@ case class ContentNotification(
   def payload: Body = Body(
     aps = APS(
       category = Some(category),
-      alert = Some(Right(message))
+      alert = Some(Right(message)),
+      `content-available` = Some(1),
+      sound = Some("default")
     ),
     customProperties = Map(
       Keys.MessageType -> `type`,
@@ -77,7 +81,9 @@ case class GoalAlertNotification(
 ) extends Notification {
   def payload: Body = Body(
     aps = APS(
-      alert = Some(Right(message))
+      alert = Some(Right(message)),
+      `content-available` = Some(1),
+      sound = Some("default")
     ),
     customProperties = Map(
       Keys.MessageType -> `type`,

--- a/notification/app/notification/models/ios/Notification.scala
+++ b/notification/app/notification/models/ios/Notification.scala
@@ -27,9 +27,7 @@ case class BreakingNewsNotification(
   def payload: Body = Body(
     aps = APS(
       category = Some(category),
-      alert = Some(Alert(
-        body = Some(message)
-      ))
+      alert = Some(Right(message))
     ),
     customProperties = Map(
       Keys.MessageType -> `type`,
@@ -56,9 +54,7 @@ case class ContentNotification(
   def payload: Body = Body(
     aps = APS(
       category = Some(category),
-      alert = Some(Alert(
-        body = Some(message)
-      ))
+      alert = Some(Right(message))
     ),
     customProperties = Map(
       Keys.MessageType -> `type`,
@@ -81,9 +77,7 @@ case class GoalAlertNotification(
 ) extends Notification {
   def payload: Body = Body(
     aps = APS(
-      alert = Some(Alert(
-        body = Some(message)
-      ))
+      alert = Some(Right(message))
     ),
     customProperties = Map(
       Keys.MessageType -> `type`,

--- a/notification/app/notification/services/azure/APNSPushConverter.scala
+++ b/notification/app/notification/services/azure/APNSPushConverter.scala
@@ -43,7 +43,7 @@ class APNSPushConverter(conf: Configuration) {
 
     ios.ContentNotification(
       category = "ITEM_CATEGORY",
-      message = cn.message,
+      message = cn.title,
       link = toIosLink(cn.link),
       topics = cn.topic,
       uri = new URI(link.uri),

--- a/notification/test/notification/models/azure/iOSNotificationSpec.scala
+++ b/notification/test/notification/models/azure/iOSNotificationSpec.scala
@@ -45,7 +45,7 @@ class iOSNotificationSpec extends Specification with Mockito {
     val notification = models.BreakingNewsNotification(
       id = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
       `type` = NotificationType.BreakingNews,
-      title  = "The Guardian",
+      title  = "French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State",
       message = "French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State",
       thumbnailUrl = Some(new URI("https://media.guim.co.uk/633850064fba4941cdac17e8f6f8de97dd736029/24_0_1800_1080/500.jpg")),
       sender = "matt.wells@guardian.co.uk",
@@ -77,7 +77,7 @@ class iOSNotificationSpec extends Specification with Mockito {
     val notification = models.ContentNotification(
       id = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
       `type` = NotificationType.Content,
-      title  = "The Guardian",
+      title  = "French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State",
       message = "French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State",
       thumbnailUrl = Some(new URI("https://media.guim.co.uk/633850064fba4941cdac17e8f6f8de97dd736029/24_0_1800_1080/500.jpg")),
       sender = "matt.wells@guardian.co.uk",

--- a/notification/test/notification/models/azure/iOSNotificationSpec.scala
+++ b/notification/test/notification/models/azure/iOSNotificationSpec.scala
@@ -59,7 +59,7 @@ class iOSNotificationSpec extends Specification with Mockito {
 
     val expected = Body(
       aps = APS(
-        alert = Some(Alert(body = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"))),
+        alert = Some(Right("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State")),
         category = Some("ITEM_CATEGORY")
       ),
       customProperties = Map(
@@ -90,7 +90,7 @@ class iOSNotificationSpec extends Specification with Mockito {
 
     val expected = Body(
       aps = APS(
-        alert = Some(Alert(body = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"))),
+        alert = Some(Right("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State")),
         category = Some("ITEM_CATEGORY")
       ),
       customProperties = Map(
@@ -138,7 +138,7 @@ class iOSNotificationSpec extends Specification with Mockito {
 
     val expected = Body(
       aps = APS(
-        alert = Some(Alert(body = Some("Leicester 2-1 Watford\nDeeney 75min (o.g.)"))),
+        alert = Some(Right("Leicester 2-1 Watford\nDeeney 75min (o.g.)")),
         category = None
       ),
       customProperties = Map(

--- a/notification/test/notification/models/azure/iOSNotificationSpec.scala
+++ b/notification/test/notification/models/azure/iOSNotificationSpec.scala
@@ -60,7 +60,9 @@ class iOSNotificationSpec extends Specification with Mockito {
     val expected = Body(
       aps = APS(
         alert = Some(Right("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State")),
-        category = Some("ITEM_CATEGORY")
+        category = Some("ITEM_CATEGORY"),
+        `content-available` = Some(1),
+        sound = Some("default")
       ),
       customProperties = Map(
         "t" -> "m",
@@ -91,7 +93,9 @@ class iOSNotificationSpec extends Specification with Mockito {
     val expected = Body(
       aps = APS(
         alert = Some(Right("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State")),
-        category = Some("ITEM_CATEGORY")
+        category = Some("ITEM_CATEGORY"),
+        `content-available` = Some(1),
+        sound = Some("default")
       ),
       customProperties = Map(
         "t" -> "m",
@@ -139,7 +143,9 @@ class iOSNotificationSpec extends Specification with Mockito {
     val expected = Body(
       aps = APS(
         alert = Some(Right("Leicester 2-1 Watford\nDeeney 75min (o.g.)")),
-        category = None
+        category = None,
+        `content-available` = Some(1),
+        sound = Some("default")
       ),
       customProperties = Map(
         "t" -> "g",


### PR DESCRIPTION
The Guardian iOS app expects the alert to be a string, not an object