### PR TITLE
Add iosUseMessage option for content notifications

### DIFF
--- a/common/src/main/scala/models/Notification.scala
+++ b/common/src/main/scala/models/Notification.scala
@@ -65,6 +65,7 @@ case class ContentNotification(
   `type`: NotificationType = Content,
   title: String,
   message: String,
+  iosUseMessage: Option[Boolean],
   thumbnailUrl: Option[URI],
   sender: String,
   link: Link,

--- a/common/src/test/scala/models/NotificationSpec.scala
+++ b/common/src/test/scala/models/NotificationSpec.scala
@@ -78,6 +78,7 @@ class NotificationSpec extends Specification {
        id = UUID.fromString("c8bd6aaa-072f-4593-a38b-322f3ecd6bd3"),
        title = "Follow",
        message = "Which countries are doing the most to stop dangerous global warming?",
+       iosUseMessage = None,
        thumbnailUrl = Some(new URI("http://media.guim.co.uk/a07334e4ed5d13d3ecf4c1ac21145f7f4a099f18/127_0_3372_2023/140.jpg")),
        sender = "test",
        link = Internal("environment/ng-interactive/2015/oct/16/which-countries-are-doing-the-most-to-stop-dangerous-global-warming", None, GITContent),

--- a/notification/app/notification/services/azure/APNSPushConverter.scala
+++ b/notification/app/notification/services/azure/APNSPushConverter.scala
@@ -45,7 +45,7 @@ class APNSPushConverter(conf: Configuration) {
 
     ios.ContentNotification(
       category = "ITEM_CATEGORY",
-      message = cn.title,
+      message = if (cn.iosUseMessage.contains(true)) cn.message else cn.title,
       link = toIosLink(cn.link),
       topics = cn.topic,
       uri = new URI(link.uri),

--- a/notification/test/notification/models/azure/iOSNotificationSpec.scala
+++ b/notification/test/notification/models/azure/iOSNotificationSpec.scala
@@ -168,6 +168,7 @@ class iOSNotificationSpec extends Specification with Mockito {
       `type` = NotificationType.Content,
       title  = "French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State",
       message = "French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State",
+      iosUseMessage = None,
       thumbnailUrl = Some(new URI("https://media.guim.co.uk/633850064fba4941cdac17e8f6f8de97dd736029/24_0_1800_1080/500.jpg")),
       sender = "matt.wells@guardian.co.uk",
       link = Internal("world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray", Some("https://gu.com/p/4p7xt"), GITContent),

--- a/notification/test/notification/services/azure/GCMPushConverterSpec.scala
+++ b/notification/test/notification/services/azure/GCMPushConverterSpec.scala
@@ -93,6 +93,7 @@ class GCMPushConverterSpec extends Specification with Mockito {
       id = UUID.fromString("c8bd6aaa-072f-4593-a38b-322f3ecd6bd3"),
       title = "Follow",
       message = "Which countries are doing the most to stop dangerous global warming?",
+      iosUseMessage = None,
       thumbnailUrl = Some(new URI("http://media.guim.co.uk/a07334e4ed5d13d3ecf4c1ac21145f7f4a099f18/127_0_3372_2023/140.jpg")),
       sender = "test",
       link = Internal("environment/ng-interactive/2015/oct/16/which-countries-are-doing-the-most-to-stop-dangerous-global-warming", None, GITContent),

--- a/notification/test/notification/services/azure/WNSPushConverterSpec.scala
+++ b/notification/test/notification/services/azure/WNSPushConverterSpec.scala
@@ -86,6 +86,7 @@ class WNSPushConverterSpec extends Specification with Mockito {
       id = UUID.fromString("c8bd6aaa-072f-4593-a38b-322f3ecd6bd3"),
       title = "Follow",
       message = "Which countries are doing the most to stop dangerous global warming?",
+      iosUseMessage = None,
       thumbnailUrl = Some(new URI("http://media.guim.co.uk/a07334e4ed5d13d3ecf4c1ac21145f7f4a099f18/127_0_3372_2023/140.jpg")),
       sender = "test",
       link = Internal("environment/ng-interactive/2015/oct/16/which-countries-are-doing-the-most-to-stop-dangerous-global-warming", None, GITContent),


### PR DESCRIPTION
Temporary workaround so that we can send a longer message to android
and iOS