### PR TITLE
Add LRU cache around is match ended

### DIFF
--- a/common/src/main/scala/auditor/package.scala
+++ b/common/src/main/scala/auditor/package.scala
@@ -55,7 +55,7 @@ package object auditor {
 
   case class FootballMatchAuditor(client: PaClient)(implicit ec: ExecutionContext) extends Auditor {
 
-    private val matchStatusCache: Cache[String] = LruCache[String](timeToLive = 5 minutes, timeToIdle = 1 minute)
+    private val matchStatusCache: Cache[String] = LruCache[String](timeToLive = 5 minutes)
 
     private val matchEndedStatuses = List(
       "FT",

--- a/common/src/main/scala/auditor/package.scala
+++ b/common/src/main/scala/auditor/package.scala
@@ -8,6 +8,7 @@ import spray.caching.{Cache, LruCache}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
+import scala.concurrent.duration.DurationInt
 
 package object auditor {
 
@@ -54,7 +55,7 @@ package object auditor {
 
   case class FootballMatchAuditor(client: PaClient)(implicit ec: ExecutionContext) extends Auditor {
 
-    private val matchStatusCache: Cache[String] = LruCache[String]()
+    private val matchStatusCache: Cache[String] = LruCache[String](timeToLive = 5 minutes, timeToIdle = 1 minute)
 
     private val matchEndedStatuses = List(
       "FT",


### PR DESCRIPTION
Naturally, the first thing I tried to determine was what are the consequences of using stale values from the cache? It looks like that just means associating an expired topic with a device, and it would stay there until removed by a later update. It looks to me like this should at worst just mean maintaining this association for no reason. 

I don't actually know when device registration/updates happen though so it's not clear to me when it's sensible to expire the data. Default capacity for the cache is 500, so it seems to me I should have some kind of TTL and/or TTI unless I'd like the data to be stale most of the time. 

I made a guess: TTL 5 minutes, TTI 1 minute. Thoughts?

@alexduf @davidfurey 