### PR TITLE
Revert "Disable mutable-content flag"

### DIFF
--- a/notification/app/notification/models/ios/Notification.scala
+++ b/notification/app/notification/models/ios/Notification.scala
@@ -32,7 +32,7 @@ case class BreakingNewsNotification(
       category = Some(category),
       alert = Some(Right(message)),
       `content-available` = Some(1),
-      `mutable-content` = None,
+      `mutable-content` = if (imageUrl.isDefined) Some(1) else None,
       sound = Some("default")
     ),
     customProperties = LegacyProperties(Map(

--- a/notification/test/notification/models/azure/iOSNotificationSpec.scala
+++ b/notification/test/notification/models/azure/iOSNotificationSpec.scala
@@ -78,7 +78,7 @@ class iOSNotificationSpec extends Specification with Mockito {
         category = Some("ITEM_CATEGORY"),
         `content-available` = Some(1),
         sound = Some("default"),
-        `mutable-content` = None
+        `mutable-content` = Some(1)
       ),
       customProperties = LegacyProperties(Map(
         "t" -> "m",
@@ -114,7 +114,7 @@ class iOSNotificationSpec extends Specification with Mockito {
         category = Some("ITEM_CATEGORY"),
         `content-available` = Some(1),
         sound = Some("default"),
-        `mutable-content` = None
+        `mutable-content` = Some(1)
       ),
       customProperties = LegacyProperties(Map(
         "t" -> "m",


### PR DESCRIPTION
Reverts guardian/mobile-n10n#99

@fgauchet has decided that enough users have upgraded to the version of iOS that resolves this issue.