### PR TITLE
Fix serialisation issue for FootballMatchStatus

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,8 @@ lazy val common = project
       "com.gu" %% "pa-client" % "6.1.0",
       "com.gu" %% "simple-configuration-ssm" % "1.4.3",
       "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.285",
-      "com.googlecode.concurrentlinkedhashmap" % "concurrentlinkedhashmap-lru" % "1.4.2"
+      "com.googlecode.concurrentlinkedhashmap" % "concurrentlinkedhashmap-lru" % "1.4.2",
+      "ai.x" %% "play-json-extensions" % "0.10.0"
     ),
     fork := true,
     startDynamoDBLocal := startDynamoDBLocal.dependsOn(compile in Test).value,

--- a/common/src/main/scala/models/Notification.scala
+++ b/common/src/main/scala/models/Notification.scala
@@ -1,9 +1,12 @@
 package models
 
 import java.util.UUID
+
 import models.NotificationType._
 import play.api.libs.json._
 import java.net.URI
+
+import ai.x.play.json.Jsonx
 import models.elections.ElectionResults
 
 sealed trait Notification {
@@ -130,7 +133,7 @@ case class FootballMatchStatusNotification(
   articleUri: Option[URI],
   importance: Importance,
   topic: Set[Topic],
-  phase: String,
+  matchStatus: String,
   eventId: String,
   debug: Boolean
 ) extends Notification {
@@ -140,90 +143,7 @@ case class FootballMatchStatusNotification(
 object FootballMatchStatusNotification {
   import JsonUtils._
 
-  implicit val jf = new Format[FootballMatchStatusNotification] {
-    override def reads(json: JsValue): JsResult[FootballMatchStatusNotification] = {
-      for {
-        id <- (json \ "id").validate[UUID]
-        typ <- (json \ "type").validate[NotificationType]
-        title <- (json \ "title").validate[String]
-        message <- (json \ "message").validate[String]
-        thumbnailUrl <- (json \ "thumbnailUrl").validateOpt[URI]
-        sender <- (json \ "sender").validate[String]
-        awayTeamName <- (json \ "awayTeamName").validate[String]
-        awayTeamScore <- (json \ "awayTeamScore").validate[Int]
-        awayTeamMessage <- (json \ "awayTeamMessage").validate[String]
-        awayTeamId <- (json \ "awayTeamId").validate[String]
-        homeTeamName <- (json \ "homeTeamName").validate[String]
-        homeTeamScore <- (json \ "homeTeamScore").validate[Int]
-        homeTeamMessage <- (json \ "homeTeamMessage").validate[String]
-        homeTeamId <- (json \ "homeTeamId").validate[String]
-        competitionName <- (json \ "competitionName").validateOpt[String]
-        venue <- (json \ "venue").validateOpt[String]
-        matchId <- (json \ "matchId").validate[String]
-        matchInfoUri <- (json \ "matchInfoUri").validate[URI]
-        articleUri <- (json \ "articleUri").validateOpt[URI]
-        importance <- (json \ "importance").validate[Importance]
-        topic <- (json \ "topic").validate[Set[Topic]]
-        matchStatus <- (json \ "matchStatus").validate[String]
-        eventId <- (json \ "eventId").validate[String]
-        debug <- (json \ "debug").validate[Boolean]
-      } yield FootballMatchStatusNotification(
-        id,
-        typ,
-        title,
-        message,
-        thumbnailUrl,
-        sender,
-        awayTeamName,
-        awayTeamScore,
-        awayTeamMessage,
-        awayTeamId,
-        homeTeamName,
-        homeTeamScore,
-        homeTeamMessage,
-        homeTeamId,
-        competitionName,
-        venue,
-        matchId,
-        matchInfoUri,
-        articleUri,
-        importance,
-        topic,
-        matchStatus,
-        eventId,
-        debug
-      )
-    }
-
-    override def writes(o: FootballMatchStatusNotification): JsValue = JsObject(
-      Seq(
-        "id" -> Json.toJson(o.id),
-        "type" -> Json.toJson(o.`type`),
-        "title" -> Json.toJson(o.title),
-        "message" -> Json.toJson(o.message),
-        "thumbnailUrl" -> Json.toJson(o.thumbnailUrl),
-        "sender" -> Json.toJson(o.sender),
-        "awayTeamName" -> Json.toJson(o.awayTeamName),
-        "awayTeamScore" -> Json.toJson(o.awayTeamScore),
-        "awayTeamMessage" -> Json.toJson(o.awayTeamMessage),
-        "awayTeamId" -> Json.toJson(o.awayTeamId),
-        "homeTeamName" -> Json.toJson(o.homeTeamName),
-        "homeTeamScore" -> Json.toJson(o.homeTeamScore),
-        "homeTeamMessage" -> Json.toJson(o.homeTeamMessage),
-        "homeTeamId" -> Json.toJson(o.homeTeamId),
-        "competitionName" -> Json.toJson(o.competitionName),
-        "venue" -> Json.toJson(o.venue),
-        "matchId" -> Json.toJson(o.matchId),
-        "matchInfoUri" -> Json.toJson(o.matchInfoUri),
-        "articleUri" -> Json.toJson(o.articleUri),
-        "importance" -> Json.toJson(o.importance),
-        "topic" -> Json.toJson(o.topic),
-        "phase" -> Json.toJson(o.phase),
-        "eventId" -> Json.toJson(o.eventId),
-        "debug" -> Json.toJson(o.debug)
-      )
-    )
-  }
+  implicit val jf: Format[FootballMatchStatusNotification] = Jsonx.formatCaseClass[FootballMatchStatusNotification]
 }
 
 case class GoalAlertNotification(

--- a/notification/app/notification/services/azure/APNSPushConverter.scala
+++ b/notification/app/notification/services/azure/APNSPushConverter.scala
@@ -109,7 +109,7 @@ class APNSPushConverter(conf: Configuration) extends PushConverter {
         awayTeamScore = matchStatus.awayTeamScore,
         awayTeamText = matchStatus.awayTeamMessage,
         currentMinute = "",
-        matchStatus = matchStatus.phase,
+        matchStatus = matchStatus.matchStatus,
         matchId = matchStatus.matchId,
         mapiUrl = matchStatus.matchInfoUri.toString,
         matchInfoUri = matchStatus.matchInfoUri.toString,

--- a/notification/app/notification/services/azure/GCMPushConverter.scala
+++ b/notification/app/notification/services/azure/GCMPushConverter.scala
@@ -161,7 +161,7 @@ class GCMPushConverter(conf: Configuration) extends PushConverter {
       "awayTeamText" -> Some(matchStatusAlert.awayTeamMessage),
       "currentMinute" -> Some(""),
       "important" -> Some(matchStatusAlert.importance.toString),
-      "matchStatus" -> Some(matchStatusAlert.phase),
+      "matchStatus" -> Some(matchStatusAlert.matchStatus),
       "matchId" -> Some(matchStatusAlert.matchId),
       "matchInfoUri" -> Some(matchStatusAlert.matchInfoUri.toString),
       "articleUri" -> matchStatusAlert.articleUri.map(_.toString),

--- a/notification/test/notification/models/azure/AndroidNotificationSpec.scala
+++ b/notification/test/notification/models/azure/AndroidNotificationSpec.scala
@@ -283,7 +283,7 @@ class AndroidNotificationSpec extends Specification with Mockito {
       articleUri = Some(new URI("https://mobile.guardianapis.com/items/some-liveblog")),
       importance = Major,
       topic = Set.empty,
-      phase = "P",
+      matchStatus = "P",
       eventId = "1000",
       debug = false
     )

--- a/notification/test/notification/models/azure/iOSNotificationSpec.scala
+++ b/notification/test/notification/models/azure/iOSNotificationSpec.scala
@@ -372,7 +372,7 @@ class iOSNotificationSpec extends Specification with Mockito {
       articleUri = Some(new URI("https://mobile.guardianapis.com/items/some-liveblog")),
       importance = Major,
       topic = Set.empty,
-      phase = "P",
+      matchStatus = "P",
       eventId = "1000",
       debug = false
     )


### PR DESCRIPTION
We store `phase` but try to retrieve `matchStatus`, leading to a deserialisation error.

It's deserialised from the notification payload a client sends to our service (`matchStatus`), then serialised in the database with `phase`, so I kept `matchStatus` in order to keep the same interface for our clients.

As far as I can tell, `phase` was only used when storing the notification in the database. That makes our past football notification unreadable, but we already can't read them. I think it's fine as we mostly store them for audit purposes.
