### PR TITLE
Update to current

### DIFF
--- a/scripts/notifyiPadUsers.sh
+++ b/scripts/notifyiPadUsers.sh
@@ -80,10 +80,22 @@ GNLAppendLog "I'm going for it."
 
 # GNM INTERNAL Notification
 
-/usr/bin/curl -v -X POST "https://notification.notifications.code.dev-guardianapis.com/push/newsstand?api-key=?????????"
+# old one pre 17 July 2017
+# /usr/bin/curl -X POST "https://notifications.guardian.co.uk/newsstand/trigger?api-key=9fpnUKZXKHx3ymRMoey7"
+# new one post 17 July 2017
+/usr/bin/curl -X POST "https://notification.notifications.guardianapis.com/push/newsstand?api-key=9fpnUKZXKHx3ymRMoey7"
 
 curlExit=$?
 
+# this is a temporary fallback to the old URL in case they've given me something that doesn't work
+# we should remove it if all's well from issue 19 July 2017
+if [ "$curlExit" -ne "0" ]; then
+	GNLAppendLog "OK so the new URL didn't work - cURL error: $curlExit . I'll try the old one"
+	/usr/bin/curl -X POST "https://notifications.guardian.co.uk/newsstand/trigger?api-key=9fpnUKZXKHx3ymRMoey7"
+	curlExit=$?
+fi
+
+# done
 if [ "$curlExit" -ne "0" ]; then
         GNLAppendLog "Problem sending GNM notification - cURL error: $curlExit"
 else


### PR DESCRIPTION
Script as deployed at present. Remove key if that's the policy (although it was present in the original commit)