### PR TITLE
Fix logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 *.class
 *.log
+logs
 
 # sbt specific
 .cache

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val common = project
       "com.typesafe.play" %% "play-json-joda" % "2.6.8",
       "com.typesafe.play" %% "play-logback" % "2.6.11",
       "com.gu" %% "pa-client" % "6.1.0",
-      "com.gu" %% "simple-configuration-ssm" % "1.4.1",
+      "com.gu" %% "simple-configuration-ssm" % "1.4.3",
       "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.285",
       "com.googlecode.concurrentlinkedhashmap" % "concurrentlinkedhashmap-lru" % "1.4.2"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,8 @@ lazy val common = project
     ),
     libraryDependencies ++= Seq(
       ws,
-      "com.microsoft.azure" % "azure-servicebus" % "1.1.1",
+      // be careful upgrading the following, recent azure-servicebus version rely on an alpha of slf4j, breaking play logging...
+      "com.microsoft.azure" % "azure-servicebus" % "0.9.8",
       "org.typelevel" %% "cats-core" % "1.0.1",
       "joda-time" % "joda-time" % "2.9.9",
       "com.typesafe.play" %% "play-json" % "2.6.8",

--- a/notification/conf/logback.xml
+++ b/notification/conf/logback.xml
@@ -1,17 +1,17 @@
 <configuration>
-    
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-     <file>${application.home}/logs/application.log</file>
-     <encoder>
-       <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
-     </encoder>
-  </appender>
+  <contextName>notification</contextName>
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>logs/application.log</file>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>logs/application.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
     </encoder>
   </appender>
 
@@ -19,23 +19,8 @@
     <appender-ref ref="FILE" />
   </appender>
 
-  <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-    <appender-ref ref="STDOUT" />
-  </appender>
-
-  <logger name="play" level="INFO" />
-  <logger name="application" level="DEBUG" />
-  <logger name="notification" level="DEBUG" />
-
-  <!-- Off these ones as they are annoying, and anyway we manage configuration ourself -->
-  <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />
-  <logger name="com.avaje.ebeaninternal.server.core.XmlConfigLoader" level="OFF" />
-  <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
-  <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
-
-  <root level="WARN">
-    <appender-ref ref="ASYNCFILE" />
-    <appender-ref ref="ASYNCSTDOUT" />
+  <root level="INFO">
+    <appender-ref ref="ASYNCFILE"/>
   </root>
-  
+
 </configuration>

--- a/registration/conf/logback.xml
+++ b/registration/conf/logback.xml
@@ -1,17 +1,17 @@
 <configuration>
-    
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-     <file>${application.home}/logs/application.log</file>
-     <encoder>
-       <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
-     </encoder>
-  </appender>
+  <contextName>registration</contextName>
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>logs/application.log</file>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>logs/application.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+
     <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+      <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
     </encoder>
   </appender>
 
@@ -19,24 +19,8 @@
     <appender-ref ref="FILE" />
   </appender>
 
-  <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-    <appender-ref ref="STDOUT" />
-  </appender>
-
-  <logger name="play" level="INFO" />
-  <logger name="application" level="DEBUG" />
-  <logger name="registration" level="DEBUG" />
-  <logger name="tracking" level="DEBUG" />
-
-  <!-- Off these ones as they are annoying, and anyway we manage configuration ourself -->
-  <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />
-  <logger name="com.avaje.ebeaninternal.server.core.XmlConfigLoader" level="OFF" />
-  <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
-  <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
-
-  <root level="WARN">
-    <appender-ref ref="ASYNCFILE" />
-    <appender-ref ref="ASYNCSTDOUT" />
+  <root level="INFO">
+    <appender-ref ref="ASYNCFILE"/>
   </root>
-  
+
 </configuration>

--- a/report/conf/logback.xml
+++ b/report/conf/logback.xml
@@ -1,41 +1,26 @@
 <configuration>
-    
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-     <file>${application.home}/logs/application.log</file>
-     <encoder>
-       <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
-     </encoder>
-  </appender>
+    <contextName>report</contextName>
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
-    </encoder>
-  </appender>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/application.log</file>
 
-  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
-    <appender-ref ref="FILE" />
-  </appender>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/application.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
 
-  <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-    <appender-ref ref="STDOUT" />
-  </appender>
+        <encoder>
+            <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+        </encoder>
+    </appender>
 
-  <logger name="play" level="INFO" />
-  <logger name="application" level="DEBUG" />
-  <logger name="report" level="DEBUG" />
+    <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FILE" />
+    </appender>
 
-  <!-- Off these ones as they are annoying, and anyway we manage configuration ourself -->
-  <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />
-  <logger name="com.avaje.ebeaninternal.server.core.XmlConfigLoader" level="OFF" />
-  <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
-  <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
+    <root level="INFO">
+        <appender-ref ref="ASYNCFILE"/>
+    </root>
 
-  <root level="WARN">
-    <appender-ref ref="ASYNCFILE" />
-    <appender-ref ref="ASYNCSTDOUT" />
-  </root>
-  
 </configuration>


### PR DESCRIPTION
Following the scala 2.12 bump, we've lost logs.

When I updated azure-servicebus I didn't realise they would use an alpha (!!) version of slf4j. That transient dependency breaks the logging compatibility with Play.
Since this is pure madness, I reverted to an older version of that library. We used to be on 0.7 before the scala 2.12 update.

I've also cleaned our loggers, and bumped our configuration library.
