### PR TITLE
Upgrade to simple-configuration 1.5.0 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val common = project
       "com.typesafe.play" %% "play-json-joda" % "2.6.8",
       "com.typesafe.play" %% "play-logback" % "2.6.11",
       "com.gu" %% "pa-client" % "6.1.0",
-      "com.gu" %% "simple-configuration-ssm" % "1.4.3",
+      "com.gu" %% "simple-configuration-ssm" % "1.5.0",
       "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.285",
       "com.googlecode.concurrentlinkedhashmap" % "concurrentlinkedhashmap-lru" % "1.4.2",
       "ai.x" %% "play-json-extensions" % "0.10.0"


### PR DESCRIPTION
Swaps from inconsistent EC2 tags to hopefully consistent ASGs tags for config.