### PR TITLE
Add unregister endpoint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ lazy val registration = project
   .settings(
     fork in run := true,
     routesImport += "binders._",
+    routesImport += "models._",
     riffRaffPackageType := (packageZipTarball in Universal).value,
     version := "1.0-SNAPSHOT"
   )

--- a/common/src/main/scala/binders/package.scala
+++ b/common/src/main/scala/binders/package.scala
@@ -1,12 +1,12 @@
 import java.util.UUID
 
 import azure.NotificationHubRegistrationId
-import models.{NotificationType, Topic}
+import models.{NotificationType, Platform, Topic, UniqueDeviceIdentifier}
 import org.joda.time.DateTime
 import play.api.mvc.{PathBindable, QueryStringBindable}
 
 import scala.language.implicitConversions
-import scala.util.{Try, Success, Failure}
+import scala.util.{Failure, Success, Try}
 
 package object binders {
 
@@ -42,6 +42,24 @@ package object binders {
           value = value
         ).right.flatMap(v => Topic.fromString(v).toEither)
       }
+    }
+
+  implicit def bindUdid(implicit strBindable: PathBindable[String]): PathBindable[UniqueDeviceIdentifier] =
+    new PathBindable[UniqueDeviceIdentifier] {
+      override def unbind(key: String, value: UniqueDeviceIdentifier): String =
+        strBindable.unbind(key = key, value = value.toString)
+
+      override def bind(key: String, value: String): Either[String, UniqueDeviceIdentifier] =
+        strBindable.bind(key, value).right.flatMap(v => UniqueDeviceIdentifier.fromString(v).toRight("Invalid udid"))
+    }
+
+  implicit def bindPlatform(implicit strBindable: PathBindable[String]): PathBindable[Platform] =
+    new PathBindable[Platform] {
+      override def unbind(key: String, value: Platform): String =
+        strBindable.unbind(key = key, value = value.toString)
+
+      override def bind(key: String, value: String): Either[String, Platform] =
+        strBindable.bind(key, value).right.flatMap(v => Platform.fromString(v).toRight("Invalid platform"))
     }
 
   implicit def bindDateTime(implicit strBinder: QueryStringBindable[String]): QueryStringBindable[DateTime] =

--- a/common/src/main/scala/models/Platform.scala
+++ b/common/src/main/scala/models/Platform.scala
@@ -17,8 +17,8 @@ object Platform {
 
   implicit val jf = new Format[Platform] {
     def reads(json: JsValue): JsResult[Platform] = json match {
-      case JsString(s) => fromString(s) map { JsSuccess(_) } getOrElse JsError(s"$s is not a valid topic type")
-      case _ => JsError(s"Topic type could not be decoded")
+      case JsString(s) => fromString(s) map { JsSuccess(_) } getOrElse JsError(s"$s is not a valid platform")
+      case _ => JsError(s"Platform could not be decoded")
     }
 
     def writes(obj: Platform): JsValue = JsString(obj.toString)

--- a/common/src/main/scala/models/UniqueDeviceIdentifier.scala
+++ b/common/src/main/scala/models/UniqueDeviceIdentifier.scala
@@ -11,6 +11,10 @@ object UniqueDeviceIdentifier {
 
   private def uuidFromString(s: String) = Try(UUID.fromString(s)).toOption
 
+  def fromString(s: String): Option[UniqueDeviceIdentifier] = unapply(s) map {
+    case (id, prefix) => UniqueDeviceIdentifier(id, prefix)
+  }
+
   def unapply(string: String): Option[(UUID, Option[String])] = {
     if (string.startsWith("gia:"))
       uuidFromString(string.stripPrefix("gia:")).map((_, Some("gia:")))
@@ -29,9 +33,11 @@ object UniqueDeviceIdentifier {
       case _ => JsError(ValidationError(s"User ID is not a valid UUID"))
     }
 
-    override def writes(o: UniqueDeviceIdentifier): JsValue = JsString(o.prefix.getOrElse("") + o.id.toString)
+    override def writes(o: UniqueDeviceIdentifier): JsValue = JsString(o.toString)
   }
 }
 
-case class UniqueDeviceIdentifier(id: UUID, prefix: Option[String] = None)
+case class UniqueDeviceIdentifier(id: UUID, prefix: Option[String] = None) {
+  override def toString: String = prefix.getOrElse("") + id.toString
+}
 

--- a/registration/app/registration/services/NotificationRegistrar.scala
+++ b/registration/app/registration/services/NotificationRegistrar.scala
@@ -15,6 +15,7 @@ object RegistrationResponse {
 }
 
 trait NotificationRegistrar {
-  type RegistrarResponse = Future[ProviderError Xor RegistrationResponse]
-  def register(oldDeviceId: String, registration: Registration): RegistrarResponse
+  type RegistrarResponse[T] = Future[ProviderError Xor T]
+  def register(oldDeviceId: String, registration: Registration): RegistrarResponse[RegistrationResponse]
+  def unregister(udid: UniqueDeviceIdentifier): RegistrarResponse[Unit]
 }

--- a/registration/conf/routes
+++ b/registration/conf/routes
@@ -1,4 +1,5 @@
 PUT         /registrations/:lastKnownDeviceId    registration.controllers.Main.register(lastKnownDeviceId)
+DELETE      /registrations/:platform/:udid       registration.controllers.Main.unregister(platform: Platform, udid: UniqueDeviceIdentifier)
 GET         /healthcheck                         registration.controllers.Main.healthCheck
 
 # Legacy Android API registration endpoint

--- a/registration/test/registration/services/WindowsNotificationRegistrarSpec.scala
+++ b/registration/test/registration/services/WindowsNotificationRegistrarSpec.scala
@@ -71,6 +71,18 @@ with Mockito {
       there was no(hubClient).delete(any[NotificationHubRegistrationId])
     }
 
+    "delete a registration" in new registrations {
+      val userRegistrations = (0 to 2).map(generateHubResponse).toList
+      hubClient.registrationsByTag(userIdTag) returns Future.successful(userRegistrations.right)
+      hubClient.delete(any[NotificationHubRegistrationId]) returns Future.successful(().right)
+
+      val response = provider.unregister(registration.udid)
+
+      response must beEqualTo(().right).await
+      there was no(hubClient).create(any[RawWindowsRegistration])
+      there was three(hubClient).delete(any[NotificationHubRegistrationId])
+    }
+
     "delete all and replace by only one registration if more than one registration for the same userId" in new registrations {
       val userRegistrations = (0 to 2).map(generateHubResponse).toList
       hubClient.registrationsByTag(userIdTag) returns Future.successful(userRegistrations.right)


### PR DESCRIPTION
This is primarily to allow us to roll backwards/forwards between pushy and n10n.  

When a device registers to pushy, it will be unregistered from n10n.
When a device registers to n10n, it will be unregistered from pushy.