### PR TITLE
remove tag migration

### DIFF
--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -61,17 +61,7 @@ final class Main(
   def pushTopic(topic: Topic): Action[Notification] = pushTopics
 
   def pushTopics: Action[Notification] = AuthenticatedAction.async(BodyJson[Notification]) { request =>
-    // todo: remove once client-side migrates users from weekend-round-up to weekend-reading
-    val topics = {
-      val rawTopics = request.body.topic
-
-      if (rawTopics.contains(weekendReadingTopic)) {
-        rawTopics + weekendRoundUpTopic
-      } else {
-        rawTopics
-      }
-    }
-
+    val topics = request.body.topic
     val MaxTopics = 20
     topics.size match {
       case 0 => Future.successful(BadRequest("Empty topic list"))

--- a/notification/test/notification/controllers/MainSpec.scala
+++ b/notification/test/notification/controllers/MainSpec.scala
@@ -27,15 +27,6 @@ class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito
       status(response) must equalTo(CREATED)
       pushSent must beSome.which(_.destination must beEqualTo(Left(validTopics)))
     }
-    "send weekend-reading notifications to weekend-round-up topic too" in new MainScope {
-      val weekendReadingTopic = Topic(TagSeries, "membership/series/weekend-reading")
-      val weekendRoundUpTopic = Topic(TagSeries, "membership/series/weekend-round-up")
-      val request = authenticatedRequest.withBody(breakingNewsNotification(Set(weekendReadingTopic)))
-      val response = main.pushTopics()(request)
-
-      status(response) must equalTo(CREATED)
-      pushSent must beSome.which(_.destination must beEqualTo(Left(Set(weekendReadingTopic, weekendRoundUpTopic))))
-    }
     "refuse a notification with an invalid key" in new MainScope {
       val request = invalidAuthenticatedRequest.withBody(breakingNewsNotification(validTopics))
       val response = main.pushTopics()(request)


### PR DESCRIPTION
This was once used to migrate some of our clients, but this isn't
necessary anymore.
It also is pushing us above 20 topics if we receive 20 topics,
triggering a server side error.