### PR TITLE
Add new reportsOnly api keys

### DIFF
--- a/report/app/report/controllers/Report.scala
+++ b/report/app/report/controllers/Report.scala
@@ -21,7 +21,7 @@ final class Report(
   (implicit executionContext: ExecutionContext)
   extends Controller with AuthenticationSupport {
 
-  val allApiKeys = configuration.apiKeys ++ configuration.electionRestrictedApiKeys
+  val allApiKeys = configuration.apiKeys ++ configuration.electionRestrictedApiKeys ++ configuration.reportsOnlyApiKeys
 
   override def validApiKey(apiKey: String): Boolean = allApiKeys.contains(apiKey)
 

--- a/report/app/report/services/Configuration.scala
+++ b/report/app/report/services/Configuration.scala
@@ -6,6 +6,7 @@ import conf.NotificationConfiguration
 class Configuration extends NotificationConfiguration("report") {
   lazy val apiKeys = conf.getStringPropertiesSplitByComma("notifications.api.secretKeys")
   lazy val electionRestrictedApiKeys = conf.getStringPropertiesSplitByComma("notifications.api.electionRestrictedKeys")
+  lazy val reportsOnlyApiKeys = conf.getStringPropertiesSplitByComma("notifications.api.reportsOnlyKeys")
   lazy val dynamoReportsTableName = getConfigString("db.dynamo.reports.table-name")
 
   lazy val defaultHub = NotificationHubConnection(


### PR DESCRIPTION
This is to grant people access to the reports API without being able to send notifications