### PR TITLE
Cats 1 migration

### DIFF
--- a/backup/src/main/scala/backup/Backup.scala
+++ b/backup/src/main/scala/backup/Backup.scala
@@ -13,7 +13,6 @@ import play.api.Logger
 import collection.JavaConversions._
 
 import scala.concurrent.{ExecutionContext, Future}
-import cats.data.Xor
 
 class Backup(conf: Configuration, ws: WSClient)(implicit ec: ExecutionContext) extends Batch {
   val logger = Logger(classOf[Backup])
@@ -41,10 +40,10 @@ class Backup(conf: Configuration, ws: WSClient)(implicit ec: ExecutionContext) e
 
     val hubClient = new NotificationHubClient(conf.notificationHubConnection, ws)
     hubClient.submitNotificationHubJob(notificationJob).map {
-      case Xor.Right(job) =>
+      case Right(job) =>
         logger.info(s"Job successfully created with id ${job.jobId}")
         logger.debug(s"Job submitted to hub: $job")
-      case Xor.Left(failure: HubFailure) =>
+      case Left(failure: HubFailure) =>
         logger.error(s"Failed submitting job to hub (provider ${failure.providerName}, reason: ${failure.reason})")
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val common = project
     libraryDependencies ++= Seq(
       ws,
       "com.microsoft.azure" % "azure-servicebus" % "0.7.0",
-      "org.typelevel" %% "cats" % "0.7.0",
+      "org.typelevel" %% "cats-core" % "1.0.1",
       "joda-time" % "joda-time" % "2.8.2",
       "com.gu" %% "configuration" % "4.1",
       "io.spray" %% "spray-caching" % "1.3.3",

--- a/common/src/main/scala/azure/NotificationDetails.scala
+++ b/common/src/main/scala/azure/NotificationDetails.scala
@@ -1,13 +1,12 @@
 package azure
 
-import cats.data.Xor
-import cats.implicits._
 import org.joda.time.DateTime
 import play.api.libs.json.Json
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
 
 import scala.xml.Elem
+import cats.syntax.either._
 
 case class NotificationDetails(
   state: NotificationState,

--- a/common/src/main/scala/azure/NotificationHubJob.scala
+++ b/common/src/main/scala/azure/NotificationHubJob.scala
@@ -5,9 +5,9 @@ import org.joda.time.DateTime
 import NotificationHubJobType._
 import Responses.RichXmlElem
 import play.api.Logger
+import cats.syntax.either._
 
 import scala.xml.{Elem, NodeSeq}
-import cats.data.Xor
 
 case class NotificationHubJobRequest(
   jobType: NotificationHubJobType,
@@ -48,7 +48,7 @@ object NotificationHubJob {
   val logger = Logger(classOf[NotificationHubJob])
 
   private def parseProperties(seq: NodeSeq): HubResult[Map[String, String]] = {
-    Xor.right(seq.map { elem =>
+    Right(seq.map { elem =>
       (elem \ "Key" text) -> (elem \ "Value" text)
     }.toMap)
   }

--- a/common/src/main/scala/azure/NotificationHubRegistrationId.scala
+++ b/common/src/main/scala/azure/NotificationHubRegistrationId.scala
@@ -3,13 +3,11 @@ package azure
 
 import play.api.libs.json.Json
 
-import cats.data.Xor
-
 case class NotificationHubRegistrationId(registrationId: String)
 
 object NotificationHubRegistrationId {
   implicit val jf = Json.format[NotificationHubRegistrationId]
 
-  def fromString(registrationId: String): String Xor NotificationHubRegistrationId =
-    Xor.right(NotificationHubRegistrationId(registrationId))
+  def fromString(registrationId: String): Either[String, NotificationHubRegistrationId] =
+    Right(NotificationHubRegistrationId(registrationId))
 }

--- a/common/src/main/scala/azure/NotificationStates.scala
+++ b/common/src/main/scala/azure/NotificationStates.scala
@@ -1,10 +1,10 @@
 package azure
 
 import azure.HubFailure.HubInvalidResponse
-import cats.data.Xor
 import models.JsonUtils
 
 import scala.PartialFunction._
+import cats.syntax.either._
 
 sealed trait NotificationState
 
@@ -14,7 +14,7 @@ object NotificationState {
 
   implicit val jf = JsonUtils.stringFormat((fromString _).andThen(_.toOption))
 
-  def fromString(s: String): Xor[HubInvalidResponse, NotificationState] = Xor.fromOption(condOpt(s) {
+  def fromString(s: String): Either[HubInvalidResponse, NotificationState] = Either.fromOption(condOpt(s) {
     case "Abandoned" => Abandoned
     case "Canceled" => Canceled
     case "Completed" => Completed

--- a/common/src/main/scala/azure/Outcome.scala
+++ b/common/src/main/scala/azure/Outcome.scala
@@ -3,6 +3,7 @@ package azure
 import play.api.libs.json.Json
 
 import scala.xml.Elem
+import cats.syntax.either._
 
 case class Outcome(name: OutcomeName, count: Int)
 

--- a/common/src/main/scala/azure/OutcomeNames.scala
+++ b/common/src/main/scala/azure/OutcomeNames.scala
@@ -1,7 +1,7 @@
 package azure
 
 import azure.HubFailure.HubInvalidResponse
-import cats.data.Xor
+import cats.syntax.either._
 import models.JsonUtils
 
 import scala.PartialFunction._
@@ -36,7 +36,7 @@ object OutcomeName {
 
   implicit val jf = JsonUtils.stringFormat((fromString _).andThen(_.toOption))
 
-  def fromString(s: String): Xor[HubInvalidResponse, OutcomeName] = Xor.fromOption(condOpt(s) {
+  def fromString(s: String): Either[HubInvalidResponse, OutcomeName] = Either.fromOption(condOpt(s) {
     case "AbandonedNotificationMessages" => AbandonedNotificationMessages
     case "BadChannel" => BadChannel
     case "ChannelDisconnected" => ChannelDisconnected

--- a/common/src/main/scala/binders/pathbinders/package.scala
+++ b/common/src/main/scala/binders/pathbinders/package.scala
@@ -23,13 +23,13 @@ package object pathbinders {
   )
 
   implicit def pathbindableNotificationHubRegistrationId: PathBindable[NotificationHubRegistrationId] = new Parsing[NotificationHubRegistrationId](
-    parse = NotificationHubRegistrationId.fromString(_).toEither,
+    parse = NotificationHubRegistrationId.fromString(_),
     serialize = _.toString,
     typeName = "registration id"
   )
 
   implicit def pathbindableTopic: play.api.mvc.PathBindable[Topic] = new Parsing[Topic](
-    parse = Topic.fromString(_).toEither,
+    parse = Topic.fromString(_),
     serialize = _.toString,
     typeName = "topic"
   )

--- a/common/src/main/scala/binders/querystringbinders/package.scala
+++ b/common/src/main/scala/binders/querystringbinders/package.scala
@@ -25,7 +25,7 @@ package object querystringbinders {
   }
 
   implicit def qsbindableTopic: QueryStringBindable[Topic] = new Parsing[Topic](
-    parse = Topic.fromString(_).toEither,
+    parse = Topic.fromString(_),
     serialize = _.toString,
     typeName = "Topic"
   )

--- a/common/src/main/scala/models/Topic.scala
+++ b/common/src/main/scala/models/Topic.scala
@@ -3,7 +3,7 @@ package models
 import org.apache.commons.codec.digest.DigestUtils.md5Hex
 import play.api.libs.json._
 
-import cats.data.Xor
+import cats.syntax.either._
 
 case class Topic(`type`: TopicType, name: String) {
   override def toString: String = s"${`type`}/$name"
@@ -14,10 +14,10 @@ object Topic {
 
   implicit val jf = Json.format[Topic]
 
-  def fromString(s: String): String Xor Topic = {
+  def fromString(s: String): Either[String, Topic] = {
     val (topicType, topicName) = s.splitAt(s.indexOf("/"))
     for {
-      tt <- Xor.fromOption(TopicType.fromString(topicType), s"Invalid topic type $topicType")
+      tt <- Either.fromOption(TopicType.fromString(topicType), s"Invalid topic type $topicType")
       tn = topicName.drop(1)
     } yield Topic(tt, tn)
   }

--- a/common/src/main/scala/tracking/BatchingTopicSubscriptionsRepository.scala
+++ b/common/src/main/scala/tracking/BatchingTopicSubscriptionsRepository.scala
@@ -75,12 +75,12 @@ class BatchingTopicSubscriptionsRepository(underlying: TopicSubscriptionsReposit
 
   override def deviceSubscribed(topic: Topic, count: Int = 1): Future[RepositoryResult[Unit]] = {
     actor ! SubscriptionEvent(Some(topic), topic.id, count)
-    Future.successful(().right)
+    Future.successful(Right(()))
   }
 
   override def deviceUnsubscribed(topicId: String, count: Int = 1): Future[RepositoryResult[Unit]] = {
     actor ! SubscriptionEvent(None, topicId, -count)
-    Future.successful(().right)
+    Future.successful(Right(()))
   }
 
   override def count(topic: Topic): Future[RepositoryResult[Int]] = underlying.count(topic)

--- a/common/src/main/scala/tracking/InMemoryTopicSubscriptionsRepository.scala
+++ b/common/src/main/scala/tracking/InMemoryTopicSubscriptionsRepository.scala
@@ -1,8 +1,8 @@
 package tracking
 
-import cats.data.Xor
 import models.Topic
 import tracking.Repository._
+import cats.syntax.either._
 
 import scala.concurrent.Future
 
@@ -26,5 +26,5 @@ class InMemoryTopicSubscriptionsRepository extends TopicSubscriptionsRepository 
   }
 
   override def topicFromId(topicId: String): Future[RepositoryResult[Topic]] =
-    Future.successful(Xor.fromOption(counters.keys.find(_.id == topicId), RepositoryError("Topic not found")))
+    Future.successful(Either.fromOption(counters.keys.find(_.id == topicId), RepositoryError("Topic not found")))
 }

--- a/common/src/main/scala/tracking/Repository.scala
+++ b/common/src/main/scala/tracking/Repository.scala
@@ -1,13 +1,11 @@
 package tracking
 
-import cats.data.Xor
-
 case class RepositoryError(message: String)
 
 object Repository {
-  type RepositoryResult[T] = RepositoryError Xor T
+  type RepositoryResult[T] = Either[RepositoryError, T]
 }
 
 object RepositoryResult {
-  def apply[T](result: T): RepositoryError Xor T = Xor.right(result)
+  def apply[T](result: T): Either[RepositoryError, T] = Right(result)
 }

--- a/common/src/main/scala/tracking/SubscriptionTracker.scala
+++ b/common/src/main/scala/tracking/SubscriptionTracker.scala
@@ -7,7 +7,6 @@ import tracking.Repository.RepositoryResult
 
 import scala.concurrent.Future
 import scala.util.{Success, Try}
-import cats.data.Xor
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -15,7 +14,7 @@ class SubscriptionTracker(topicSubscriptionsRepository: TopicSubscriptionsReposi
   val logger = Logger(classOf[SubscriptionTracker])
 
   def recordSubscriptionChange(topicSubscriptionTracking: TopicSubscriptionTracking): PartialFunction[Try[HubResult[_]], Unit] = {
-    case Success(Xor.Right(_)) =>
+    case Success(Right(_)) =>
       Future.traverse(topicSubscriptionTracking.addedTopics) { topic =>
         logger.debug(s"Informing about new topic registrations. [$topic]")
         topicSubscriptionsRepository.deviceSubscribed(topic, 1)

--- a/common/src/test/scala/azure/AtomFeedResponseSpec.scala
+++ b/common/src/test/scala/azure/AtomFeedResponseSpec.scala
@@ -3,7 +3,7 @@ package azure
 import NotificationHubClient.HubResult
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import cats.implicits._
+import cats.syntax.either._
 
 import scala.xml.Elem
 
@@ -12,7 +12,7 @@ class AtomFeedResponseSpec extends Specification {
   "The AtomEntry parser" should {
     "parse a valid XML into an entry" in new AtomEntryScope {
       val parsedObject = atomReader.reads(xmlEntry("a value")).map(_.content)
-      parsedObject shouldEqual SomeObject("a value").right
+      parsedObject shouldEqual Right(SomeObject("a value"))
     }
   }
 
@@ -20,7 +20,7 @@ class AtomFeedResponseSpec extends Specification {
     "parse a valid XML into a feed" in new AtomFeedScope {
       val entries = List(xmlEntry("Hello"), xmlEntry("this"), xmlEntry("is"), xmlEntry("Doge"))
       val parsedObject = feedReader.reads(xmlFeed(entries)).map(_.items)
-      parsedObject shouldEqual List(SomeObject("Hello"), SomeObject("this"), SomeObject("is"), SomeObject("Doge")).right
+      parsedObject shouldEqual Right(List(SomeObject("Hello"), SomeObject("this"), SomeObject("is"), SomeObject("Doge")))
     }
   }
 
@@ -28,7 +28,7 @@ class AtomFeedResponseSpec extends Specification {
     case class SomeObject(someValue: String)
 
     implicit val someObjectReader = new XmlReads[SomeObject] {
-      override def reads(xml: Elem): HubResult[SomeObject] = SomeObject(xml \ "someValue" text).right
+      override def reads(xml: Elem): HubResult[SomeObject] = Right(SomeObject(xml \ "someValue" text))
     }
 
     implicit val atomReader = AtomEntry.reader[SomeObject]

--- a/common/src/test/scala/models/NotificationReportTest.scala
+++ b/common/src/test/scala/models/NotificationReportTest.scala
@@ -69,7 +69,7 @@ class NotificationReportTest extends Specification {
             topic = Set(Topic(Breaking, "uk"))
           ),
           reports = List(
-            SenderReport("Windows", sentTime, None, PlatformStatistics(WindowsMobile, recipientsCount = 3).some)
+            SenderReport("Windows", sentTime, None, Some(PlatformStatistics(WindowsMobile, recipientsCount = 3)))
           )
         )
       }

--- a/common/src/test/scala/tracking/BatchingTopicSubscriptionsRepositorySpec.scala
+++ b/common/src/test/scala/tracking/BatchingTopicSubscriptionsRepositorySpec.scala
@@ -82,8 +82,8 @@ class BatchingTopicSubscriptionsRepositorySpec(implicit ev: ExecutionEnv) extend
 
   trait TestScope extends Scope {
     val underlying = mock[TopicSubscriptionsRepository]
-    underlying.deviceSubscribed(any[Topic], any[Int]).returns(Future.successful(().right))
-    underlying.deviceUnsubscribed(any[String], any[Int]).returns(Future.successful(().right))
+    underlying.deviceSubscribed(any[Topic], any[Int]).returns(Future.successful(Right(())))
+    underlying.deviceUnsubscribed(any[String], any[Int]).returns(Future.successful(Right(())))
     val batching = new BatchingTopicSubscriptionsRepository(underlying)
     val topic1 = Topic(TopicTypes.Breaking, "test1")
     val topic2 = Topic(TopicTypes.Breaking, "test2")

--- a/common/src/test/scala/tracking/DynamoNotificationReportRepositorySpec.scala
+++ b/common/src/test/scala/tracking/DynamoNotificationReportRepositorySpec.scala
@@ -18,7 +18,7 @@ import scala.collection.JavaConversions._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import cats.implicits._
+import cats.syntax.either._
 
 class DynamoNotificationReportRepositorySpec(implicit ev: ExecutionEnv) extends DynamodbSpecification with Mockito {
 
@@ -82,7 +82,7 @@ class DynamoNotificationReportRepositorySpec(implicit ev: ExecutionEnv) extends 
         topic = Set(Topic(Breaking, "uk"))
       ),
       reports = List(
-        SenderReport("Windows", DateTime.parse(sentTime).withZone(DateTimeZone.UTC), Some(s"hub-$id"), PlatformStatistics(WindowsMobile, 5).some)
+        SenderReport("Windows", DateTime.parse(sentTime).withZone(DateTimeZone.UTC), Some(s"hub-$id"), Some(PlatformStatistics(WindowsMobile, 5)))
       )
     )
   }

--- a/common/src/test/scala/tracking/DynamoTopicSubscriptionsRepositorySpec.scala
+++ b/common/src/test/scala/tracking/DynamoTopicSubscriptionsRepositorySpec.scala
@@ -6,6 +6,7 @@ import models._
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import scala.concurrent.duration._
+import cats.syntax.either._
 
 import scala.collection.JavaConversions._
 

--- a/notification/app/notification/services/package.scala
+++ b/notification/app/notification/services/package.scala
@@ -3,8 +3,6 @@ package notification
 import _root_.models.SenderReport
 import error.NotificationsError
 
-import cats.data.Xor
-
 package object services {
   trait SenderError extends NotificationsError {
     def senderName: String
@@ -21,5 +19,5 @@ package object services {
     val FrontendAlerts = "Frontend Alerts Sender"
   }
 
-  type SenderResult = NotificationRejected Xor SenderReport
+  type SenderResult = Either[NotificationRejected, SenderReport]
 }

--- a/notification/test/notification/services/azure/WNSSenderSpec.scala
+++ b/notification/test/notification/services/azure/WNSSenderSpec.scala
@@ -12,7 +12,6 @@ import org.specs2.specification.Scope
 import tracking.TopicSubscriptionsRepository
 
 import scala.concurrent.Future
-import cats.data.Xor
 import cats.implicits._
 
 class WNSSenderSpec(implicit ev: ExecutionEnv) extends Specification
@@ -21,7 +20,7 @@ class WNSSenderSpec(implicit ev: ExecutionEnv) extends Specification
   "the notification sender" should {
     "filter out Minor notifications" in new WNSScope {
       override val importance = Minor
-      val expectedReport = senderReport(Senders.AzureNotificationsHub).right
+      val expectedReport = Right(senderReport(Senders.AzureNotificationsHub))
       val result = windowsNotificationSender.sendNotification(userPush)
 
       result should beEqualTo(expectedReport).await
@@ -31,7 +30,7 @@ class WNSSenderSpec(implicit ev: ExecutionEnv) extends Specification
     "process a Minor election notification" in new WNSScope {
       val result = windowsNotificationSender.sendNotification(electionPush(Minor))
 
-      result should beEqualTo(senderReport(Senders.AzureNotificationsHub, platformStats = PlatformStatistics(WindowsMobile, 1).some, sendersId = "fake-id".some).right).await
+      result should beEqualTo(Right(senderReport(Senders.AzureNotificationsHub, platformStats = Some(PlatformStatistics(WindowsMobile, 1)), sendersId = Some("fake-id")))).await
       got {
         one(hubClient).sendNotification(pushConverter.toRawPush(electionPush(Minor)).get)
       }
@@ -41,7 +40,7 @@ class WNSSenderSpec(implicit ev: ExecutionEnv) extends Specification
       "send two separate with notifications with differently encoded topics when addressed to topic" in new WNSScope {
         val result = windowsNotificationSender.sendNotification(topicPush)
 
-        result should beEqualTo(senderReport(Senders.AzureNotificationsHub, platformStats = PlatformStatistics(WindowsMobile, 2).some, sendersId = "fake-id".some).right).await
+        result should beEqualTo(Right(senderReport(Senders.AzureNotificationsHub, platformStats = Some(PlatformStatistics(WindowsMobile, 2)), sendersId = Some("fake-id")))).await
         got {
           one(hubClient).sendNotification(pushConverter.toRawPush(topicPush).get)
         }
@@ -50,7 +49,7 @@ class WNSSenderSpec(implicit ev: ExecutionEnv) extends Specification
       "send only one notification when destination is user so that user do not receive the same message twice" in new WNSScope {
         val result = windowsNotificationSender.sendNotification(userPush)
 
-        result should beEqualTo(senderReport(Senders.AzureNotificationsHub, platformStats = PlatformStatistics(WindowsMobile, 1).some, sendersId = "fake-id".some).right).await
+        result should beEqualTo(Right(senderReport(Senders.AzureNotificationsHub, platformStats = Some(PlatformStatistics(WindowsMobile, 1)), sendersId = Some("fake-id")))).await
         got {
           one(hubClient).sendNotification(pushConverter.toRawPush(userPush).get)
         }
@@ -74,7 +73,7 @@ class WNSSenderSpec(implicit ev: ExecutionEnv) extends Specification
     val configuration = mock[Configuration].debug returns true
     val hubClient = {
       val client = mock[NotificationHubClient]
-      client.sendNotification(any[WNSRawPush]) returns Future.successful(Some("fake-id").right)
+      client.sendNotification(any[WNSRawPush]) returns Future.successful(Right(Some("fake-id")))
       client
     }
 
@@ -82,7 +81,7 @@ class WNSSenderSpec(implicit ev: ExecutionEnv) extends Specification
 
     val topicSubscriptionsRepository = {
       val m = mock[TopicSubscriptionsRepository]
-      m.count(any[Topic]) returns Future.successful(1.right)
+      m.count(any[Topic]) returns Future.successful(Right(1))
       m
     }
 

--- a/notification/test/notification/services/frontend/FrontendAlertsSpec.scala
+++ b/notification/test/notification/services/frontend/FrontendAlertsSpec.scala
@@ -26,7 +26,7 @@ class FrontendAlertsSpec(implicit ee: ExecutionEnv) extends Specification with M
         notification = breakingNewsNotification(validTopics).asInstanceOf[BreakingNewsNotification].copy(link = External("url"))
       )
 
-      alerts.sendNotification(push) must beEqualTo(NotificationRejected(Some(FrontendAlertsProviderError("Alert could not be created"))).left).await
+      alerts.sendNotification(push) must beEqualTo(Left(NotificationRejected(Some(FrontendAlertsProviderError("Alert could not be created"))))).await
 
       there was no(wsClient).url(any)
     }
@@ -40,7 +40,7 @@ class FrontendAlertsSpec(implicit ee: ExecutionEnv) extends Specification with M
       } { implicit port =>
         WsTestClient.withClient { client =>
           val alerts = new FrontendAlerts(config, client)
-          alerts.sendNotification(userTargetedBreakingNewsPush()) map { _.toEither } must beRight.await
+          alerts.sendNotification(userTargetedBreakingNewsPush()) must beRight.await
         }
       }
     }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/registration/app/registration/services/LegacyNewsstandRegistrationConverter.scala
+++ b/registration/app/registration/services/LegacyNewsstandRegistrationConverter.scala
@@ -1,6 +1,5 @@
 package registration.services
 
-import cats.data.Xor
 import cats.implicits._
 import error.NotificationsError
 import models._
@@ -8,15 +7,15 @@ import registration.models.LegacyNewsstandRegistration
 
 class LegacyNewsstandRegistrationConverter extends RegistrationConverter[LegacyNewsstandRegistration] {
 
-  def toRegistration(legacyRegistration: LegacyNewsstandRegistration): NotificationsError Xor Registration = {
+  def toRegistration(legacyRegistration: LegacyNewsstandRegistration): Either[NotificationsError, Registration] = {
     val udid = NewsstandUdid.fromDeviceToken(legacyRegistration.pushToken)
-    Registration(
+    Right(Registration(
       deviceId = legacyRegistration.pushToken,
       platform = Newsstand,
       udid = udid,
       topics = Set(Topic(TopicTypes.Newsstand, "newsstand")),
       buildTier = None
-    ).right
+    ))
   }
 
   def fromResponse(legacyRegistration: LegacyNewsstandRegistration, response: RegistrationResponse): LegacyNewsstandRegistration =

--- a/registration/app/registration/services/LegacyRegistrationConverter.scala
+++ b/registration/app/registration/services/LegacyRegistrationConverter.scala
@@ -4,24 +4,23 @@ import error.NotificationsError
 import registration.models.LegacyTopic
 import models._
 import registration.models.LegacyRegistration
-import cats.data.Xor
 import cats.implicits._
 
 class LegacyRegistrationConverter extends RegistrationConverter[LegacyRegistration] {
 
-  def toRegistration(legacyRegistration: LegacyRegistration): NotificationsError Xor Registration = {
-    val unsupportedPlatform: NotificationsError Xor Registration =
-      Xor.left(UnsupportedPlatform(legacyRegistration.device.platform))
+  def toRegistration(legacyRegistration: LegacyRegistration): Either[NotificationsError, Registration] = {
+    val unsupportedPlatform: Either[NotificationsError, Registration] =
+      Left(UnsupportedPlatform(legacyRegistration.device.platform))
 
     Platform.fromString(legacyRegistration.device.platform).fold(unsupportedPlatform) { platform =>
-      Registration(
+      Right(Registration(
         deviceId = legacyRegistration.device.pushToken,
         platform = platform,
         // The Windows app sends a device generated guid as the userId, not a real Guardian user id so udid is equivalent
         udid = legacyRegistration.device.udid,
         topics = topics(legacyRegistration),
         buildTier = Some(legacyRegistration.device.buildTier)
-      ).right
+      ))
     }
   }
 

--- a/registration/app/registration/services/NotificationRegistrar.scala
+++ b/registration/app/registration/services/NotificationRegistrar.scala
@@ -4,7 +4,6 @@ import models._
 import providers.ProviderError
 
 import scala.concurrent.Future
-import cats.data.Xor
 import models.pagination.Paginated
 
 case class RegistrationResponse(deviceId: String, platform: Platform, userId: UniqueDeviceIdentifier, topics: Set[Topic])
@@ -35,11 +34,11 @@ object StoredRegistration {
 
 
 trait NotificationRegistrar {
-  type RegistrarResponse[T] = Future[ProviderError Xor T]
+  type RegistrarResponse[T] = Future[Either[ProviderError, T]]
   val providerIdentifier: String
   def register(oldDeviceId: String, registration: Registration): RegistrarResponse[RegistrationResponse]
   def unregister(udid: UniqueDeviceIdentifier): RegistrarResponse[Unit]
-  def findRegistrations(topic: Topic, cursor: Option[String] = None): Future[ProviderError Xor Paginated[StoredRegistration]]
-  def findRegistrations(lastKnownChannelUri: String): Future[ProviderError Xor List[StoredRegistration]]
-  def findRegistrations(udid: UniqueDeviceIdentifier): Future[ProviderError Xor Paginated[StoredRegistration]]
+  def findRegistrations(topic: Topic, cursor: Option[String] = None): Future[Either[ProviderError, Paginated[StoredRegistration]]]
+  def findRegistrations(lastKnownChannelUri: String): Future[Either[ProviderError, List[StoredRegistration]]]
+  def findRegistrations(udid: UniqueDeviceIdentifier): Future[Either[ProviderError, Paginated[StoredRegistration]]]
 }

--- a/registration/app/registration/services/NotificationRegistrarProvider.scala
+++ b/registration/app/registration/services/NotificationRegistrarProvider.scala
@@ -6,14 +6,13 @@ import registration.services.azure._
 
 import scala.collection.breakOut
 import scala.concurrent.ExecutionContext
-import cats.data.Xor
 import cats.implicits._
 
 trait RegistrarProvider {
-  def registrarFor(registration: Registration): Xor[NotificationsError, NotificationRegistrar] =
+  def registrarFor(registration: Registration): Either[NotificationsError, NotificationRegistrar] =
     registrarFor(registration.platform, registration.buildTier)
 
-  def registrarFor(platform: Platform, buildTier: Option[String]): Xor[NotificationsError, NotificationRegistrar]
+  def registrarFor(platform: Platform, buildTier: Option[String]): Either[NotificationsError, NotificationRegistrar]
 
   def withAllRegistrars[T](fn: (NotificationRegistrar => T)): List[T]
 }
@@ -36,12 +35,12 @@ final class NotificationRegistrarProvider(
       .values
       .flatMap(_.headOption)(breakOut)
 
-  override def registrarFor(platform: Platform, buildTier: Option[String]): NotificationsError Xor NotificationRegistrar = platform match {
-    case WindowsMobile => windowsRegistrar.right
-    case Android => gcmRegistrar.right
-    case `iOS` => apnsRegistrar.right
-    case Newsstand => newsstandRegistrar.right
-    case _ => UnsupportedPlatform(platform.toString).left
+  override def registrarFor(platform: Platform, buildTier: Option[String]): Either[NotificationsError, NotificationRegistrar] = platform match {
+    case WindowsMobile => Right(windowsRegistrar)
+    case Android => Right(gcmRegistrar)
+    case `iOS` => Right(apnsRegistrar)
+    case Newsstand => Right(newsstandRegistrar)
+    case _ => Left(UnsupportedPlatform(platform.toString))
   }
 
   def withAllRegistrars[T](fn: (NotificationRegistrar => T)): List[T] =

--- a/registration/app/registration/services/RegistrationConverter.scala
+++ b/registration/app/registration/services/RegistrationConverter.scala
@@ -1,10 +1,9 @@
 package registration.services
 
-import cats.data.Xor
 import error.NotificationsError
 import models.Registration
 
 trait RegistrationConverter[T] {
-  def toRegistration(from: T): NotificationsError Xor Registration
+  def toRegistration(from: T): Either[NotificationsError, Registration]
   def fromResponse(legacyRegistration: T, response: RegistrationResponse): T
 }

--- a/registration/test/registration/controllers/MainControllerSpec.scala
+++ b/registration/test/registration/controllers/MainControllerSpec.scala
@@ -45,12 +45,12 @@ class MainControllerSpec extends PlaySpecification with JsonMatchers with Mockit
     "not include in invalid topics in response to legacy registration" in new RegistrationsContext {
       override lazy val fakeTopicValidator = {
         val validator = mock[TopicValidator]
-        validator.removeInvalid(topics) returns Future.successful(topics.right)
-        validator.removeInvalid(legacyTopics) returns Future.successful(legacyTopics.right)
+        validator.removeInvalid(topics) returns Future.successful(Right(topics))
+        validator.removeInvalid(legacyTopics) returns Future.successful(Right(legacyTopics))
         validator
       }
 
-      fakeTopicValidator.removeInvalid(topics) returns Future.successful((topics - footballMatchTopic).right)
+      fakeTopicValidator.removeInvalid(topics) returns Future.successful(Right(topics - footballMatchTopic))
 
       val Some(result) = route(app, FakeRequest(POST, "/legacy/device/register").withJsonBody(Json.parse(legacyIosRegistrationWithFootballMatchTopicJson)))
 
@@ -64,8 +64,8 @@ class MainControllerSpec extends PlaySpecification with JsonMatchers with Mockit
     "return 204 and empty response for unregistration of udid" in new RegistrationsContext {
       override lazy val fakeRegistrarProvider = {
         val provider = mock[RegistrarProvider]
-        provider.registrarFor(any[Platform], any[Option[String]]) returns fakeNotificationRegistrar.right
-        provider.registrarFor(any[Registration]) returns fakeNotificationRegistrar.right
+        provider.registrarFor(any[Platform], any[Option[String]]) returns Right(fakeNotificationRegistrar)
+        provider.registrarFor(any[Registration]) returns Right(fakeNotificationRegistrar)
         provider
       }
 
@@ -84,8 +84,8 @@ class MainControllerSpec extends PlaySpecification with JsonMatchers with Mockit
     "register with topics in registration when validation fails" in new RegistrationsContext {
       override lazy val fakeTopicValidator = {
         val validator = mock[TopicValidator]
-        validator.removeInvalid(topics) returns Future.successful(topics.right)
-        validator.removeInvalid(legacyTopics) returns Future.successful(legacyTopics.right)
+        validator.removeInvalid(topics) returns Future.successful(Right(topics))
+        validator.removeInvalid(legacyTopics) returns Future.successful(Right(legacyTopics))
         validator
       }
 
@@ -94,7 +94,7 @@ class MainControllerSpec extends PlaySpecification with JsonMatchers with Mockit
         override def topicsQueried: Set[Topic] = topics
       }
 
-      fakeTopicValidator.removeInvalid(topics) returns Future.successful(validatorError.left)
+      fakeTopicValidator.removeInvalid(topics) returns Future.successful(Left(validatorError))
 
       val Some(result) = route(app, FakeRequest(PUT, "/registrations/anotherRegId").withJsonBody(Json.parse(registrationJson)))
       status(result) must equalTo(OK)
@@ -105,12 +105,12 @@ class MainControllerSpec extends PlaySpecification with JsonMatchers with Mockit
     "register only with valid topics" in new RegistrationsContext {
       override lazy val fakeTopicValidator = {
         val validator = mock[TopicValidator]
-        validator.removeInvalid(topics) returns Future.successful(topics.right)
-        validator.removeInvalid(legacyTopics) returns Future.successful(legacyTopics.right)
+        validator.removeInvalid(topics) returns Future.successful(Right(topics))
+        validator.removeInvalid(legacyTopics) returns Future.successful(Right(legacyTopics))
         validator
       }
 
-      fakeTopicValidator.removeInvalid(topics) returns Future.successful((topics - footballMatchTopic).right)
+      fakeTopicValidator.removeInvalid(topics) returns Future.successful(Right(topics - footballMatchTopic))
 
       val Some(result) = route(app, FakeRequest(PUT, "/registrations/anotherRegId").withJsonBody(Json.parse(registrationJson)))
       status(result) must equalTo(OK)

--- a/registration/test/registration/services/WindowsNotificationRegistrarSpec.scala
+++ b/registration/test/registration/services/WindowsNotificationRegistrarSpec.scala
@@ -23,35 +23,35 @@ class WindowsNotificationRegistrarSpec(implicit ev: ExecutionEnv) extends Specif
 with Mockito {
   "Windows Notification Provider registration" should {
     "create new registration when no registrations found for channel uri" in new registrations {
-      hubClient.create(fromMobileRegistration(registration)) returns Future.successful(hubRegResponse.right)
+      hubClient.create(fromMobileRegistration(registration)) returns Future.successful(Right(hubRegResponse))
 
       val response = provider.register(channelUri, registration)
 
-      response must beEqualTo(registrationResponse.right).await
+      response must beEqualTo(Right(registrationResponse)).await
       there was one(hubClient).create(any[RawWindowsRegistration])
       there was no(hubClient).update(any[NotificationHubRegistrationId], any[RawWindowsRegistration])
       there was no(hubClient).delete(any[NotificationHubRegistrationId])
     }
 
     "update existing registration when registration with same channel already exist" in new registrations {
-      hubClient.registrationsByChannelUri(channelUri) returns Future.successful(List(hubRegResponse).right)
-      hubClient.update(hubRegResponse.registration, fromMobileRegistration(registration)) returns Future.successful(hubRegResponse.right)
+      hubClient.registrationsByChannelUri(channelUri) returns Future.successful(Right(List(hubRegResponse)))
+      hubClient.update(hubRegResponse.registration, fromMobileRegistration(registration)) returns Future.successful(Right(hubRegResponse))
 
       val response = provider.register(channelUri, registration)
 
-      response must beEqualTo(registrationResponse.right).await
+      response must beEqualTo(Right(registrationResponse)).await
       there was no(hubClient).create(any[RawWindowsRegistration])
       there was one(hubClient).update(any[NotificationHubRegistrationId], any[RawWindowsRegistration])
       there was no(hubClient).delete(any[NotificationHubRegistrationId])
     }
 
     "update existing registration when registration with same userId already exist" in new registrations {
-      hubClient.registrationsByTag(userIdTag) returns Future.successful(Registrations(List(hubRegResponse), None).right)
-      hubClient.update(hubRegResponse.registration, fromMobileRegistration(registration)) returns Future.successful(hubRegResponse.right)
+      hubClient.registrationsByTag(userIdTag) returns Future.successful(Right(Registrations(List(hubRegResponse), None)))
+      hubClient.update(hubRegResponse.registration, fromMobileRegistration(registration)) returns Future.successful(Right(hubRegResponse))
 
       val response = provider.register(channelUri, registration)
 
-      response must beEqualTo(registrationResponse.right).await
+      response must beEqualTo(Right(registrationResponse)).await
       there was no(hubClient).create(any[RawWindowsRegistration])
       there was one(hubClient).update(any[NotificationHubRegistrationId], any[RawWindowsRegistration])
       there was no(hubClient).delete(any[NotificationHubRegistrationId])
@@ -59,13 +59,13 @@ with Mockito {
 
     "update existing registration, including channelUri when the registration already exist" in new registrations {
       val lastKnownChannelUri = "lastKnownChannelUri"
-      hubClient.registrationsByChannelUri(lastKnownChannelUri) returns Future.successful(List(hubRegResponse.copy(channelUri = lastKnownChannelUri)).right)
-      hubClient.registrationsByTag(userIdTag) returns Future.successful(Registrations(Nil, None).right)
-      hubClient.update(hubRegResponse.registration, fromMobileRegistration(registration)) returns Future.successful(hubRegResponse.right)
+      hubClient.registrationsByChannelUri(lastKnownChannelUri) returns Future.successful(Right(List(hubRegResponse.copy(channelUri = lastKnownChannelUri))))
+      hubClient.registrationsByTag(userIdTag) returns Future.successful(Right(Registrations(Nil, None)))
+      hubClient.update(hubRegResponse.registration, fromMobileRegistration(registration)) returns Future.successful(Right(hubRegResponse))
 
       val response = provider.register(lastKnownChannelUri, registration)
 
-      response must beEqualTo(registrationResponse.right).await
+      response must beEqualTo(Right(registrationResponse)).await
       there was no(hubClient).create(any[RawWindowsRegistration])
       there was one(hubClient).update(any[NotificationHubRegistrationId], any[RawWindowsRegistration])
       there was no(hubClient).delete(any[NotificationHubRegistrationId])
@@ -73,25 +73,25 @@ with Mockito {
 
     "delete a registration" in new registrations {
       val userRegistrations = (0 to 2).map(generateHubResponse).toList
-      hubClient.registrationsByTag(userIdTag) returns Future.successful(Registrations(userRegistrations, None).right)
-      hubClient.delete(any[NotificationHubRegistrationId]) returns Future.successful(().right)
+      hubClient.registrationsByTag(userIdTag) returns Future.successful(Right(Registrations(userRegistrations, None)))
+      hubClient.delete(any[NotificationHubRegistrationId]) returns Future.successful(Right(()))
 
       val response = provider.unregister(registration.udid)
 
-      response must beEqualTo(().right).await
+      response must beEqualTo(Right(())).await
       there was no(hubClient).create(any[RawWindowsRegistration])
       there was three(hubClient).delete(any[NotificationHubRegistrationId])
     }
 
     "delete all and replace by only one registration if more than one registration for the same userId" in new registrations {
       val userRegistrations = (0 to 2).map(generateHubResponse).toList
-      hubClient.registrationsByTag(userIdTag) returns Future.successful(Registrations(userRegistrations, None).right)
-      hubClient.delete(any[NotificationHubRegistrationId]) returns Future.successful(().right)
-      hubClient.create(fromMobileRegistration(registration)) returns Future.successful(hubRegResponse.right)
+      hubClient.registrationsByTag(userIdTag) returns Future.successful(Right(Registrations(userRegistrations, None)))
+      hubClient.delete(any[NotificationHubRegistrationId]) returns Future.successful(Right(()))
+      hubClient.create(fromMobileRegistration(registration)) returns Future.successful(Right(hubRegResponse))
 
       val response = provider.register(channelUri, registration)
 
-      response must beEqualTo(registrationResponse.right).await
+      response must beEqualTo(Right(registrationResponse)).await
       there was one(hubClient).create(any[RawWindowsRegistration])
       there was no(hubClient).update(any[NotificationHubRegistrationId], any[RawWindowsRegistration])
       there was three(hubClient).delete(any[NotificationHubRegistrationId])
@@ -99,14 +99,14 @@ with Mockito {
 
     "delete all and replace by only one registration if more than one registration" in new registrations {
       val userRegistrations = (0 to 1).map(generateHubResponse).toList
-      hubClient.registrationsByTag(userIdTag) returns Future.successful(Registrations(userRegistrations, None).right)
-      hubClient.registrationsByChannelUri(registration.deviceId) returns Future.successful(List(generateHubResponse(3)).right)
-      hubClient.delete(any[NotificationHubRegistrationId]) returns Future.successful(().right)
-      hubClient.create(fromMobileRegistration(registration)) returns Future.successful(hubRegResponse.right)
+      hubClient.registrationsByTag(userIdTag) returns Future.successful(Right(Registrations(userRegistrations, None)))
+      hubClient.registrationsByChannelUri(registration.deviceId) returns Future.successful(Right(List(generateHubResponse(3))))
+      hubClient.delete(any[NotificationHubRegistrationId]) returns Future.successful(Right(()))
+      hubClient.create(fromMobileRegistration(registration)) returns Future.successful(Right(hubRegResponse))
 
       val response = provider.register(channelUri, registration)
 
-      response must beEqualTo(registrationResponse.right).await
+      response must beEqualTo(Right(registrationResponse)).await
       there was one(hubClient).create(any[RawWindowsRegistration])
       there was no(hubClient).update(any[NotificationHubRegistrationId], any[RawWindowsRegistration])
       there was exactly(3)(hubClient).delete(any[NotificationHubRegistrationId])
@@ -114,7 +114,7 @@ with Mockito {
 
     "track topic subscriptons" in {
       "record added topic subscriptions from new registration" in new registrations {
-        hubClient.create(any) returns Future.successful(hubRegResponse.right)
+        hubClient.create(any) returns Future.successful(Right(hubRegResponse))
 
         Await.result(provider.register(channelUri, registrationWithTopics), 5.seconds)
 
@@ -123,8 +123,8 @@ with Mockito {
 
       "record updated topic subscriptions from existing registration" in new registrations {
         val hubResponseWithTopics = hubRegResponse.copy(tags = Tag.fromTopic(tagTopic).encodedTag :: hubRegResponse.tags)
-        hubClient.registrationsByTag(userIdTag) returns Future.successful(Registrations(List(hubResponseWithTopics), None).right)
-        hubClient.update(hubResponseWithTopics.registration, fromMobileRegistration(registrationWithTopics)) returns Future.successful(hubResponseWithTopics.right)
+        hubClient.registrationsByTag(userIdTag) returns Future.successful(Right(Registrations(List(hubResponseWithTopics), None)))
+        hubClient.update(hubResponseWithTopics.registration, fromMobileRegistration(registrationWithTopics)) returns Future.successful(Right(hubResponseWithTopics))
 
         Await.result(provider.register(channelUri, registrationWithTopics), 5.seconds)
 
@@ -163,8 +163,8 @@ with Mockito {
     )
     val hubClient = {
       val client = mock[NotificationHubClient]
-      client.registrationsByTag(userIdTag) returns Future.successful(Registrations(Nil, None).right)
-      client.registrationsByChannelUri(registration.deviceId) returns Future.successful(Nil.right)
+      client.registrationsByTag(userIdTag) returns Future.successful(Right(Registrations(Nil, None)))
+      client.registrationsByChannelUri(registration.deviceId) returns Future.successful(Right(Nil))
       client
     }
     val topicSubRepo = mock[TopicSubscriptionsRepository]

--- a/registration/test/registration/services/topic/AuditorTopicValidatorSpec.scala
+++ b/registration/test/registration/services/topic/AuditorTopicValidatorSpec.scala
@@ -1,20 +1,20 @@
 package registration.services.topic
 
-import auditor.{Auditor, AuditorGroup, AuditorGroupConfig, ApiConfig}
+import auditor.{ApiConfig, Auditor, AuditorGroup, AuditorGroupConfig}
 import models.{Topic, TopicTypes}
 import models.TopicTypes.{Content, FootballMatch}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import org.specs2.matcher.XorMatchers
+import org.specs2.matcher.EitherMatchers
 import registration.services.Configuration
 
 import scala.concurrent.Future.successful
 import scala.concurrent.ExecutionContext
 import cats.implicits._
 
-class AuditorTopicValidatorSpec(implicit ee: ExecutionEnv) extends Specification with Mockito with XorMatchers {
+class AuditorTopicValidatorSpec(implicit ee: ExecutionEnv) extends Specification with Mockito with EitherMatchers {
   "Auditor Topic Validator" should {
     "return filtered list of topics from both auditors" in new validators {
       val validTopic = Topic(`type` = FootballMatch, name = "invalidFromAuditorA")
@@ -30,7 +30,7 @@ class AuditorTopicValidatorSpec(implicit ee: ExecutionEnv) extends Specification
 
       val validTopics = topicValidator.removeInvalid(topics)
 
-      validTopics must beEqualTo(Set(validTopic).right).await
+      validTopics must beEqualTo(Right(Set(validTopic))).await
     }
 
     "Limit the number of tags to 200" in new validators {
@@ -43,7 +43,7 @@ class AuditorTopicValidatorSpec(implicit ee: ExecutionEnv) extends Specification
 
       val validTopics = topicValidator.removeInvalid(topics.toSet)
 
-      validTopics must beXorRight(haveSize[Set[Topic]](testMaxTopics)).await
+      validTopics must beRight(haveSize[Set[Topic]](testMaxTopics)).await
     }
 
     "Do not filter breaking news if topic list too long" in new validators {
@@ -56,7 +56,7 @@ class AuditorTopicValidatorSpec(implicit ee: ExecutionEnv) extends Specification
       val breakingNewsTopic = Topic(TopicTypes.Breaking, "uk")
       val validTopics = topicValidator.removeInvalid(topics.toSet + breakingNewsTopic)
 
-      validTopics must beXorRight(contain(breakingNewsTopic)).await
+      validTopics must beRight(contain(breakingNewsTopic)).await
     }
   }
 

--- a/report/app/report/services/NotificationReportEnricher.scala
+++ b/report/app/report/services/NotificationReportEnricher.scala
@@ -8,6 +8,7 @@ import scala.concurrent.ExecutionContext
 import scala.PartialFunction._
 import scala.concurrent.Future
 import scala.util.Try
+import cats.syntax.either._
 
 class NotificationReportEnricher(hubClient: NotificationHubClient)(implicit ec: ExecutionContext) {
 

--- a/report/test/report/controllers/ReportIntegrationSpec.scala
+++ b/report/test/report/controllers/ReportIntegrationSpec.scala
@@ -74,7 +74,7 @@ class ReportIntegrationSpec(implicit ee: ExecutionEnv) extends PlaySpecification
           topic = Set(Topic(Breaking, "uk"))
         ),
         reports = List(
-          SenderReport("Windows", DateTime.now.withZone(UTC), Some(s"hub-$id"), PlatformStatistics(WindowsMobile, 5).some)
+          SenderReport("Windows", DateTime.now.withZone(UTC), Some(s"hub-$id"), Some(PlatformStatistics(WindowsMobile, 5)))
         )
       )
     }

--- a/report/test/report/services/NotificationReportEnricherSpec.scala
+++ b/report/test/report/services/NotificationReportEnricherSpec.scala
@@ -69,7 +69,7 @@ class NotificationReportEnricherSpec(implicit ev: ExecutionEnv) extends Specific
     }
 
     senderReportsWithDetails.foreach { case (sendersId, _, details) =>
-      hubClient.notificationDetails(sendersId) returns Future.successful(details.right)
+      hubClient.notificationDetails(sendersId) returns Future.successful(Right(details))
     }
 
     val report = NotificationReport(


### PR DESCRIPTION
Before migrating to the parameter store I upgraded our libs on mobile-notifications.
This is PR 1 out of 3

This on focuses only on migrating to the latest Cats version. That means using scala's 2.11 biased `Either` instead of the now deprecated `Xor`