### PR TITLE
send full web url to client side.

### DIFF
--- a/notification/app/notification/services/azure/APNSPushConverter.scala
+++ b/notification/app/notification/services/azure/APNSPushConverter.scala
@@ -107,7 +107,7 @@ class APNSPushConverter(conf: Configuration) extends PushConverter {
   case class PlatformUri(uri: String, `type`: PlatformUriType)
 
   private def toPlatformLink(link: Link) = link match {
-    case Link.Internal(contentApiId, _, _) => PlatformUri(s"x-gu://$contentApiId", Item)
+    case Link.Internal(contentApiId, _, _) => PlatformUri(s"https://www.theguardian.com/$contentApiId", Item)
     case Link.External(url) => PlatformUri(url, External)
   }
 

--- a/notification/test/notification/models/azure/iOSNotificationSpec.scala
+++ b/notification/test/notification/models/azure/iOSNotificationSpec.scala
@@ -92,7 +92,7 @@ class iOSNotificationSpec extends Specification with Mockito {
         "notificationType" -> "news",
         "link" -> "x-gu:///p/4p7xt",
         "topics" -> "breaking/uk,breaking/us,breaking/au,breaking/international",
-        "uri" -> "x-gu://world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
+        "uri" -> "https://www.theguardian.com/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
         "imageUrl" -> "https://media.guim.co.uk/633850064fba4941cdac17e8f6f8de97dd736029/24_0_1800_1080/500.jpg",
         "uriType" -> "item"
       ))
@@ -128,7 +128,7 @@ class iOSNotificationSpec extends Specification with Mockito {
         "notificationType" -> "news",
         "link" -> "x-gu:///p/4p7xt",
         "topics" -> "breaking/uk,breaking/us,breaking/au,breaking/international",
-        "uri" -> "x-gu://world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
+        "uri" -> "https://www.theguardian.com/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
         "imageUrl" -> "https://media.guim.co.uk/633850064fba4941cdac17e8f6f8de97dd736029/24_0_1800_1080/500-image-url.jpg",
         "uriType" -> "item"
       ))
@@ -163,7 +163,7 @@ class iOSNotificationSpec extends Specification with Mockito {
         "notificationType" -> "news",
         "link" -> "x-gu:///p/4p7xt",
         "topics" -> "breaking/uk,breaking/us,breaking/au,breaking/international",
-        "uri" -> "x-gu://world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
+        "uri" -> "https://www.theguardian.com/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
         "uriType" -> "item"
       ))
     )
@@ -197,7 +197,7 @@ class iOSNotificationSpec extends Specification with Mockito {
         "notificationType" -> "content",
         "link" -> "x-gu:///p/4p7xt",
         "topics" -> "tag-series/series-a,tag-series/series-b",
-        "uri" -> "x-gu://world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
+        "uri" -> "https://www.theguardian.com/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
         "uriType" -> "item"
       ))
     )


### PR DESCRIPTION
It's apprently simpler for the ios client side to resolve with the full url