### PR TITLE
Batch topic subscriptions

### DIFF
--- a/common/src/main/scala/conf/NotificationConfiguration.scala
+++ b/common/src/main/scala/conf/NotificationConfiguration.scala
@@ -2,11 +2,17 @@ package conf
 
 import com.gu.conf.ConfigurationFactory
 
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
 class NotificationConfiguration(projectName: String) {
   lazy val conf = ConfigurationFactory.getConfiguration(
     applicationName = projectName,
     webappConfDirectory = "gu-conf"
   )
+
+  def getFiniteDuration(key: String): Option[FiniteDuration] = conf.getStringProperty(key).map(Duration.apply) collect {
+    case finite: FiniteDuration => finite
+  }
 
   def getConfigString(key: String): String = conf.getStringProperty(key)
     .getOrElse(throw new RuntimeException(s"key $key not found in configuration"))

--- a/common/src/main/scala/tracking/BatchingTopicSubscriptionsRepository.scala
+++ b/common/src/main/scala/tracking/BatchingTopicSubscriptionsRepository.scala
@@ -1,0 +1,94 @@
+package tracking
+import akka.actor.ActorSystem
+import models.Topic
+import tracking.Repository.RepositoryResult
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import akka.actor.{Actor, Props}
+import akka.pattern.ask
+import akka.util.Timeout
+import cats.implicits._
+
+import scala.concurrent.duration.FiniteDuration
+
+object BatchingTopicSubscriptionsRepository {
+
+  case class SubscriptionEvent(topic: Option[Topic], topicId: String, count: Int)
+
+  case object Flush
+
+  private class InternalActor(underlying: TopicSubscriptionsRepository) extends Actor {
+
+    implicit val ec = context.dispatcher
+
+    var events = collection.mutable.Buffer[SubscriptionEvent]()
+
+    override def receive: Actor.Receive = {
+      case event: SubscriptionEvent =>
+        events.append(event)
+
+      case Flush =>
+        if (events.nonEmpty) {
+          val requestor = sender
+          flush() foreach { _ => requestor ! () }
+        } else {
+          sender ! ()
+        }
+    }
+
+    def flush(): Future[Unit] = {
+      val eventsByTopic = events.toList.groupBy(_.topicId)
+      val result = Future.sequence(eventsByTopic.map(submitSubscriptions)).map(_ => ())
+      events = collection.mutable.Buffer[SubscriptionEvent]()
+      result
+    }
+
+    private def submitSubscriptions: PartialFunction[(String, List[SubscriptionEvent]), Future[Unit]] = {
+      case (topicId, topicEvents) =>
+        val subscriptionCount = topicEvents.map(_.count).sum
+
+        val result = if (subscriptionCount < 0) {
+          Some(underlying.deviceUnsubscribed(topicId, -subscriptionCount))
+        } else if (subscriptionCount > 0) {
+          val topic = topicEvents.collectFirst { case SubscriptionEvent(Some(t), _, _) => t }
+          topic.map { topic => underlying.deviceSubscribed(topic, subscriptionCount) }
+        } else None
+
+        def futureToUnit[T](f: Future[T]) = f.map(_ => ())
+
+        def defaultSuccess = Future.successful(())
+
+        result.map(futureToUnit).getOrElse(defaultSuccess)
+    }
+  }
+}
+class BatchingTopicSubscriptionsRepository(underlying: TopicSubscriptionsRepository)(implicit val system: ActorSystem) extends TopicSubscriptionsRepository {
+
+  import BatchingTopicSubscriptionsRepository._
+
+  implicit val ec = system.dispatcher
+
+  val actor = system.actorOf(Props(classOf[InternalActor], underlying))
+
+  override def deviceSubscribed(topic: Topic, count: Int = 1): Future[RepositoryResult[Unit]] = {
+    actor ! SubscriptionEvent(Some(topic), topic.id, count)
+    Future.successful(().right)
+  }
+
+  override def deviceUnsubscribed(topicId: String, count: Int = 1): Future[RepositoryResult[Unit]] = {
+    actor ! SubscriptionEvent(None, topicId, -count)
+    Future.successful(().right)
+  }
+
+  override def count(topic: Topic): Future[RepositoryResult[Int]] = underlying.count(topic)
+
+  def flush(): Future[Unit] = {
+    implicit val timeout = Timeout(1.minute)
+    (actor ? Flush).mapTo[Unit]
+  }
+
+  def scheduleFlush(interval: FiniteDuration): Unit = {
+    system.scheduler.schedule(interval, interval, actor, Flush)
+  }
+}

--- a/common/src/main/scala/tracking/DynamoTopicSubscriptionsRepository.scala
+++ b/common/src/main/scala/tracking/DynamoTopicSubscriptionsRepository.scala
@@ -23,8 +23,8 @@ class DynamoTopicSubscriptionsRepository(client: AsyncDynamo, tableName: String)
     val SubscriberCount = "topicSubscriberCount"
   }
 
-  override def deviceSubscribed(topic: Topic): Future[RepositoryResult[Unit]] = {
-    val subscriptionCountChange = +1
+  override def deviceSubscribed(topic: Topic, count: Int = 1): Future[RepositoryResult[Unit]] = {
+    val subscriptionCountChange = count
     val req = newUpdateRequest
       .addKeyEntry(TopicFields.Id, new AttributeValue(topic.id))
       .withUpdateExpression(s"SET ${TopicFields.Topic} = :topic ADD ${TopicFields.SubscriberCount} :amount")
@@ -35,8 +35,8 @@ class DynamoTopicSubscriptionsRepository(client: AsyncDynamo, tableName: String)
     updateItem(req)
   }
 
-  override def deviceUnsubscribed(topicId: String): Future[RepositoryResult[Unit]] = {
-    val subscriptionCountChange = -1
+  override def deviceUnsubscribed(topicId: String, count: Int = 1): Future[RepositoryResult[Unit]] = {
+    val subscriptionCountChange = -count
     val req = newUpdateRequest
       .addKeyEntry(TopicFields.Id, new AttributeValue(topicId))
       .withUpdateExpression(s"ADD ${TopicFields.SubscriberCount} :amount")

--- a/common/src/main/scala/tracking/InMemoryTopicSubscriptionsRepository.scala
+++ b/common/src/main/scala/tracking/InMemoryTopicSubscriptionsRepository.scala
@@ -9,17 +9,17 @@ class InMemoryTopicSubscriptionsRepository extends TopicSubscriptionsRepository 
 
   val counters = scala.collection.mutable.Map.empty[Topic, Int]
 
-  override def deviceSubscribed(topic: Topic): Future[RepositoryResult[Unit]] = {
-    counters.update(topic, counters.getOrElse(topic, 0) + 1)
+  override def deviceSubscribed(topic: Topic, count: Int = 1): Future[RepositoryResult[Unit]] = {
+    counters.update(topic, counters.getOrElse(topic, 0) + count)
     Future.successful(RepositoryResult(()))
   }
 
   override def count(topic: Topic): Future[RepositoryResult[Int]] =
     Future.successful(RepositoryResult(counters.getOrElse(topic, 0)))
 
-  override def deviceUnsubscribed(topicId: String): Future[RepositoryResult[Unit]] = {
-    counters.transform { case (topic, count) =>
-      if (topic.id == topicId) count - 1 else count
+  override def deviceUnsubscribed(topicId: String, count: Int): Future[RepositoryResult[Unit]] = {
+    counters.transform { case (topic, existingCount) =>
+      if (topic.id == topicId) existingCount - count else existingCount
     }
     Future.successful(RepositoryResult(()))
   }

--- a/common/src/main/scala/tracking/SubscriptionTracker.scala
+++ b/common/src/main/scala/tracking/SubscriptionTracker.scala
@@ -18,11 +18,11 @@ class SubscriptionTracker(topicSubscriptionsRepository: TopicSubscriptionsReposi
     case Success(Xor.Right(_)) =>
       Future.traverse(topicSubscriptionTracking.addedTopics) { topic =>
         logger.debug(s"Informing about new topic registrations. [$topic]")
-        topicSubscriptionsRepository.deviceSubscribed(topic)
+        topicSubscriptionsRepository.deviceSubscribed(topic, 1)
       } map handleErrors
       Future.traverse(topicSubscriptionTracking.removedTopicsIds) { topicId =>
         logger.debug(s"Informing about removed topic registrations. [$topicId]")
-        topicSubscriptionsRepository.deviceUnsubscribed(topicId)
+        topicSubscriptionsRepository.deviceUnsubscribed(topicId, 1)
       } map handleErrors
 
     case _ => logger.error("Topic subscription counters not updated. Preceding action failed.")

--- a/common/src/main/scala/tracking/TopicSubscriptionsRepository.scala
+++ b/common/src/main/scala/tracking/TopicSubscriptionsRepository.scala
@@ -5,9 +5,9 @@ import tracking.Repository.RepositoryResult
 import scala.concurrent.Future
 
 trait TopicSubscriptionsRepository {
-  def deviceSubscribed(topic: Topic): Future[RepositoryResult[Unit]]
+  def deviceSubscribed(topic: Topic, count: Int = 1): Future[RepositoryResult[Unit]]
 
-  def deviceUnsubscribed(topicId: String): Future[RepositoryResult[Unit]]
+  def deviceUnsubscribed(topicId: String, count: Int = 1): Future[RepositoryResult[Unit]]
 
   def count(topic: Topic): Future[RepositoryResult[Int]]
 }

--- a/common/src/test/scala/tracking/BatchingTopicSubscriptionsRepositorySpec.scala
+++ b/common/src/test/scala/tracking/BatchingTopicSubscriptionsRepositorySpec.scala
@@ -1,0 +1,96 @@
+package tracking
+
+import akka.actor.ActorSystem
+import models.{Topic, TopicTypes}
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.{AfterAll, Scope}
+
+import scala.concurrent.duration._
+import scala.concurrent.Future
+import cats.implicits._
+import org.mockito.Matchers.{eq => argEq}
+class BatchingTopicSubscriptionsRepositorySpec(implicit ev: ExecutionEnv) extends Specification with Mockito with AfterAll {
+
+  implicit val actorSystem = ActorSystem("BatchingTopicSubscriptionsRepositorySpec")
+
+  "A BatchingTopicSubscriptionRepository" should {
+    "Batch up multiple subscribe events" in new TestScope {
+      batching.deviceSubscribed(topic1)
+      batching.deviceSubscribed(topic1)
+      batching.deviceSubscribed(topic1)
+      batching.flush() must beEqualTo(()).awaitFor(10.seconds)
+      there was one(underlying).deviceSubscribed(topic1, 3)
+    }
+
+    "Batch up multiple unsubscribe events" in new TestScope {
+      batching.deviceUnsubscribed(topic1.id)
+      batching.deviceUnsubscribed(topic1.id)
+      batching.deviceUnsubscribed(topic1.id)
+      batching.flush() must beEqualTo(()).awaitFor(10.seconds)
+      there was one(underlying).deviceUnsubscribed(topic1.id, 3)
+    }
+
+    "Call underlying subscribe if more subs than unsubs" in new TestScope {
+      batching.deviceSubscribed(topic1)
+      batching.deviceSubscribed(topic1)
+      batching.deviceSubscribed(topic1)
+      batching.deviceUnsubscribed(topic1.id)
+      batching.flush() must beEqualTo(()).awaitFor(10.seconds)
+      there was one(underlying).deviceSubscribed(topic1, 2)
+      there was no(underlying).deviceUnsubscribed(any[String], any[Int])
+    }
+
+    "Do nothing if subs equals unsubs" in new TestScope {
+      batching.deviceSubscribed(topic1)
+      batching.deviceSubscribed(topic1)
+      batching.deviceSubscribed(topic1)
+      batching.deviceUnsubscribed(topic1.id)
+      batching.deviceUnsubscribed(topic1.id)
+      batching.deviceUnsubscribed(topic1.id)
+      batching.flush() must beEqualTo(()).awaitFor(10.seconds)
+      there was no(underlying).deviceSubscribed(any[Topic], any[Int])
+      there was no(underlying).deviceUnsubscribed(any[String], any[Int])
+    }
+
+    "Track different topics counts separately" in new TestScope {
+      batching.deviceSubscribed(topic1)
+      batching.deviceUnsubscribed(topic1.id)
+
+      batching.deviceUnsubscribed(topic2.id)
+      batching.deviceSubscribed(topic2)
+      batching.deviceSubscribed(topic2)
+
+      batching.deviceSubscribed(topic3)
+      batching.deviceUnsubscribed(topic3.id)
+      batching.deviceUnsubscribed(topic3.id)
+      batching.deviceUnsubscribed(topic3.id)
+
+      batching.flush() must beEqualTo(()).await
+
+      there was no(underlying).deviceSubscribed(argEq(topic1), any[Int])
+      there was no(underlying).deviceUnsubscribed(argEq(topic1.id), any[Int])
+
+      there was one(underlying).deviceSubscribed(topic2, 1)
+      there was no(underlying).deviceUnsubscribed(argEq(topic2.id), any[Int])
+
+      there was no(underlying).deviceSubscribed(argEq(topic3), any[Int])
+      there was one(underlying).deviceUnsubscribed(topic3.id, 2)
+    }
+  }
+
+  trait TestScope extends Scope {
+    val underlying = mock[TopicSubscriptionsRepository]
+    underlying.deviceSubscribed(any[Topic], any[Int]).returns(Future.successful(().right))
+    underlying.deviceUnsubscribed(any[String], any[Int]).returns(Future.successful(().right))
+    val batching = new BatchingTopicSubscriptionsRepository(underlying)
+    val topic1 = Topic(TopicTypes.Breaking, "test1")
+    val topic2 = Topic(TopicTypes.Breaking, "test2")
+    val topic3 = Topic(TopicTypes.Breaking, "test3")
+  }
+
+  override def afterAll(): Unit = {
+    actorSystem.terminate()
+  }
+}

--- a/notification/app/notification/services/Configuration.scala
+++ b/notification/app/notification/services/Configuration.scala
@@ -1,6 +1,7 @@
 package notification.services
 
 import conf.NotificationConfiguration
+import scala.concurrent.duration._
 
 class Configuration extends NotificationConfiguration("notification") {
   lazy val hubEndpoint = getConfigString("azure.hub.endpoint")
@@ -13,5 +14,6 @@ class Configuration extends NotificationConfiguration("notification") {
   lazy val frontendNewsAlertApiKey = getConfigString("notifications.frontendNewsAlert.apiKey")
   lazy val dynamoReportsTableName = getConfigString("db.dynamo.reports.table-name")
   lazy val dynamoTopicsTableName = getConfigString("db.dynamo.topics.table-name")
+  lazy val dynamoTopicsFlushInterval = getFiniteDuration("db.dynamo.topics.flush-interval").getOrElse(60.seconds)
   lazy val frontendBaseUrl = getConfigString("frontend.baseUrl")
 }

--- a/registration/app/registration/RegistrationApplicationLoader.scala
+++ b/registration/app/registration/RegistrationApplicationLoader.scala
@@ -1,6 +1,7 @@
 package registration
 
 import _root_.controllers.Assets
+import akka.actor.ActorSystem
 import auditor.AuditorWSClient
 import azure.{NotificationHubClient, NotificationHubConnection}
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -13,7 +14,7 @@ import registration.services.topic.{AuditorTopicValidator, TopicValidator}
 import registration.services.azure.{APNSNotificationRegistrar, GCMNotificationRegistrar, WindowsNotificationRegistrar}
 import router.Routes
 import registration.services._
-import tracking.{DynamoTopicSubscriptionsRepository, SubscriptionTracker}
+import tracking.{BatchingTopicSubscriptionsRepository, DynamoTopicSubscriptionsRepository, SubscriptionTracker, TopicSubscriptionsRepository}
 
 import scala.concurrent.ExecutionContext
 
@@ -112,10 +113,12 @@ trait Tracking {
   import com.amazonaws.regions.Regions.EU_WEST_1
   import aws.AsyncDynamo
 
-  lazy val topicSubscriptionRepository = new DynamoTopicSubscriptionsRepository(
-    AsyncDynamo(region = EU_WEST_1),
-    appConfig.dynamoTopicsTableName
-  )
+  lazy val topicSubscriptionsRepository: TopicSubscriptionsRepository = {
+    val underlying = new DynamoTopicSubscriptionsRepository(AsyncDynamo(EU_WEST_1), appConfig.dynamoTopicsTableName)
+    val batching = new BatchingTopicSubscriptionsRepository(underlying)
+    batching.scheduleFlush(appConfig.dynamoTopicsFlushInterval)
+    batching
+  }
 
   lazy val subscriptionTracker = wire[SubscriptionTracker]
 }
@@ -146,4 +149,5 @@ trait PlayComponents extends BuiltInComponents {
 trait ExecutionEnv {
   self: PlayComponents =>
   implicit lazy val executionContext: ExecutionContext = actorSystem.dispatcher
+  implicit lazy val implicitActorSystem: ActorSystem = actorSystem
 }

--- a/registration/app/registration/services/Configuration.scala
+++ b/registration/app/registration/services/Configuration.scala
@@ -2,6 +2,7 @@ package registration.services
 
 import auditor.AuditorGroupConfig
 import conf.NotificationConfiguration
+import scala.concurrent.duration._
 
 class Configuration extends NotificationConfiguration("registration") {
   lazy val legacyNotficationsEndpoint = getConfigString("legacy_notifications.endpoint")
@@ -15,4 +16,5 @@ class Configuration extends NotificationConfiguration("registration") {
     )
   )
   lazy val dynamoTopicsTableName = getConfigString("db.dynamo.topics.table-name")
+  lazy val dynamoTopicsFlushInterval = getFiniteDuration("db.dynamo.topics.flush-interval").getOrElse(60.seconds)
 }

--- a/registration/test/registration/services/WindowsNotificationRegistrarSpec.scala
+++ b/registration/test/registration/services/WindowsNotificationRegistrarSpec.scala
@@ -118,7 +118,7 @@ with Mockito {
 
         Await.result(provider.register(channelUri, registrationWithTopics), 5.seconds)
 
-        there was one(topicSubRepo).deviceSubscribed(breakingTopic) andThen one(topicSubRepo).deviceSubscribed(contentTopic)
+        there was one(topicSubRepo).deviceSubscribed(breakingTopic, 1) andThen one(topicSubRepo).deviceSubscribed(contentTopic, 1)
       }
 
       "record updated topic subscriptions from existing registration" in new registrations {
@@ -128,8 +128,8 @@ with Mockito {
 
         Await.result(provider.register(channelUri, registrationWithTopics), 5.seconds)
 
-        there was one(topicSubRepo).deviceSubscribed(breakingTopic) andThen one(topicSubRepo).deviceSubscribed(contentTopic)
-        there was one(topicSubRepo).deviceUnsubscribed(tagTopic.id)
+        there was one(topicSubRepo).deviceSubscribed(breakingTopic, 1) andThen one(topicSubRepo).deviceSubscribed(contentTopic, 1)
+        there was one(topicSubRepo).deviceUnsubscribed(tagTopic.id, 1)
       }
     }
   }


### PR DESCRIPTION
Update topic subscriptions repository every 60s.  This should avoid the flood of dynamodb writes when we send a breaking news alert