### PR TITLE
Return correct response for legacy clients

### DIFF
--- a/registration/app/registration/controllers/Main.scala
+++ b/registration/app/registration/controllers/Main.scala
@@ -10,11 +10,7 @@ import cats.implicits._
 import error.{NotificationsError, RequestError}
 import models._
 import play.api.Logger
-import play.api.libs.json.{Json, Writes}
-import play.api.mvc.BodyParsers.parse.{json => BodyJson}
-import play.api.mvc.{Action, AnyContent, Controller, Result}
-import registration.models.{LegacyRegistration, LegacyTopic}
-import play.api.libs.json.{Json, Format}
+import play.api.libs.json.{Format, Json, Writes}
 import play.api.mvc.BodyParsers.parse.{json => BodyJson}
 import play.api.mvc.{Action, AnyContent, AnyContentAsEmpty, BodyParser, BodyParsers, Controller, Request, Result}
 import registration.models.{LegacyNewsstandRegistration, LegacyRegistration}
@@ -28,7 +24,6 @@ import cats.implicits._
 import play.api.http.HttpEntity
 import providers.ProviderError
 
-import scala.concurrent.duration._
 import scala.util.{Success, Try}
 
 final class Main(

--- a/registration/app/registration/services/LegacyNewsstandRegistrationConverter.scala
+++ b/registration/app/registration/services/LegacyNewsstandRegistrationConverter.scala
@@ -4,7 +4,7 @@ import cats.data.Xor
 import cats.implicits._
 import error.NotificationsError
 import models._
-import registration.models.{LegacyNewsstandRegistration, LegacyRegistration, LegacyTopic}
+import registration.models.LegacyNewsstandRegistration
 
 class LegacyNewsstandRegistrationConverter extends RegistrationConverter[LegacyNewsstandRegistration] {
 

--- a/registration/app/registration/services/LegacyRegistrationConverter.scala
+++ b/registration/app/registration/services/LegacyRegistrationConverter.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import error.NotificationsError
 import models.{UniqueDeviceIdentifier, _}
-import registration.models.LegacyRegistration
+import registration.models.{LegacyRegistration, LegacyTopic}
 import cats.data.Xor
 import cats.implicits._
 
@@ -23,6 +23,16 @@ class LegacyRegistrationConverter {
         topics = topics(legacyRegistration)
       ).right
     }
+  }
+
+  def fromResponse(legacyRegistration: LegacyRegistration, response: RegistrationResponse): LegacyRegistration = {
+    val topics = response.topics.map { topic =>
+      LegacyTopic(topic.`type`.toString, topic.name)
+    }
+
+    val preferences = legacyRegistration.preferences.copy(topics = Some(topics.toSeq))
+
+    legacyRegistration.copy(preferences = preferences)
   }
 
   private def topics(request: LegacyRegistration): Set[Topic] = {

--- a/registration/app/registration/services/RegistrationConverter.scala
+++ b/registration/app/registration/services/RegistrationConverter.scala
@@ -3,7 +3,6 @@ package registration.services
 import cats.data.Xor
 import error.NotificationsError
 import models.Registration
-import registration.models.LegacyRegistration
 
 trait RegistrationConverter[T] {
   def toRegistration(from: T): NotificationsError Xor Registration


### PR DESCRIPTION
Returning the correct response will allow legacy clients to update
their local list of subscribed topics.