### PR TITLE
Use custom credential provider to allow running the app locally

### DIFF
--- a/common/src/main/scala/aws/AsyncDynamo.scala
+++ b/common/src/main/scala/aws/AsyncDynamo.scala
@@ -1,6 +1,6 @@
 package aws
 
-import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.regions.Regions.EU_WEST_1
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder}
@@ -25,7 +25,7 @@ object AsyncDynamo {
     .withComparisonOperator(ComparisonOperator.BETWEEN)
     .withAttributeValueList(new AttributeValue(a), new AttributeValue(b))
 
-  def apply(regions: Regions, credentialsProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain): AsyncDynamo = {
+  def apply(regions: Regions, credentialsProvider: AWSCredentialsProvider): AsyncDynamo = {
     val dynamoClient: AmazonDynamoDBAsync = AmazonDynamoDBAsyncClientBuilder.standard()
       .withCredentials(credentialsProvider)
       .withRegion(regions.getName)

--- a/common/src/main/scala/utils/MobileAwsCredentialsProvider.scala
+++ b/common/src/main/scala/utils/MobileAwsCredentialsProvider.scala
@@ -1,0 +1,9 @@
+package utils
+
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.{AWSCredentialsProviderChain, EC2ContainerCredentialsProviderWrapper}
+
+class MobileAwsCredentialsProvider extends AWSCredentialsProviderChain(
+  new ProfileCredentialsProvider("mobile"),
+  new EC2ContainerCredentialsProviderWrapper()
+)

--- a/registration/app/registration/RegistrationApplicationLoader.scala
+++ b/registration/app/registration/RegistrationApplicationLoader.scala
@@ -22,8 +22,7 @@ import registration.services.topic.{AuditorTopicValidator, TopicValidator}
 import registration.services.azure.{APNSNotificationRegistrar, GCMNotificationRegistrar, NewsstandNotificationRegistrar}
 import registration.services._
 import tracking.{BatchingTopicSubscriptionsRepository, DynamoTopicSubscriptionsRepository, SubscriptionTracker, TopicSubscriptionsRepository}
-import utils.CustomApplicationLoader
-
+import utils.{CustomApplicationLoader, MobileAwsCredentialsProvider}
 import router.Routes
 import _root_.models.NewsstandShardConfig
 
@@ -42,9 +41,11 @@ class RegistrationApplicationComponents(context: Context) extends BuiltInCompone
 
   lazy val appConfig = new Configuration(configuration)
 
+  val credentialsProvider = new MobileAwsCredentialsProvider()
+
   lazy val mainController = wire[Main]
   lazy val topicSubscriptionsRepository: TopicSubscriptionsRepository = {
-    val underlying = new DynamoTopicSubscriptionsRepository(AsyncDynamo(EU_WEST_1), appConfig.dynamoTopicsTableName)
+    val underlying = new DynamoTopicSubscriptionsRepository(AsyncDynamo(EU_WEST_1, credentialsProvider), appConfig.dynamoTopicsTableName)
     val batching = new BatchingTopicSubscriptionsRepository(underlying)
     batching.scheduleFlush(appConfig.dynamoTopicsFlushInterval)
     batching

--- a/report/app/report/ReportApplicationLoader.scala
+++ b/report/app/report/ReportApplicationLoader.scala
@@ -17,8 +17,7 @@ import report.authentication.ReportAuthAction
 import report.controllers.Report
 import report.services.{Configuration, NotificationReportEnricher}
 import tracking.{DynamoNotificationReportRepository, SentNotificationReportRepository}
-import utils.CustomApplicationLoader
-
+import utils.{CustomApplicationLoader, MobileAwsCredentialsProvider}
 import router.Routes
 
 class ReportApplicationLoader extends CustomApplicationLoader {
@@ -39,8 +38,10 @@ class ReportApplicationComponents(context: Context) extends BuiltInComponentsFro
 
   lazy val reportController = wire[Report]
 
+  val credentialsProvider = new MobileAwsCredentialsProvider()
+
   lazy val notificationReportRepository: SentNotificationReportRepository =
-    new DynamoNotificationReportRepository(AsyncDynamo(regions = EU_WEST_1), appConfig.dynamoReportsTableName)
+    new DynamoNotificationReportRepository(AsyncDynamo(regions = EU_WEST_1, credentialsProvider), appConfig.dynamoReportsTableName)
 
   lazy val defaultHubClient = new NotificationHubClient(appConfig.defaultHub, wsClient)
 


### PR DESCRIPTION
It seems we were still relying on exporting local variables for AWS credentials (deprecated)

This should solve it by getting credentials from the local profile and still work on our EC2 instances