### PR TITLE
The new ELBs don't seem to like the fancy close-my-connection response.

### DIFF
--- a/registration/app/registration/controllers/Main.scala
+++ b/registration/app/registration/controllers/Main.scala
@@ -41,15 +41,7 @@ final class Main(
   private val logger = Logger(classOf[Main])
 
   def healthCheck: Action[AnyContent] = Action {
-    // This forces Play to close the connection rather than allowing
-    // keep-alive (because the content length is unknown)
-    Ok.sendEntity(
-      HttpEntity.Streamed(
-        data =  Source(Array(ByteString("Good")).toVector),
-        contentLength = None,
-        contentType = Some("text/plain")
-      )
-    )
+    Ok("Good")
   }
 
   def register(lastKnownDeviceId: String): Action[Registration] = actionWithTimeout(BodyJson[Registration]) { request =>


### PR DESCRIPTION
We currently are observing a reboot-loop on our services, and it started on the 24th of march, unrelated to our changes.
I can only assume AWS has changed the way ELBs are handling healthcheck and don't like getting these responses back anymore.

I have deployed that branch already and am currently monitoring it.