### PR TITLE
add newsstand to platform parameter verification

### DIFF
--- a/common/src/main/scala/models/Platform.scala
+++ b/common/src/main/scala/models/Platform.scala
@@ -14,6 +14,7 @@ object Platform {
     case "android" => Android
     case "ios" => iOS
     case "windows-mobile" => WindowsMobile
+    case "newsstand" => Newsstand
   }
 
   implicit val jf = new Format[Platform] {


### PR DESCRIPTION
My Bad

This is just a little fix to help us verify that the newsstand notifications works. The 'newsstand' was previously defined as a platform here: https://github.com/guardian/mobile-n10n/blob/master/common/src/main/scala/models/Platform.scala#L9, and I forgot to add this change into the branch that i merged into master. (I'd previously deployed a branch to code with lots of extra debug in which also had this change)

This means we can't verify a registration with the GET /regjstrations route, because when we pass 'newsstand', it causes an error. 