### PR TITLE
Add sendersId to notification report

### DIFF
--- a/common/src/main/scala/azure/NotificationHubClient.scala
+++ b/common/src/main/scala/azure/NotificationHubClient.scala
@@ -70,7 +70,7 @@ class NotificationHubClient(notificationHubConnection: NotificationHubConnection
       }
   }
 
-  def sendNotification[T](rawPush: RawPush[T]): Future[HubResult[Unit]] = {
+  def sendNotification[T](rawPush: RawPush[T]): Future[HubResult[Option[String]]] = {
     val serviceBusTags = rawPush.tagQuery.map(tagQuery => "ServiceBusNotification-Tags" -> tagQuery).toList
     logger.debug(s"Sending Raw Notification: $rawPush")
     request(Endpoints.Messages)
@@ -79,7 +79,7 @@ class NotificationHubClient(notificationHubConnection: NotificationHubConnection
       .withHeaders(serviceBusTags: _*)
       .post(rawPush.body)(rawPush.writeable)
       .map {
-        case r if r.isSuccess => ().right
+        case r if r.isSuccess => r.header("Location").right
         case r => XmlParser.parseError(r).left
       }
   }

--- a/common/src/main/scala/models/NotificationReport.scala
+++ b/common/src/main/scala/models/NotificationReport.scala
@@ -18,6 +18,7 @@ case class NotificationReport(
 case class SenderReport(
   senderName: String,
   sentTime: DateTime,
+  sendersId: Option[String] = None,
   platformStatistics: Option[PlatformStatistics] = None
 )
 

--- a/common/src/test/scala/models/NotificationReportTest.scala
+++ b/common/src/test/scala/models/NotificationReportTest.scala
@@ -69,7 +69,7 @@ class NotificationReportTest extends Specification {
             topic = Set(Topic(Breaking, "uk"))
           ),
           reports = List(
-            SenderReport("Windows", sentTime, PlatformStatistics(WindowsMobile, recipientsCount = 3).some)
+            SenderReport("Windows", sentTime, None, PlatformStatistics(WindowsMobile, recipientsCount = 3).some)
           )
         )
       }

--- a/common/src/test/scala/tracking/DynamoNotificationReportRepositorySpec.scala
+++ b/common/src/test/scala/tracking/DynamoNotificationReportRepositorySpec.scala
@@ -82,7 +82,7 @@ class DynamoNotificationReportRepositorySpec(implicit ev: ExecutionEnv) extends 
         topic = Set(Topic(Breaking, "uk"))
       ),
       reports = List(
-        SenderReport("Windows", DateTime.parse(sentTime).withZone(DateTimeZone.UTC), PlatformStatistics(WindowsMobile, 5).some)
+        SenderReport("Windows", DateTime.parse(sentTime).withZone(DateTimeZone.UTC), Some(s"hub-$id"), PlatformStatistics(WindowsMobile, 5).some)
       )
     )
   }

--- a/notification/app/notification/services/azure/APNSSender.scala
+++ b/notification/app/notification/services/azure/APNSSender.scala
@@ -12,6 +12,6 @@ class APNSSender(hubClient: NotificationHubClient, configuration: Configuration,
 
   protected val azureRawPushConverter = new APNSPushConverter(configuration)
 
-  override protected def send(push: Push): Future[HubResult[Unit]] =
+  override protected def send(push: Push): Future[HubResult[Option[String]]] =
     hubClient.sendNotification(azureRawPushConverter.toRawPush(push))
 }

--- a/notification/app/notification/services/azure/GCMSender.scala
+++ b/notification/app/notification/services/azure/GCMSender.scala
@@ -12,6 +12,6 @@ class GCMSender(hubClient: NotificationHubClient, configuration: Configuration, 
 
   protected val azureRawPushConverter = new GCMPushConverter(configuration)
 
-  override protected def send(push: Push): Future[HubResult[Unit]] =
+  override protected def send(push: Push): Future[HubResult[Option[String]]] =
     hubClient.sendNotification(azureRawPushConverter.toRawPush(push))
 }

--- a/notification/app/notification/services/azure/WNSSender.scala
+++ b/notification/app/notification/services/azure/WNSSender.scala
@@ -13,6 +13,6 @@ class WNSSender(hubClient: NotificationHubClient, configuration: Configuration, 
 
   protected val azureRawPushConverter = new WNSPushConverter(configuration)
 
-  override protected def send(push: Push): Future[HubResult[Unit]] =
+  override protected def send(push: Push): Future[HubResult[Option[String]]] =
     hubClient.sendNotification(azureRawPushConverter.toRawPush(push))
 }

--- a/notification/test/notification/NotificationsFixtures.scala
+++ b/notification/test/notification/NotificationsFixtures.scala
@@ -53,8 +53,13 @@ trait NotificationsFixtures {
   val validTopics = Set(Topic(Breaking, "uk"), Topic(Breaking, "us"))
   val requestWithValidTopics = authenticatedRequest.withBody(breakingNewsNotification(validTopics))
 
-  def senderReport(senderName: String, platformStats: Option[PlatformStatistics] = None, sentTimeOffsetSeconds: Int = 0): SenderReport =
-    SenderReport(senderName, DateTime.now.plusSeconds(sentTimeOffsetSeconds), platformStats)
+  def senderReport(
+    senderName: String,
+    platformStats: Option[PlatformStatistics] = None,
+    sendersId: Option[String] = None,
+    sentTimeOffsetSeconds: Int = 0
+  ): SenderReport =
+    SenderReport(senderName, DateTime.now.plusSeconds(sentTimeOffsetSeconds), sendersId, platformStats)
 
   def reportWithSenderReports(reports: List[SenderReport]): NotificationReport = NotificationReport.create(
     breakingNewsNotification(validTopics),

--- a/notification/test/notification/services/azure/GCMSenderSpec.scala
+++ b/notification/test/notification/services/azure/GCMSenderSpec.scala
@@ -32,7 +32,7 @@ class GCMSenderSpec(implicit ev: ExecutionEnv) extends Specification
       "send two separate with notifications with differently encoded topics when addressed to topic" in new GCMScope {
         val result = androidNotificationSender.sendNotification(topicPush)
 
-        result should beEqualTo(senderReport(Senders.AzureNotificationsHub, platformStats = PlatformStatistics(WindowsMobile, 2).some).right).await
+        result should beEqualTo(senderReport(Senders.AzureNotificationsHub, platformStats = PlatformStatistics(WindowsMobile, 2).some, sendersId = "fake-id".some).right).await
         got {
           one(hubClient).sendNotification(pushConverter.toRawPush(topicPush))
         }
@@ -41,7 +41,7 @@ class GCMSenderSpec(implicit ev: ExecutionEnv) extends Specification
       "send only one notification when destination is user so that user do not receive the same message twice" in new GCMScope {
         val result = androidNotificationSender.sendNotification(userPush)
 
-        result should beEqualTo(senderReport(Senders.AzureNotificationsHub, platformStats = PlatformStatistics(WindowsMobile, 1).some).right).await
+        result should beEqualTo(senderReport(Senders.AzureNotificationsHub, platformStats = PlatformStatistics(WindowsMobile, 1).some, sendersId = "fake-id".some).right).await
         got {
           one(hubClient).sendNotification(pushConverter.toRawPush(userPush))
         }
@@ -62,7 +62,7 @@ class GCMSenderSpec(implicit ev: ExecutionEnv) extends Specification
     val configuration = mock[Configuration].debug returns true
     val hubClient = {
       val client = mock[NotificationHubClient]
-      client.sendNotification(any[GCMRawPush]) returns Future.successful(().right)
+      client.sendNotification(any[GCMRawPush]) returns Future.successful(Some("fake-id").right)
       client
     }
 

--- a/notification/test/notification/services/azure/WNSSenderSpec.scala
+++ b/notification/test/notification/services/azure/WNSSenderSpec.scala
@@ -32,7 +32,7 @@ class WNSSenderSpec(implicit ev: ExecutionEnv) extends Specification
       "send two separate with notifications with differently encoded topics when addressed to topic" in new WNSScope {
         val result = windowsNotificationSender.sendNotification(topicPush)
 
-        result should beEqualTo(senderReport(Senders.AzureNotificationsHub, platformStats = PlatformStatistics(WindowsMobile, 2).some).right).await
+        result should beEqualTo(senderReport(Senders.AzureNotificationsHub, platformStats = PlatformStatistics(WindowsMobile, 2).some, sendersId = "fake-id".some).right).await
         got {
           one(hubClient).sendNotification(pushConverter.toRawPush(topicPush))
         }
@@ -41,7 +41,7 @@ class WNSSenderSpec(implicit ev: ExecutionEnv) extends Specification
       "send only one notification when destination is user so that user do not receive the same message twice" in new WNSScope {
         val result = windowsNotificationSender.sendNotification(userPush)
 
-        result should beEqualTo(senderReport(Senders.AzureNotificationsHub, platformStats = PlatformStatistics(WindowsMobile, 1).some).right).await
+        result should beEqualTo(senderReport(Senders.AzureNotificationsHub, platformStats = PlatformStatistics(WindowsMobile, 1).some, sendersId = "fake-id".some).right).await
         got {
           one(hubClient).sendNotification(pushConverter.toRawPush(userPush))
         }
@@ -62,7 +62,7 @@ class WNSSenderSpec(implicit ev: ExecutionEnv) extends Specification
     val configuration = mock[Configuration].debug returns true
     val hubClient = {
       val client = mock[NotificationHubClient]
-      client.sendNotification(any[WNSRawPush]) returns Future.successful(().right)
+      client.sendNotification(any[WNSRawPush]) returns Future.successful(Some("fake-id").right)
       client
     }
 

--- a/report/test/report/controllers/ReportIntegrationSpec.scala
+++ b/report/test/report/controllers/ReportIntegrationSpec.scala
@@ -61,7 +61,7 @@ class ReportIntegrationSpec(implicit ee: ExecutionEnv) extends PlaySpecification
           topic = Set(Topic(Breaking, "uk"))
         ),
         reports = List(
-          SenderReport("Windows", DateTime.now.withZone(UTC), PlatformStatistics(WindowsMobile, 5).some)
+          SenderReport("Windows", DateTime.now.withZone(UTC), Some(s"hub-$id"), PlatformStatistics(WindowsMobile, 5).some)
         )
       )
     }


### PR DESCRIPTION
Include the notification id generated by azure so that we can fetch
telemetry from azure