### PR TITLE
Convert iOS payload to firebase Payload

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ lazy val common = project
       ws,
       // be careful upgrading the following, recent azure-servicebus version rely on an alpha of slf4j, breaking play logging...
       "com.microsoft.azure" % "azure-servicebus" % "0.9.8",
+      "com.google.firebase" % "firebase-admin" % "6.1.0",
       "org.typelevel" %% "cats-core" % "1.0.1",
       "joda-time" % "joda-time" % "2.9.9",
       "com.typesafe.play" %% "play-json" % "2.6.8",

--- a/notification/app/notification/services/fcm/ApnsConfigConverter.scala
+++ b/notification/app/notification/services/fcm/ApnsConfigConverter.scala
@@ -1,0 +1,174 @@
+package notification.services.fcm
+
+import java.net.URI
+
+import azure._
+import azure.apns.FootballMatchStatusProperties
+import com.google.firebase.messaging.{ApnsConfig, Aps, ApsAlert}
+import models.NotificationType.{BreakingNews, Content, FootballMatchStatus}
+import models._
+import notification.models.Destination._
+import notification.models.ios.{Keys, MessageTypes}
+import notification.models.Push
+import notification.services.Configuration
+import notification.services.azure.PlatformUriType
+import notification.services.azure.PlatformUriTypes.{External, Item}
+import play.api.Logger
+
+import collection.JavaConverters._
+
+class ApnsConfigConverter(conf: Configuration) {
+
+  val logger = Logger(classOf[ApnsConfigConverter])
+
+  def toIosConfig(push: Push): Option[ApnsConfig] = {
+    toFirebaseApnsNotification(push).map(_.toApnsConfig)
+  }
+
+  def toFirebaseApnsNotification(push: Push): Option[FirebaseApnsNotification] = {
+    logger.debug(s"Converting push to Azure: $push")
+
+    PartialFunction.condOpt(push.notification) {
+      case contentNotification: ContentNotification => toContent(contentNotification)
+      case breakingNews: BreakingNewsNotification => toBreakingNews(breakingNews)
+      case football: FootballMatchStatusNotification => toMatchStatusAlert(football)
+    }
+  }
+
+  case class FirebaseApsAlert(title: String, body: String)
+
+  case class FirebaseApnsNotification(
+    category: Option[String],
+    alert: Option[Either[String, FirebaseApsAlert]],
+    contentAvailable: Option[Boolean],
+    mutableContent: Option[Boolean],
+    sound: Option[String],
+    customData: List[(String, Option[AnyRef])]
+  ) {
+    def toApnsConfig: ApnsConfig = {
+      val apnsConfigBuilder = ApnsConfig.builder()
+
+      val apsBuilder = Aps.builder()
+      category.foreach(apsBuilder.setCategory)
+      alert match {
+        case Some(Left(alertString)) => apsBuilder.setAlert(alertString)
+        case Some(Right(alertObject)) => apsBuilder.setAlert(
+          ApsAlert.builder()
+            .setBody(alertObject.body)
+            .setTitle(alertObject.title)
+            .build())
+        case _ => ()
+      }
+      contentAvailable.foreach(apsBuilder.setContentAvailable)
+      mutableContent.foreach(apsBuilder.setMutableContent)
+      sound.foreach(apsBuilder.setSound)
+      val aps = apsBuilder.build()
+
+      val allCustomData = customData
+        .collect { case (key, Some(value)) => key -> value }
+        .toMap.asJava
+
+      apnsConfigBuilder.setAps(aps)
+      apnsConfigBuilder.putAllCustomData(allCustomData)
+      apnsConfigBuilder.build()
+    }
+  }
+
+  private def toContent(cn: ContentNotification): FirebaseApnsNotification = {
+    val link = toPlatformLink(cn.link)
+
+    FirebaseApnsNotification(
+      category = Some("ITEM_CATEGORY"),
+      alert = if (cn.iosUseMessage.contains(true)) Some(Left(cn.message)) else Some(Left(cn.title)),
+      contentAvailable = Some(true),
+      mutableContent = None,
+      sound = Some("default"),
+      customData = List(
+        Keys.NotificationType -> Some(Content.value),
+        Keys.Link -> Some(toIosLink(cn.link).toString),
+        Keys.Topics -> Some(cn.topic.map(_.toString).mkString(",")),
+        Keys.Uri -> Some(new URI(link.uri).toString),
+        Keys.UriType -> Some(link.`type`.toString)
+      )
+    )
+  }
+
+  private def toBreakingNews(breakingNews: BreakingNewsNotification): FirebaseApnsNotification = {
+    val link = toPlatformLink(breakingNews.link)
+
+    val category = breakingNews.link match {
+      case _: Link.External => Some("")
+      case _: Link.Internal => Some("ITEM_CATEGORY")
+    }
+    val imageUrl = breakingNews.thumbnailUrl orElse breakingNews.imageUrl
+
+    FirebaseApnsNotification(
+      category = category,
+      alert = Some(Left(breakingNews.message)),
+      contentAvailable = Some(true),
+      mutableContent = if (imageUrl.isDefined) Some(true) else None,
+      sound = Some("default"),
+      customData = List(
+        Keys.NotificationType -> Some(BreakingNews.value),
+        Keys.Link -> Some(toIosLink(breakingNews.link).toString),
+        Keys.Topics -> Some(breakingNews.topic.map(_.toString).mkString(",")),
+        Keys.Uri -> Some(new URI(link.uri).toString),
+        Keys.UriType -> Some(link.`type`.toString),
+        Keys.ImageUrl -> imageUrl.map(_.toString)
+      )
+    )
+  }
+
+  private def toMatchStatusAlert(matchStatus: FootballMatchStatusNotification): FirebaseApnsNotification = {
+    FirebaseApnsNotification(
+      category = Some("football-match"),
+      alert = Some(Right(FirebaseApsAlert(matchStatus.title, matchStatus.message))),
+      contentAvailable = Some(true),
+      mutableContent = Some(true),
+      sound = if (matchStatus.importance == Importance.Major) Some("default") else None,
+      customData = List(
+        Keys.NotificationType -> Some(FootballMatchStatus.value),
+        "matchStatus" -> Some(FootballMatchStatusProperties(
+          homeTeamName = matchStatus.homeTeamName,
+          homeTeamId = matchStatus.homeTeamId,
+          homeTeamScore = matchStatus.homeTeamScore,
+          homeTeamText = matchStatus.homeTeamMessage,
+          awayTeamName = matchStatus.awayTeamName,
+          awayTeamId = matchStatus.awayTeamId,
+          awayTeamScore = matchStatus.awayTeamScore,
+          awayTeamText = matchStatus.awayTeamMessage,
+          currentMinute = "",
+          matchStatus = matchStatus.matchStatus,
+          matchId = matchStatus.matchId,
+          mapiUrl = matchStatus.matchInfoUri.toString,
+          matchInfoUri = matchStatus.matchInfoUri.toString,
+          articleUri = matchStatus.articleUri.map(_.toString),
+          uri = "",
+          competitionName = matchStatus.competitionName,
+          venue = matchStatus.venue
+        ))
+      )
+    )
+  }
+
+  case class PlatformUri(uri: String, `type`: PlatformUriType)
+
+  private def toPlatformLink(link: Link) = link match {
+    case Link.Internal(contentApiId, _, _) => PlatformUri(s"https://www.theguardian.com/$contentApiId", Item)
+    case Link.External(url) => PlatformUri(url, External)
+  }
+
+  private def toTags(destination: Destination) = destination match {
+    case Left(topics: Set[Topic]) => Some(Tags.fromTopics(topics))
+    case Right(user: UniqueDeviceIdentifier) => Some(Tags.fromUserId(user))
+  }
+
+  private def toIosLink(link: Link) = link match {
+    case Link.Internal(contentApiId, Some(shortUrl), _) => new URI(s"x-gu://${new URI(shortUrl).getPath}")
+    case _ => link.webUri(conf.frontendBaseUrl)
+  }
+
+  private def replaceHost(uri: URI) =
+    new URI(List(Some("x-gu://"), Option(uri.getPath), Option(uri.getQuery).map("?" + _)).flatten.mkString)
+
+}

--- a/notification/test/notification/services/fcm/ApnsConfigConverterSpec.scala
+++ b/notification/test/notification/services/fcm/ApnsConfigConverterSpec.scala
@@ -1,0 +1,174 @@
+package notification.services.fcm
+
+import java.net.URI
+import java.util.UUID
+
+import azure.apns.FootballMatchStatusProperties
+import models.Importance.Major
+import models.Link.Internal
+import models.TopicTypes.{Breaking, TagSeries}
+import models._
+import notification.models.Push
+import notification.models.ios.Keys
+import notification.services.Configuration
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import play.api.{Configuration => PlayConfig}
+
+class ApnsConfigConverterSpec extends Specification {
+  "ApnsConfigConverter" should {
+    "convert a breaking news to the firebase format" in new ApnsConfigConverterScope {
+      val push = Push(
+        notification = BreakingNewsNotification(
+          id = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
+          title = "Test notification",
+          message = "The message",
+          thumbnailUrl = Some(new URI("https://invalid.url/img.png")),
+          sender = "UnitTests",
+          link = Internal("some/capi/id", None, GITContent),
+          imageUrl = Some(new URI("https://invalid.url/img.png")),
+          importance = Major,
+          topic = Set(Topic(`type` = Breaking, name = "uk"))
+        ),
+        destination = Left(Set())
+      )
+
+      val apnsNotification = convert(push)
+
+
+      val expected = apnsConfigConverter.FirebaseApnsNotification(
+        category = Some("ITEM_CATEGORY"),
+        alert = Some(Left("The message")),
+        contentAvailable = Some(true),
+        sound = Some("default"),
+        mutableContent = Some(true),
+        customData = List(
+          Keys.NotificationType -> Some("news"),
+          Keys.Link -> Some("https://www.theguardian.com/some/capi/id"),
+          Keys.Topics -> Some("breaking/uk"),
+          Keys.Uri -> Some("https://www.theguardian.com/some/capi/id"),
+          Keys.UriType -> Some("item"),
+          Keys.ImageUrl -> Some("https://invalid.url/img.png")
+        )
+      )
+
+      apnsNotification shouldEqual expected
+    }
+
+    "convert a content notification to the firebase format" in new ApnsConfigConverterScope {
+      val push = Push(
+        notification = ContentNotification(
+          id = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
+          title = "Test notification",
+          message = "The message",
+          thumbnailUrl = Some(new URI("https://invalid.url/img.png")),
+          sender = "UnitTests",
+          link = Internal("some/capi/id", None, GITContent),
+          importance = Major,
+          topic = Set(Topic(`type` = TagSeries, name = "some/tag")),
+          iosUseMessage = Some(true)
+        ),
+        destination = Left(Set())
+      )
+
+      val apnsNotification = convert(push)
+
+
+      val expected = apnsConfigConverter.FirebaseApnsNotification(
+        category = Some("ITEM_CATEGORY"),
+        alert = Some(Left("The message")),
+        contentAvailable = Some(true),
+        sound = Some("default"),
+        mutableContent = None,
+        customData = List(
+          Keys.NotificationType -> Some("content"),
+          Keys.Link -> Some("https://www.theguardian.com/some/capi/id"),
+          Keys.Topics -> Some("tag-series/some/tag"),
+          Keys.Uri -> Some("https://www.theguardian.com/some/capi/id"),
+          Keys.UriType -> Some("item")
+        )
+      )
+
+      apnsNotification shouldEqual expected
+    }
+
+    "convert a football notification to the firebase format" in new ApnsConfigConverterScope {
+      val push = Push(
+        notification = FootballMatchStatusNotification(
+          id = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
+          title = "Test notification",
+          message = "The message",
+          thumbnailUrl = Some(new URI("https://invalid.url/img.png")),
+          sender = "UnitTests",
+          importance = Major,
+          topic = Set(Topic(`type` = Breaking, name = "uk")),
+          awayTeamName = "Team1",
+          awayTeamScore = 0,
+          awayTeamMessage = "team1 message",
+          awayTeamId = "123",
+          homeTeamName = "Team2",
+          homeTeamScore = 1,
+          homeTeamMessage = "team2 message",
+          homeTeamId = "456",
+          competitionName = Some("World cup 3012"),
+          venue = Some("Venue"),
+          matchId = "123456",
+          matchInfoUri = new URI("https://some.invalid.url/detail"),
+          articleUri = Some(new URI("https://some.other.invalid.url/detail")),
+          matchStatus = "1",
+          eventId = "2",
+          debug = true
+        ),
+        destination = Left(Set())
+      )
+
+      val apnsNotification = convert(push)
+
+      val expected = apnsConfigConverter.FirebaseApnsNotification(
+        category = Some("football-match"),
+        alert = Some(Right(apnsConfigConverter.FirebaseApsAlert("Test notification", "The message"))),
+        contentAvailable = Some(true),
+        sound = Some("default"),
+        mutableContent = Some(true),
+        customData = List(
+          Keys.NotificationType -> Some("football-match-status"),
+          "matchStatus" -> Some(FootballMatchStatusProperties(
+            homeTeamName = "Team2",
+            homeTeamId = "456",
+            homeTeamScore = 1,
+            homeTeamText = "team2 message",
+            awayTeamName = "Team1",
+            awayTeamId = "123",
+            awayTeamScore = 0,
+            awayTeamText = "team1 message",
+            currentMinute = "",
+            matchStatus = "1",
+            matchId = "123456",
+            mapiUrl = "https://some.invalid.url/detail",
+            matchInfoUri = "https://some.invalid.url/detail",
+            articleUri = Some("https://some.other.invalid.url/detail"),
+            uri = "",
+            competitionName = Some("World cup 3012"),
+            venue = Some("Venue")
+          ))
+        )
+      )
+
+      apnsNotification shouldEqual expected
+    }
+  }
+
+
+  trait ApnsConfigConverterScope extends Scope {
+    val configuration = new Configuration(PlayConfig.empty) {
+      override lazy val debug: Boolean = true
+      override lazy val frontendBaseUrl: String = "https://www.theguardian.com/"
+    }
+    val apnsConfigConverter = new ApnsConfigConverter(configuration)
+
+    def convert(push: Push) = {
+      val Some(firebaseAndroidNotification) = apnsConfigConverter.toFirebaseApnsNotification(push)
+      firebaseAndroidNotification
+    }
+  }
+}


### PR DESCRIPTION
This is branch 1/3

This PR only focuses on converting notifications to the ios firebase payload. It doesn't actually send the notification yet.