### PR TITLE
Remove topics field from android breaking news

### DIFF
--- a/notification/app/notification/models/android/Notification.scala
+++ b/notification/app/notification/models/android/Notification.scala
@@ -24,7 +24,6 @@ case class BreakingNewsNotification(
   debug: Boolean,
   editions: Set[Edition],
   link: URI,
-  topics: Set[String],
   uriType: PlatformUriType,
   uri: String,
   section: Option[URI],
@@ -43,7 +42,6 @@ case class BreakingNewsNotification(
     Keys.Debug -> debug.toString,
     Keys.Editions -> editions.mkString(","),
     Keys.Link -> link.toString,
-    Keys.Topics -> topics.mkString(","),
     Keys.UriType -> uriType.toString,
     Keys.Uri -> uri) ++ Map(
       Keys.Section -> section.map(_.toString),

--- a/notification/app/notification/services/azure/GCMPushConverter.scala
+++ b/notification/app/notification/services/azure/GCMPushConverter.scala
@@ -67,7 +67,6 @@ class GCMPushConverter(conf: Configuration) {
       debug = conf.debug,
       editions = editions,
       link = toAndroidLink(breakingNews.link),
-      topics = breakingNews.topic.map(toAndroidTopic),
       uriType = link.`type`,
       uri = link.uri,
       section = sectionLink.map(new URI(_)),

--- a/notification/test/notification/models/azure/AndroidNotificationSpec.scala
+++ b/notification/test/notification/models/azure/AndroidNotificationSpec.scala
@@ -61,7 +61,6 @@ class AndroidNotificationSpec extends Specification with Mockito {
       uri = "http://mobile-apps.guardianapis.com/items/world/live/2015/nov/20/mali-hotel-attack-gunmen-take-hostages-in-bamako-live-updates-uri",
       imageUrl = Some(new URI("https://mobile.guardianapis.com/img/media/a5fb401022d09b2f624a0cc0484c563fd1b6ad93/" +
         "0_308_4607_2764/master/4607.jpg/6ad3110822bdb2d1d7e8034bcef5dccf?width=800&height=-&quality=85")),
-      topics = Set("breaking//uk"),
       debug = true,
       section = None,
       edition = None,
@@ -71,7 +70,6 @@ class AndroidNotificationSpec extends Specification with Mockito {
     )
 
     val expected = Map(
-      "topics" -> "breaking//uk",
       "uniqueIdentifier" -> "30aac5f5-34bb-4a88-8b69-97f995a4907b",
       "editions" -> "",
       "uri" -> "http://mobile-apps.guardianapis.com/items/world/live/2015/nov/20/mali-hotel-attack-gunmen-take-hostages-in-bamako-live-updates-uri",

--- a/notification/test/notification/services/azure/GCMPushConverterSpec.scala
+++ b/notification/test/notification/services/azure/GCMPushConverterSpec.scala
@@ -84,7 +84,6 @@ class GCMPushConverterSpec extends Specification with Mockito {
       link = new URI("x-gu://www.guardian.co.uk/world/live/2015/nov/20/mali-hotel-attack-gunmen-take-hostages-in-bamako-live-updates"),
       uri = "x-gu:///items/world/live/2015/nov/20/mali-hotel-attack-gunmen-take-hostages-in-bamako-live-updates",
       imageUrl = Some(new URI("https://mobile.guardianapis.com/img/media/a5fb401022d09b2f624a0cc0484c563fd1b6ad93/0_308_4607_2764/master/4607.jpg/6ad3110822bdb2d1d7e8034bcef5dccf?width=800&height=-&quality=85")),
-      topics = Set("breaking//uk"),
       debug = true
     )
   }


### PR DESCRIPTION
Including this field causes the app to filter out these notifications because it doesn’t model breaking news as breaking//<edition>