### PR TITLE
Send notifications to firebase

### DIFF
--- a/common/src/main/scala/models/Notification.scala
+++ b/common/src/main/scala/models/Notification.scala
@@ -16,8 +16,8 @@ sealed trait Notification {
   def title: String
   def message: String
   def importance: Importance
-  def topic: Set[Topic]
-  def withTopics(topics: Set[Topic]): Notification
+  def topic: List[Topic]
+  def withTopics(topics: List[Topic]): Notification
 }
 
 object Notification {
@@ -61,9 +61,9 @@ case class BreakingNewsNotification(
   link: Link,
   imageUrl: Option[URI],
   importance: Importance,
-  topic: Set[Topic]
+  topic: List[Topic]
 ) extends Notification with NotificationWithLink {
-  override def withTopics(topics: Set[Topic]): Notification = copy(topic = topics)
+  override def withTopics(topics: List[Topic]): Notification = copy(topic = topics)
 }
 
 object BreakingNewsNotification {
@@ -80,8 +80,8 @@ case class NewsstandShardNotification(
   override def message: String = ""
   override def sender: String = "newsstand-shard"
   override def importance: Importance = Importance.Minor
-  override def withTopics(topics: Set[Topic]): Notification = this
-  override def topic: Set[Topic] = Set(Topic(TopicTypes.NewsstandShard, s"newsstand-shard-$shard"))
+  override def withTopics(topics: List[Topic]): Notification = this
+  override def topic: List[Topic] = List(Topic(TopicTypes.NewsstandShard, s"newsstand-shard-$shard"))
 
 }
 object NewsstandShardNotification {
@@ -100,9 +100,9 @@ case class ContentNotification(
   sender: String,
   link: Link,
   importance: Importance,
-  topic: Set[Topic]
+  topic: List[Topic]
 ) extends Notification with NotificationWithLink {
-  override def withTopics(topics: Set[Topic]): Notification = copy(topic = topics)
+  override def withTopics(topics: List[Topic]): Notification = copy(topic = topics)
 }
 
 object ContentNotification {
@@ -132,12 +132,12 @@ case class FootballMatchStatusNotification(
   matchInfoUri: URI,
   articleUri: Option[URI],
   importance: Importance,
-  topic: Set[Topic],
+  topic: List[Topic],
   matchStatus: String,
   eventId: String,
   debug: Boolean
 ) extends Notification {
-  override def withTopics(topics: Set[Topic]): Notification = copy(topic = topics)
+  override def withTopics(topics: List[Topic]): Notification = copy(topic = topics)
 }
 
 object FootballMatchStatusNotification {
@@ -165,10 +165,10 @@ case class GoalAlertNotification(
   matchId: String,
   mapiUrl: URI,
   importance: Importance,
-  topic: Set[Topic],
+  topic: List[Topic],
   addedTime: Option[String]
 ) extends Notification {
-  override def withTopics(topics: Set[Topic]): Notification = copy(topic = topics)
+  override def withTopics(topics: List[Topic]): Notification = copy(topic = topics)
 }
 
 object GoalAlertNotification {
@@ -188,9 +188,9 @@ case class ElectionNotification(
   link: Link,
   resultsLink: Link,
   results: ElectionResults,
-  topic: Set[Topic]
+  topic: List[Topic]
 ) extends Notification {
-  override def withTopics(topics: Set[Topic]): Notification = copy(topic = topics)
+  override def withTopics(topics: List[Topic]): Notification = copy(topic = topics)
 }
 
 object ElectionNotification {
@@ -210,9 +210,9 @@ case class LiveEventNotification(
   link1: Link,
   link2: Link,
   imageUrl: Option[URI],
-  topic: Set[Topic]
+  topic: List[Topic]
 ) extends Notification {
-  override def withTopics(topics: Set[Topic]): Notification = copy(topic = topics)
+  override def withTopics(topics: List[Topic]): Notification = copy(topic = topics)
 }
 
 object LiveEventNotification {

--- a/common/src/test/scala/models/NotificationReportTest.scala
+++ b/common/src/test/scala/models/NotificationReportTest.scala
@@ -66,7 +66,7 @@ class NotificationReportTest extends Specification {
             link = Internal("some/capi/id-with-dashes", None, GITContent),
             imageUrl = Some(new URI("http://some.url/i.jpg")),
             importance = Major,
-            topic = Set(Topic(Breaking, "uk"))
+            topic = List(Topic(Breaking, "uk"))
           ),
           reports = List(
             SenderReport("Firebase", sentTime, None, Some(PlatformStatistics(Android, recipientsCount = 3)))

--- a/common/src/test/scala/models/NotificationSpec.scala
+++ b/common/src/test/scala/models/NotificationSpec.scala
@@ -47,7 +47,7 @@ class NotificationSpec extends Specification {
        imageUrl = Some(new URI("https://mobile.guardianapis.com/img/media/a5fb401022d09b2f624a0cc0484c563fd1b6ad93/" +
          "0_308_4607_2764/master/4607.jpg/6ad3110822bdb2d1d7e8034bcef5dccf?width=800&height=-&quality=85")),
        importance = Major,
-       topic = Set(Topic(Breaking, "uk"))
+       topic = List(Topic(Breaking, "uk"))
      )
 
      val expected =
@@ -83,7 +83,7 @@ class NotificationSpec extends Specification {
        sender = "test",
        link = Internal("environment/ng-interactive/2015/oct/16/which-countries-are-doing-the-most-to-stop-dangerous-global-warming", None, GITContent),
        importance = Major,
-       topic = Set(Topic(TagSeries, "environment/series/keep-it-in-the-ground"))
+       topic = List(Topic(TagSeries, "environment/series/keep-it-in-the-ground"))
      )
 
      val expected =
@@ -126,7 +126,7 @@ class NotificationSpec extends Specification {
        matchId = "3833380",
        mapiUrl = new URI("http://football.mobile-apps.guardianapis.com/match-info/3833380"),
        importance = Major,
-       topic = Set(
+       topic = List(
          Topic(FootballTeam, "29"),
          Topic(FootballTeam, "41"),
          Topic(FootballMatch, "3833380")

--- a/common/src/test/scala/tracking/DynamoNotificationReportRepositorySpec.scala
+++ b/common/src/test/scala/tracking/DynamoNotificationReportRepositorySpec.scala
@@ -79,7 +79,7 @@ class DynamoNotificationReportRepositorySpec(implicit ev: ExecutionEnv) extends 
         link = Internal("some/capi/id-with-dashes", None, GITContent),
         imageUrl = Some(new URI("http://some.url/i.jpg")),
         importance = Major,
-        topic = Set(Topic(Breaking, "uk"))
+        topic = List(Topic(Breaking, "uk"))
       ),
       reports = List(
         SenderReport("Firebase", DateTime.parse(sentTime).withZone(DateTimeZone.UTC), Some(s"hub-$id"), Some(PlatformStatistics(Android, 5)))

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -8,14 +8,12 @@ import notification.models.{Push, PushResult}
 import notification.services.{Configuration, NotificationSender}
 import play.api.Logger
 import play.api.libs.json.Json.toJson
-import play.api.mvc.BodyParsers.parse.{json => BodyJson}
 import play.api.mvc._
 import tracking.SentNotificationReportRepository
 
 import scala.concurrent.Future.sequence
 import scala.concurrent.{ExecutionContext, Future}
 import notification.services.azure.NewsstandSender
-import cats.syntax.either._
 
 final class Main(
     configuration: Configuration,

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -50,13 +50,13 @@ final class Main(
 
   def pushTopics: Action[Notification] = authAction.async(parse.json[Notification]) { request =>
     val topics = request.body.topic
-    val MaxTopics = 20
+    val MaxTopics = 3
     topics.size match {
       case 0 => Future.successful(BadRequest("Empty topic list"))
       case a: Int if a > MaxTopics => Future.successful(BadRequest(s"Too many topics, maximum: $MaxTopics"))
       case _ if !topics.forall{request.isPermittedTopic} =>
         Future.successful(Unauthorized(s"This API key is not valid for ${topics.filterNot(request.isPermittedTopic)}."))
-      case _ => pushWithDuplicateProtection(Push(request.body.withTopics(topics), topics))
+      case _ => pushWithDuplicateProtection(Push(request.body.withTopics(topics), topics.toSet))
     }
   }
 

--- a/notification/app/notification/services/Configuration.scala
+++ b/notification/app/notification/services/Configuration.scala
@@ -35,6 +35,9 @@ class Configuration(conf: PlayConfig) {
 
   lazy val newsstandShards: Int = conf.get[Int]("newsstand.shards")
 
+  lazy val firebaseServiceAccountKey: String = conf.get[String]("notifications.firebase.serviceAccountKey")
+  lazy val firebaseDatabaseUrl: String = conf.get[String]("notifications.firebase.databaseUrl")
+
   private def getConfigurableHubConnection(hubConfigurationName: String): NotificationHubConnection = {
     val hub = for {
       endpoint <- conf.getOptional[String](s"$hubConfigurationName.hub.endpoint")

--- a/notification/app/notification/services/azure/APNSPushConverter.scala
+++ b/notification/app/notification/services/azure/APNSPushConverter.scala
@@ -39,7 +39,7 @@ class APNSPushConverter(conf: Configuration) extends AzurePushConverter {
       },
       message = breakingNews.message,
       link = toIosLink(breakingNews.link), //check this
-      topics = breakingNews.topic,
+      topics = breakingNews.topic.toSet,
       uri = new URI(link.uri),
       uriType = link.`type`,
       legacyLink = toIosLink(breakingNews.link).toString, //check this
@@ -54,7 +54,7 @@ class APNSPushConverter(conf: Configuration) extends AzurePushConverter {
       category = "ITEM_CATEGORY",
       message = if (cn.iosUseMessage.contains(true)) cn.message else cn.title,
       link = toIosLink(cn.link),
-      topics = cn.topic,
+      topics = cn.topic.toSet,
       uri = new URI(link.uri),
       uriType = link.`type`,
       legacyLink = toIosLink(cn.link).toString

--- a/notification/app/notification/services/azure/GCMPushConverter.scala
+++ b/notification/app/notification/services/azure/GCMPushConverter.scala
@@ -58,6 +58,7 @@ class GCMPushConverter(conf: Configuration) extends AzurePushConverter {
       .filter(_.`type` == TopicTypes.Breaking)
       .map(_.name)
       .collect(Edition.fromString)
+      .toSet
 
     android.BreakingNewsNotification(
       `type` = AndroidMessageTypes.Custom,
@@ -88,7 +89,7 @@ class GCMPushConverter(conf: Configuration) extends AzurePushConverter {
       ticker = cn.message,
       message = cn.message,
       link = toAndroidLink(cn.link),
-      topics = cn.topic.map(toAndroidTopic),
+      topics = cn.topic.map(toAndroidTopic).toSet,
       uriType = link.`type`,
       uri = new URI(link.uri),
       thumbnailUrl = cn.thumbnailUrl,

--- a/notification/app/notification/services/fcm/APNSConfigConverter.scala
+++ b/notification/app/notification/services/fcm/APNSConfigConverter.scala
@@ -2,7 +2,6 @@ package notification.services.fcm
 
 import java.net.URI
 
-import azure._
 import azure.apns.FootballMatchStatusProperties
 import com.google.firebase.messaging.{ApnsConfig, Aps, ApsAlert}
 import models.NotificationType.{BreakingNews, Content, FootballMatchStatus}
@@ -156,8 +155,6 @@ class APNSConfigConverter(conf: Configuration) extends FCMConfigConverter[ApnsCo
     case Link.Internal(contentApiId, _, _) => PlatformUri(s"https://www.theguardian.com/$contentApiId", Item)
     case Link.External(url) => PlatformUri(url, External)
   }
-
-  private def toTags(destination: Set[Topic]) = Some(Tags.fromTopics(destination))
 
   private def toIosLink(link: Link) = link match {
     case Link.Internal(contentApiId, Some(shortUrl), _) => new URI(s"x-gu://${new URI(shortUrl).getPath}")

--- a/notification/app/notification/services/fcm/APNSConfigConverter.scala
+++ b/notification/app/notification/services/fcm/APNSConfigConverter.scala
@@ -16,11 +16,11 @@ import play.api.Logger
 
 import collection.JavaConverters._
 
-class APNSConfigConverter(conf: Configuration) {
+class APNSConfigConverter(conf: Configuration) extends FCMConfigConverter[ApnsConfig] {
 
   val logger = Logger(classOf[APNSConfigConverter])
 
-  def toIosConfig(push: Push): Option[ApnsConfig] = {
+  override def toFCM(push: Push): Option[ApnsConfig] = {
     toFirebaseApnsNotification(push).map(_.toApnsConfig)
   }
 

--- a/notification/app/notification/services/fcm/AndroidConfigConverter.scala
+++ b/notification/app/notification/services/fcm/AndroidConfigConverter.scala
@@ -15,11 +15,11 @@ import utils.MapImplicits._
 import scala.PartialFunction._
 import collection.JavaConverters._
 
-class AndroidConfigConverter(conf: Configuration) {
+class AndroidConfigConverter(conf: Configuration) extends FCMConfigConverter[AndroidConfig] {
 
   val logger = Logger(classOf[AndroidConfigConverter])
 
-  def toAndroidConfig(push: Push): Option[AndroidConfig] = toFirebaseAndroidNotification(push).map(_.toAndroidConfig)
+  override def toFCM(push: Push): Option[AndroidConfig] = toFirebaseAndroidNotification(push).map(_.toAndroidConfig)
 
   case class FirebaseAndroidNotification(
     data: Map[String, String]

--- a/notification/app/notification/services/fcm/AndroidConfigConverter.scala
+++ b/notification/app/notification/services/fcm/AndroidConfigConverter.scala
@@ -2,7 +2,6 @@ package notification.services.fcm
 
 import java.net.URI
 
-import _root_.azure.Tags
 import com.google.firebase.messaging.AndroidConfig
 import models._
 import notification.models.android.Editions.Edition
@@ -142,6 +141,4 @@ class AndroidConfigConverter(conf: Configuration) extends FCMConfigConverter[And
     case Link.Internal(contentApiId, _, _) => new URI(s"x-gu://www.guardian.co.uk/$contentApiId")
     case Link.External(url) => new URI(url)
   }
-
-  private[services] def toTags(destination: Set[Topic]) = Some(Tags.fromTopics(destination))
 }

--- a/notification/app/notification/services/fcm/FCMConfigConverter.scala
+++ b/notification/app/notification/services/fcm/FCMConfigConverter.scala
@@ -1,0 +1,7 @@
+package notification.services.fcm
+
+import notification.models.Push
+
+trait FCMConfigConverter[A] {
+  def toFCM(push: Push): Option[A]
+}

--- a/notification/app/notification/services/fcm/FCMNotificationSender.scala
+++ b/notification/app/notification/services/fcm/FCMNotificationSender.scala
@@ -36,16 +36,6 @@ class FCMNotificationSender(
     }
   }
 
-  def setDestination(messageBuilder: Message.Builder, destination: List[Topic]): Message.Builder = {
-    def topicToFirebase(topic: Topic): String = s"${topic.`type`}/${topic.name}".replaceAll("/", "%")
-    destination match {
-      case topic :: Nil => messageBuilder.setTopic(topicToFirebase(topic))
-      case topics: List[Topic] =>
-        messageBuilder.setCondition(topics.map(topic => s"'${topicToFirebase(topic)}' in topics").mkString("||"))
-    }
-    messageBuilder
-  }
-
   def buildAndSendMessage(push: Push, androidConfig: Option[AndroidConfig], apnsConfig: Option[ApnsConfig]): Future[SenderResult] = {
 
     val messageBuilder = Message.builder()
@@ -62,6 +52,16 @@ class FCMNotificationSender(
     Future(firebaseMessaging.send(firebaseNotification))(fcmExecutionContext)
       .map(messageId => Right(SenderReport("FCM", DateTime.now(), sendersId = Some(messageId), None)))
 
+  }
+
+  def setDestination(messageBuilder: Message.Builder, destination: List[Topic]): Message.Builder = {
+    def topicToFirebase(topic: Topic): String = s"${topic.`type`}/${topic.name}".replaceAll("/", "%")
+    destination match {
+      case topic :: Nil => messageBuilder.setTopic(topicToFirebase(topic))
+      case topics: List[Topic] =>
+        messageBuilder.setCondition(topics.map(topic => s"'${topicToFirebase(topic)}' in topics").mkString("||"))
+    }
+    messageBuilder
   }
 
 }

--- a/notification/app/notification/services/fcm/FCMNotificationSender.scala
+++ b/notification/app/notification/services/fcm/FCMNotificationSender.scala
@@ -8,57 +8,65 @@ import notification.models.Push
 import notification.services._
 import org.joda.time.DateTime
 import play.api.Logger
-import com.google.firebase.FirebaseApp
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 class FCMNotificationSender(
-  apnsConfigConverter: ApnsConfigConverter,
-  gcmPushConverter: AndroidConfigConverter,
-  firebaseApp: FirebaseApp
-)(implicit ec: ExecutionContext, actorSystem: ActorSystem) extends NotificationSender {
+  apnsConfigConverter: FCMConfigConverter[ApnsConfig],
+  androidConfigConverter: FCMConfigConverter[AndroidConfig],
+  firebaseMessaging: FirebaseMessaging,
+  fcmExecutionContext: ExecutionContext
+)(implicit ec: ExecutionContext) extends NotificationSender {
 
   private val logger = Logger(classOf[FCMNotificationSender])
 
-  // FCM calls are blocking, this is to block on a separate thread pool
-  private val fcmExecutionContext: ExecutionContext = actorSystem.dispatchers.lookup("fcm-io")
+  override def sendNotification(push: Push): Future[SenderResult] = {
 
-  private implicit class MessageBuilder(messageBuilder: Message.Builder) {
-    def setDestination(destination: Destination): Message.Builder = {
-      def topicToFirebase(topic: Topic): String = s"${topic.`type`}/${topic.name}".replaceAll("/", "%")
-      destination match {
-        case Left(topics) if topics.size == 1 => messageBuilder.setTopic(topicToFirebase(topics.head))
-        case Left(topics) if topics.size != 1 =>
-          messageBuilder.setCondition(topics.map(topic => s"'${topicToFirebase(topic)}' in topics").mkString("||"))
-        case Right(token) => messageBuilder.setToken(token.id.toString)
-      }
+    val androidConfig = androidConfigConverter.toFCM(push)
+    val apnsConfig = apnsConfigConverter.toFCM(push)
+
+    if (androidConfig.isDefined || apnsConfig.isDefined) {
+      buildAndSendMessage(push, androidConfig, apnsConfig)
+        .recover {
+          case NonFatal(exception) =>
+            logger.error(s"An error occurred while sending the push notification $push", exception)
+            Left(FCMSenderError(Senders.FCM, exception.getMessage))
+        }
+    } else {
+      Future.successful(Left(FCMSenderError(Senders.FCM, "No payload for ios or android to send")))
     }
   }
 
-  private def notification(push: Push): Notification = {
-    new Notification(push.notification.title, push.notification.message)
+  def setDestination(messageBuilder: Message.Builder, destination: Destination): Message.Builder = {
+    def topicToFirebase(topic: Topic): String = s"${topic.`type`}/${topic.name}".replaceAll("/", "%")
+    destination match {
+      case Left(topics) if topics.size == 1 => messageBuilder.setTopic(topicToFirebase(topics.head))
+      case Left(topics) if topics.size != 1 =>
+        messageBuilder.setCondition(topics.map(topic => s"'${topicToFirebase(topic)}' in topics").mkString("||"))
+      case Right(token) => messageBuilder.setToken(token.id.toString)
+    }
+    messageBuilder
   }
 
-  override def sendNotification(push: Push): Future[SenderResult] = {
+  def buildAndSendMessage(push: Push, androidConfig: Option[AndroidConfig], apnsConfig: Option[ApnsConfig]): Future[SenderResult] = {
+
     val messageBuilder = Message.builder()
-      .setNotification(notification(push))
-      .setDestination(push.destination)
+      .setNotification(new Notification(push.notification.title, push.notification.message))
 
-    apnsConfigConverter.toIosConfig(push).foreach(messageBuilder.setApnsConfig)
-    gcmPushConverter.toAndroidConfig(push).foreach(messageBuilder.setAndroidConfig)
+    setDestination(messageBuilder, push.destination)
 
-    val message = messageBuilder.build()
+    androidConfig.foreach(messageBuilder.setAndroidConfig)
+    apnsConfig.foreach(messageBuilder.setApnsConfig)
+
+    val firebaseNotification = messageBuilder.build
 
     // FCM's async calls doesn't come with its own thread pool, so we may as well block in a separate thread pool
-    Future(FirebaseMessaging.getInstance(firebaseApp).send(message))(fcmExecutionContext)
+    Future(firebaseMessaging.send(firebaseNotification))(fcmExecutionContext)
       .map(messageId => Right(SenderReport("FCM", DateTime.now(), sendersId = Some(messageId), None)))
-      .recover {
-        case NonFatal(exception) =>
-          logger.error(s"An error occurred while sending the push notification $push", exception)
-          Left(NotificationRejected(Some(FCMSenderError("FCM", exception.getMessage))))
-      }
+
   }
 
-  case class FCMSenderError(senderName: String, reason: String) extends SenderError
 }
+
+case class FCMSenderError(senderName: String, reason: String) extends SenderError

--- a/notification/app/notification/services/fcm/FCMNotificationSender.scala
+++ b/notification/app/notification/services/fcm/FCMNotificationSender.scala
@@ -1,0 +1,64 @@
+package notification.services.fcm
+
+import akka.actor.ActorSystem
+import com.google.firebase.messaging._
+import models.{SenderReport, Topic}
+import notification.models.Destination.Destination
+import notification.models.Push
+import notification.services._
+import org.joda.time.DateTime
+import play.api.Logger
+import com.google.firebase.FirebaseApp
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+
+class FCMNotificationSender(
+  apnsConfigConverter: ApnsConfigConverter,
+  gcmPushConverter: AndroidConfigConverter,
+  firebaseApp: FirebaseApp
+)(implicit ec: ExecutionContext, actorSystem: ActorSystem) extends NotificationSender {
+
+  private val logger = Logger(classOf[FCMNotificationSender])
+
+  // FCM calls are blocking, this is to block on a separate thread pool
+  private val fcmExecutionContext: ExecutionContext = actorSystem.dispatchers.lookup("fcm-io")
+
+  private implicit class MessageBuilder(messageBuilder: Message.Builder) {
+    def setDestination(destination: Destination): Message.Builder = {
+      def topicToFirebase(topic: Topic): String = s"${topic.`type`}/${topic.name}".replaceAll("/", "%")
+      destination match {
+        case Left(topics) if topics.size == 1 => messageBuilder.setTopic(topicToFirebase(topics.head))
+        case Left(topics) if topics.size != 1 =>
+          messageBuilder.setCondition(topics.map(topic => s"'${topicToFirebase(topic)}' in topics").mkString("||"))
+        case Right(token) => messageBuilder.setToken(token.id.toString)
+      }
+    }
+  }
+
+  private def notification(push: Push): Notification = {
+    new Notification(push.notification.title, push.notification.message)
+  }
+
+  override def sendNotification(push: Push): Future[SenderResult] = {
+    val messageBuilder = Message.builder()
+      .setNotification(notification(push))
+      .setDestination(push.destination)
+
+    apnsConfigConverter.toIosConfig(push).foreach(messageBuilder.setApnsConfig)
+    gcmPushConverter.toAndroidConfig(push).foreach(messageBuilder.setAndroidConfig)
+
+    val message = messageBuilder.build()
+
+    // FCM's async calls doesn't come with its own thread pool, so we may as well block in a separate thread pool
+    Future(FirebaseMessaging.getInstance(firebaseApp).send(message))(fcmExecutionContext)
+      .map(messageId => Right(SenderReport("FCM", DateTime.now(), sendersId = Some(messageId), None)))
+      .recover {
+        case NonFatal(exception) =>
+          logger.error(s"An error occurred while sending the push notification $push", exception)
+          Left(NotificationRejected(Some(FCMSenderError("FCM", exception.getMessage))))
+      }
+  }
+
+  case class FCMSenderError(senderName: String, reason: String) extends SenderError
+}

--- a/notification/app/notification/services/frontend/NewsAlert.scala
+++ b/notification/app/notification/services/frontend/NewsAlert.scala
@@ -38,7 +38,7 @@ object NewsAlert {
         thumbnailUrl = notification.thumbnailUrl,
         imageUrl = notification.thumbnailUrl,
         publicationDate = sent,
-        topics = notification.topic.map(_.toString)
+        topics = notification.topic.map(_.toString).toSet
       )
     }
   }

--- a/notification/app/notification/services/package.scala
+++ b/notification/app/notification/services/package.scala
@@ -12,6 +12,7 @@ package object services {
   object Senders {
     val AzureNotificationsHub = "Azure Notifications Hub"
     val FrontendAlerts = "Frontend Alerts Sender"
+    val FCM = "FCM Notification Sender"
   }
 
   type SenderResult = Either[SenderError, SenderReport]

--- a/notification/conf/application.conf
+++ b/notification/conf/application.conf
@@ -1,2 +1,8 @@
 play.application.loader="notification.NotificationApplicationLoader"
 pidfile.path=/tmp/notification.pid
+
+fcm-io {
+  fork-join-executor {
+    parallelism-max = 10
+  }
+}

--- a/notification/test/notification/NotificationsFixtures.scala
+++ b/notification/test/notification/NotificationsFixtures.scala
@@ -16,7 +16,7 @@ import org.joda.time.DateTime
 import play.api.test.FakeRequest
 
 trait NotificationsFixtures {
-  def breakingNewsNotification(topics: Set[Topic]): BreakingNewsNotification = BreakingNewsNotification(
+  def breakingNewsNotification(topics: List[Topic]): BreakingNewsNotification = BreakingNewsNotification(
     id = UUID.fromString("30aac5f5-34bb-4a88-8b69-97f995a4907b"),
     title = "The Guardian",
     message = "Mali hotel attack: UN counts 27 bodies as hostage situation ends",
@@ -57,7 +57,7 @@ trait NotificationsFixtures {
         color = "#d61d00"
       )
     )),
-    topic = Set(Topic(ElectionResults, "us-presidential-2016"))
+    topic = List(Topic(ElectionResults, "us-presidential-2016"))
   )
 
   def newsstandShardNotification() = NewsstandShardNotification(
@@ -75,14 +75,14 @@ trait NotificationsFixtures {
       link = Internal("capiId", None, GITContent),
       imageUrl = None,
       importance = importance,
-      topic = Set()
+      topic = List()
     ),
     destination = Set(Topic(ElectionResults, "us-presidential-2016"))
   )
 
   def topicTargetedBreakingNewsPush(notification: Notification): Push = Push(
     notification = notification,
-    destination = notification.topic
+    destination = notification.topic.toSet
   )
 
   val providerError = new NotificationHubSenderError(new NotificationsError {
@@ -94,9 +94,9 @@ trait NotificationsFixtures {
   val authenticatedRequest = FakeRequest(method = "POST", path = s"?api-key=$apiKey")
   val electionsAuthenticatedRequest = FakeRequest(method = "POST", path = s"?api-key=$electionsApiKey")
   val invalidAuthenticatedRequest = FakeRequest(method = "POST", path = s"?api-key=wrong-key")
-  val validTopics = Set(Topic(Breaking, "uk"), Topic(Breaking, "us"))
-  val validElectionTopics = Set(Topic(ElectionResults, "uk"), Topic(ElectionResults, "us"))
-  val validNewsstandNotificationsTopic = Set(Topic(TopicTypes.NewsstandShard, "newsstand-shard-1"))
+  val validTopics = List(Topic(Breaking, "uk"), Topic(Breaking, "us"))
+  val validElectionTopics = List(Topic(ElectionResults, "uk"), Topic(ElectionResults, "us"))
+  val validNewsstandNotificationsTopic = List(Topic(TopicTypes.NewsstandShard, "newsstand-shard-1"))
   val requestWithValidTopics = authenticatedRequest.withBody(breakingNewsNotification(validTopics))
 
   def senderReport(

--- a/notification/test/notification/controllers/MainSpec.scala
+++ b/notification/test/notification/controllers/MainSpec.scala
@@ -58,12 +58,12 @@ class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito
       status(secondResponse) must equalTo(BAD_REQUEST)
     }
     "refuse a notification without a topic" in new MainScope {
-      val request = authenticatedRequest.withBody(breakingNewsNotification(Set()))
+      val request = authenticatedRequest.withBody(breakingNewsNotification(List()))
       status(main.pushTopics()(request)) must equalTo(BAD_REQUEST)
     }
     "refuse a notification with too many topics" in new MainScope {
       val topics = (1 to 21).map(i => Topic(Breaking, s"$i"))
-      val request = authenticatedRequest.withBody(breakingNewsNotification(Set()))
+      val request = authenticatedRequest.withBody(breakingNewsNotification(List()))
       status(main.pushTopics()(request)) must equalTo(BAD_REQUEST)
     }
   }
@@ -111,7 +111,7 @@ class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito
 
       status(response) must equalTo(CREATED)
 
-      val sentTime = reportRepository.getByUuid(breakingNewsNotification(Set.empty).id).map(_.map(_.sentTime))
+      val sentTime = reportRepository.getByUuid(breakingNewsNotification(List.empty).id).map(_.map(_.sentTime))
 
       sentTime must beEqualTo(Right(frontendAlertsReport.sentTime)).await
     }

--- a/notification/test/notification/controllers/MainSpec.scala
+++ b/notification/test/notification/controllers/MainSpec.scala
@@ -29,7 +29,7 @@ class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito
       val response = main.pushTopics()(request)
 
       status(response) must equalTo(CREATED)
-      pushSent must beSome.which(_.destination must beEqualTo(validTopics))
+      pushSent must beSome.which(_.destination must beEqualTo(validTopics.toSet))
     }
     "refuse a notification with an invalid key" in new MainScope {
       val request = invalidAuthenticatedRequest.withBody(breakingNewsNotification(validTopics))
@@ -48,7 +48,7 @@ class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito
       val response = main.pushTopics()(request)
 
       status(response) must equalTo(CREATED)
-      pushSent must beSome.which(_.destination must beEqualTo(validElectionTopics))
+      pushSent must beSome.which(_.destination must beEqualTo(validElectionTopics.toSet))
     }
     "refuse a notification that is sent twice" in new MainScope {
       val request = requestWithValidTopics
@@ -139,7 +139,7 @@ class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito
       val request = authenticatedRequest.withBody(newsstandShardNotification())
       val response = main.pushTopics(request)
       status(response) must equalTo(CREATED)
-      pushSent must beSome.which(_.destination must beEqualTo(validNewsstandNotificationsTopic))
+      pushSent must beSome.which(_.destination must beEqualTo(validNewsstandNotificationsTopic.toSet))
 
     }
   }

--- a/notification/test/notification/models/azure/AndroidNotificationSpec.scala
+++ b/notification/test/notification/models/azure/AndroidNotificationSpec.scala
@@ -194,7 +194,7 @@ class AndroidNotificationSpec extends Specification with Mockito {
           color = "#d61d00"
         )
       )),
-      topic = Set.empty
+      topic = List.empty
     )
 
     val push = Push(notification, Set(Topic(TagSeries, "series-a"), Topic(TagSeries, "series-b")))
@@ -240,10 +240,10 @@ class AndroidNotificationSpec extends Specification with Mockito {
       link1 = Internal("world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray", Some("https://gu.com/p/4p7xt"), GITContent),
       link2 = Internal("world/2016/oct/26/canada-women-un-ranking-discrimination-justin-trudeau", Some("https://gu.com/p/5982v"), GITContent),
       imageUrl = Some(new URI("http://gu.com/some-image.png")),
-      topic = Set(Topic(LiveNotification, "super-bowl-li"))
+      topic = List(Topic(LiveNotification, "super-bowl-li"))
     )
 
-    val push = Push(notification, notification.topic)
+    val push = Push(notification, notification.topic.toSet)
 
     val expected =  Map(
       "uniqueIdentifier" -> "068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7",
@@ -282,13 +282,13 @@ class AndroidNotificationSpec extends Specification with Mockito {
       matchInfoUri = new URI("https://mobile.guardianapis.com/sport/football/match-info/3955232"),
       articleUri = Some(new URI("https://mobile.guardianapis.com/items/some-liveblog")),
       importance = Major,
-      topic = Set.empty,
+      topic = List.empty,
       matchStatus = "P",
       eventId = "1000",
       debug = false
     )
 
-    val push = Push(notification, notification.topic)
+    val push = Push(notification, notification.topic.toSet)
 
     val expected =  Map(
       "type" -> "footballMatchAlert",

--- a/notification/test/notification/models/azure/iOSNotificationSpec.scala
+++ b/notification/test/notification/models/azure/iOSNotificationSpec.scala
@@ -74,7 +74,7 @@ class iOSNotificationSpec extends Specification with Mockito {
       link = Internal("world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray", Some("https://gu.com/p/4p7xt"), GITContent),
       imageUrl = Some(new URI("https://media.guim.co.uk/633850064fba4941cdac17e8f6f8de97dd736029/24_0_1800_1080/500-image-url.jpg")),
       importance = Major,
-      topic = Set(Topic(Breaking, "uk"), Topic(Breaking, "us"), Topic(Breaking, "au"), Topic(Breaking, "international"))
+      topic = List(Topic(Breaking, "uk"), Topic(Breaking, "us"), Topic(Breaking, "au"), Topic(Breaking, "international"))
     )
 
     val push = Push(notification, Set(Topic(Breaking, "uk"), Topic(Breaking, "us"), Topic(Breaking, "au"), Topic(Breaking, "international")))
@@ -110,7 +110,7 @@ class iOSNotificationSpec extends Specification with Mockito {
       link = Internal("world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray", Some("https://gu.com/p/4p7xt"), GITContent),
       imageUrl = Some(new URI("https://media.guim.co.uk/633850064fba4941cdac17e8f6f8de97dd736029/24_0_1800_1080/500-image-url.jpg")),
       importance = Major,
-      topic = Set(Topic(Breaking, "uk"), Topic(Breaking, "us"), Topic(Breaking, "au"), Topic(Breaking, "international"))
+      topic = List(Topic(Breaking, "uk"), Topic(Breaking, "us"), Topic(Breaking, "au"), Topic(Breaking, "international"))
     )
 
     val push = Push(notification, Set(Topic(Breaking, "uk"), Topic(Breaking, "us"), Topic(Breaking, "au"), Topic(Breaking, "international")))
@@ -146,7 +146,7 @@ class iOSNotificationSpec extends Specification with Mockito {
       link = Internal("world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray", Some("https://gu.com/p/4p7xt"), GITContent),
       imageUrl = None,
       importance = Major,
-      topic = Set(Topic(Breaking, "uk"), Topic(Breaking, "us"), Topic(Breaking, "au"), Topic(Breaking, "international"))
+      topic = List(Topic(Breaking, "uk"), Topic(Breaking, "us"), Topic(Breaking, "au"), Topic(Breaking, "international"))
     )
 
     val push = Push(notification, Set(Topic(Breaking, "uk"), Topic(Breaking, "us"), Topic(Breaking, "au"), Topic(Breaking, "international")))
@@ -180,7 +180,7 @@ class iOSNotificationSpec extends Specification with Mockito {
       sender = "matt.wells@guardian.co.uk",
       link = Internal("world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray", Some("https://gu.com/p/4p7xt"), GITContent),
       importance = Major,
-      topic = Set(Topic(TagSeries, "series-a"), Topic(TagSeries, "series-b"))
+      topic = List(Topic(TagSeries, "series-a"), Topic(TagSeries, "series-b"))
     )
 
     val push = Push(notification, Set(Topic(TagSeries, "series-a"), Topic(TagSeries, "series-b")))
@@ -204,7 +204,7 @@ class iOSNotificationSpec extends Specification with Mockito {
   }
 
   trait GoalAlertNotificationScope extends NotificationScope {
-    val topics = Set(
+    val topics = List(
       Topic(TopicTypes.FootballTeam, "home-team-id"),
       Topic(TopicTypes.FootballTeam, "away-team-id"),
       Topic(TopicTypes.FootballMatch, "match-id")
@@ -280,7 +280,7 @@ class iOSNotificationSpec extends Specification with Mockito {
           color = "#d61d00"
         )
       )),
-      topic = Set.empty
+      topic = List.empty
     )
 
     val push = Push(notification, Set(Topic(TagSeries, "series-a"), Topic(TagSeries, "series-b")))
@@ -321,10 +321,10 @@ class iOSNotificationSpec extends Specification with Mockito {
       link1 = Internal("world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray", Some("https://gu.com/p/4p7xt"), GITContent),
       link2 = Internal("world/2016/oct/26/canada-women-un-ranking-discrimination-justin-trudeau", Some("https://gu.com/p/5982v"), GITContent),
       imageUrl = Some(new URI("http://gu.com/some-image.png")),
-      topic = Set(Topic(LiveNotification, "super-bowl-li"))
+      topic = List(Topic(LiveNotification, "super-bowl-li"))
     )
 
-    val push = Push(notification, notification.topic)
+    val push = Push(notification, notification.topic.toSet)
 
     val expected = Body(
       aps = APS(
@@ -371,13 +371,13 @@ class iOSNotificationSpec extends Specification with Mockito {
       matchInfoUri = new URI("https://mobile.guardianapis.com/sport/football/match-info/3955232"),
       articleUri = Some(new URI("https://mobile.guardianapis.com/items/some-liveblog")),
       importance = Major,
-      topic = Set.empty,
+      topic = List.empty,
       matchStatus = "P",
       eventId = "1000",
       debug = false
     )
 
-    val push = Push(notification, notification.topic)
+    val push = Push(notification, notification.topic.toSet)
 
     val expected = Body(
       aps = APS(

--- a/notification/test/notification/services/azure/APNSPushConverterSpec.scala
+++ b/notification/test/notification/services/azure/APNSPushConverterSpec.scala
@@ -25,7 +25,7 @@ class APNSPushConverterSpec extends Specification with Mockito {
       )
 
 
-      val maybeAPNSRawPush = aPNSPushConverter.toRawPush(Push(newsstandShardNotification, newsstandShardNotification.topic))
+      val maybeAPNSRawPush = aPNSPushConverter.toRawPush(Push(newsstandShardNotification, newsstandShardNotification.topic.toSet))
       maybeAPNSRawPush must be_==(Some(APNSRawPush(
         body = Body(
           aps = APS(

--- a/notification/test/notification/services/azure/GCMPushConverterSpec.scala
+++ b/notification/test/notification/services/azure/GCMPushConverterSpec.scala
@@ -60,7 +60,7 @@ class GCMPushConverterSpec extends Specification with Mockito {
       link = Internal("world/live/2015/nov/20/mali-hotel-attack-gunmen-take-hostages-in-bamako-live-updates", None, GITContent),
       imageUrl = Some(new URI("https://mobile.guardianapis.com/img/media/a5fb401022d09b2f624a0cc0484c563fd1b6ad93/0_308_4607_2764/master/4607.jpg/6ad3110822bdb2d1d7e8034bcef5dccf?width=800&height=-&quality=85")),
       importance = Major,
-      topic = Set(Topic(Breaking, "uk"))
+      topic = List(Topic(Breaking, "uk"))
     )
 
     val azureNotification = android.BreakingNewsNotification(
@@ -91,7 +91,7 @@ class GCMPushConverterSpec extends Specification with Mockito {
       sender = "test",
       link = Internal("environment/ng-interactive/2015/oct/16/which-countries-are-doing-the-most-to-stop-dangerous-global-warming", None, GITContent),
       importance = Major,
-      topic = Set(Topic(TagSeries, "environment/series/keep-it-in-the-ground"))
+      topic = List(Topic(TagSeries, "environment/series/keep-it-in-the-ground"))
     )
 
     val azureNotification = android.ContentNotification(
@@ -126,7 +126,7 @@ class GCMPushConverterSpec extends Specification with Mockito {
       matchId = "3833380",
       mapiUrl = new URI("http://football.mobile-apps.guardianapis.com/match-info/3833380"),
       importance = Major,
-      topic = Set(
+      topic = List(
         Topic(FootballTeam, "29"),
         Topic(FootballTeam, "41"),
         Topic(FootballMatch, "3833380")

--- a/notification/test/notification/services/azure/GCMSenderSpec.scala
+++ b/notification/test/notification/services/azure/GCMSenderSpec.scala
@@ -62,7 +62,7 @@ class GCMSenderSpec(implicit ev: ExecutionEnv) extends Specification
   trait GCMScope extends Scope with NotificationsFixtures {
     def importance: Importance = Major
     val topicPush = topicTargetedBreakingNewsPush(
-      breakingNewsNotification(Set(
+      breakingNewsNotification(List(
         Topic(TopicTypes.Breaking, "world/religion"),
         Topic(TopicTypes.Breaking, "world/isis")
       )).copy(importance = importance)

--- a/notification/test/notification/services/fcm/APNSConfigConverterSpec.scala
+++ b/notification/test/notification/services/fcm/APNSConfigConverterSpec.scala
@@ -28,7 +28,7 @@ class APNSConfigConverterSpec extends Specification {
           link = Internal("some/capi/id", None, GITContent),
           imageUrl = Some(new URI("https://invalid.url/img.png")),
           importance = Major,
-          topic = Set(Topic(`type` = Breaking, name = "uk"))
+          topic = List(Topic(`type` = Breaking, name = "uk"))
         ),
         destination = Set()
       )
@@ -65,7 +65,7 @@ class APNSConfigConverterSpec extends Specification {
           sender = "UnitTests",
           link = Internal("some/capi/id", None, GITContent),
           importance = Major,
-          topic = Set(Topic(`type` = TagSeries, name = "some/tag")),
+          topic = List(Topic(`type` = TagSeries, name = "some/tag")),
           iosUseMessage = Some(true)
         ),
         destination = Set()
@@ -101,7 +101,7 @@ class APNSConfigConverterSpec extends Specification {
           thumbnailUrl = Some(new URI("https://invalid.url/img.png")),
           sender = "UnitTests",
           importance = Major,
-          topic = Set(Topic(`type` = Breaking, name = "uk")),
+          topic = List(Topic(`type` = Breaking, name = "uk")),
           awayTeamName = "Team1",
           awayTeamScore = 0,
           awayTeamMessage = "team1 message",

--- a/notification/test/notification/services/fcm/AndroidConfigConverterSpec.scala
+++ b/notification/test/notification/services/fcm/AndroidConfigConverterSpec.scala
@@ -27,7 +27,7 @@ class AndroidConfigConverterSpec extends Specification {
           link = Internal("some/capi/id", None, GITContent),
           imageUrl = Some(new URI("https://invalid.url/img.png")),
           importance = Major,
-          topic = Set(Topic(`type` = Breaking, name = "uk"))
+          topic = List(Topic(`type` = Breaking, name = "uk"))
         ),
         destination = Set()
       )
@@ -62,7 +62,7 @@ class AndroidConfigConverterSpec extends Specification {
           sender = "UnitTests",
           link = Internal("some/capi/id", None, GITContent),
           importance = Major,
-          topic = Set(Topic(`type` = Breaking, name = "uk")),
+          topic = List(Topic(`type` = Breaking, name = "uk")),
           iosUseMessage = Some(true)
         ),
         destination = Set()
@@ -94,7 +94,7 @@ class AndroidConfigConverterSpec extends Specification {
           thumbnailUrl = Some(new URI("https://invalid.url/img.png")),
           sender = "UnitTests",
           importance = Major,
-          topic = Set(Topic(`type` = Breaking, name = "uk")),
+          topic = List(Topic(`type` = Breaking, name = "uk")),
           awayTeamName = "Team1",
           awayTeamScore = 0,
           awayTeamMessage = "team1 message",

--- a/notification/test/notification/services/fcm/FCMNotificationSenderSpec.scala
+++ b/notification/test/notification/services/fcm/FCMNotificationSenderSpec.scala
@@ -34,7 +34,7 @@ class FCMNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specification
     }
 
     "Set the topic attribute if the destination is only one topic" in new FCMNotificationSenderScope {
-      val destination = Left(Set(Topic(Breaking, "uk")))
+      val destination = List(Topic(Breaking, "uk"))
 
       val messageBuilder = mock[Message.Builder]
       fcmNotificationSender(androidConfig = Some(mock[AndroidConfig])).setDestination(messageBuilder, destination)
@@ -47,7 +47,7 @@ class FCMNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specification
     }
 
     "Set the condition attribute if the destination is more than one topic" in new FCMNotificationSenderScope {
-      val destination = Left(Set(Topic(Breaking, "uk"), Topic(Breaking, "us")))
+      val destination = List(Topic(Breaking, "uk"), Topic(Breaking, "us"))
 
       val messageBuilder = mock[Message.Builder]
       fcmNotificationSender(androidConfig = Some(mock[AndroidConfig])).setDestination(messageBuilder, destination)
@@ -57,19 +57,6 @@ class FCMNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specification
       there was one(messageBuilder).setCondition(conditionCaptor.capture())
       conditionCaptor.getValue shouldEqual "'breaking%uk' in topics||'breaking%us' in topics"
       there was no(messageBuilder).setToken(any)
-    }
-
-    "Set the token attribute if the destination is a token" in new FCMNotificationSenderScope {
-      val destination = Right(UniqueDeviceIdentifierImpl(UUID.fromString("2977fe3e-f3ec-4986-9d08-00e5b8b7636b")))
-
-      val messageBuilder = mock[Message.Builder]
-      fcmNotificationSender(androidConfig = Some(mock[AndroidConfig])).setDestination(messageBuilder, destination)
-
-      val token = ArgumentCaptor.forClass(classOf[String])
-      there was no(messageBuilder).setTopic(any)
-      there was no(messageBuilder).setCondition(any)
-      there was one(messageBuilder).setToken(token.capture())
-      token.getValue shouldEqual "2977fe3e-f3ec-4986-9d08-00e5b8b7636b"
     }
   }
 
@@ -107,7 +94,7 @@ class FCMNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specification
         importance = Major,
         topic = Set()
       ),
-      destination = Right(UniqueDeviceIdentifierImpl(UUID.randomUUID()))
+      destination = Set(Topic(`type` = TopicTypes.Breaking, name = "uk"))
     )
   }
 }

--- a/notification/test/notification/services/fcm/FCMNotificationSenderSpec.scala
+++ b/notification/test/notification/services/fcm/FCMNotificationSenderSpec.scala
@@ -92,7 +92,7 @@ class FCMNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specification
         link = Internal("world/2018/jun/19/eu-migrant-processing-centres-north-africa-refugees", None, GITContent),
         imageUrl = None,
         importance = Major,
-        topic = Set()
+        topic = List()
       ),
       destination = Set(Topic(`type` = TopicTypes.Breaking, name = "uk"))
     )

--- a/notification/test/notification/services/fcm/FCMNotificationSenderSpec.scala
+++ b/notification/test/notification/services/fcm/FCMNotificationSenderSpec.scala
@@ -1,0 +1,113 @@
+package notification.services.fcm
+
+import java.util.UUID
+
+import com.google.firebase.messaging.{AndroidConfig, ApnsConfig, FirebaseMessaging, Message}
+import models._
+import models.Importance.Major
+import models.Link.Internal
+import models.TopicTypes.Breaking
+import notification.models.Push
+import notification.services.Senders
+import org.mockito.ArgumentCaptor
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import scala.concurrent.Future
+
+class FCMNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specification with Mockito {
+  "FCMNotificationSender" should {
+    "Not send a notification if there's neither an iOS nor an Android payload" in new FCMNotificationSenderScope {
+      val result = fcmNotificationSender().sendNotification(push)
+
+      result should beEqualTo(Left(FCMSenderError(Senders.FCM, "No payload for ios or android to send"))).await
+      there was no(firebaseMessaging).send(any)
+    }
+
+    "Send a notification if an iOS or Android config is present" in new FCMNotificationSenderScope {
+      val result = fcmNotificationSender(androidConfig = Some(mock[AndroidConfig])).sendNotification(push)
+
+      result should beRight(haveClass[SenderReport]).await
+      there was one(firebaseMessaging).send(any)
+    }
+
+    "Set the topic attribute if the destination is only one topic" in new FCMNotificationSenderScope {
+      val destination = Left(Set(Topic(Breaking, "uk")))
+
+      val messageBuilder = mock[Message.Builder]
+      fcmNotificationSender(androidConfig = Some(mock[AndroidConfig])).setDestination(messageBuilder, destination)
+
+      val topicCaptor = ArgumentCaptor.forClass(classOf[String])
+      there was one(messageBuilder).setTopic(topicCaptor.capture())
+      topicCaptor.getValue shouldEqual "breaking%uk"
+      there was no(messageBuilder).setCondition(any)
+      there was no(messageBuilder).setToken(any)
+    }
+
+    "Set the condition attribute if the destination is more than one topic" in new FCMNotificationSenderScope {
+      val destination = Left(Set(Topic(Breaking, "uk"), Topic(Breaking, "us")))
+
+      val messageBuilder = mock[Message.Builder]
+      fcmNotificationSender(androidConfig = Some(mock[AndroidConfig])).setDestination(messageBuilder, destination)
+
+      val conditionCaptor = ArgumentCaptor.forClass(classOf[String])
+      there was no(messageBuilder).setTopic(any)
+      there was one(messageBuilder).setCondition(conditionCaptor.capture())
+      conditionCaptor.getValue shouldEqual "'breaking%uk' in topics||'breaking%us' in topics"
+      there was no(messageBuilder).setToken(any)
+    }
+
+    "Set the token attribute if the destination is a token" in new FCMNotificationSenderScope {
+      val destination = Right(UniqueDeviceIdentifierImpl(UUID.fromString("2977fe3e-f3ec-4986-9d08-00e5b8b7636b")))
+
+      val messageBuilder = mock[Message.Builder]
+      fcmNotificationSender(androidConfig = Some(mock[AndroidConfig])).setDestination(messageBuilder, destination)
+
+      val token = ArgumentCaptor.forClass(classOf[String])
+      there was no(messageBuilder).setTopic(any)
+      there was no(messageBuilder).setCondition(any)
+      there was one(messageBuilder).setToken(token.capture())
+      token.getValue shouldEqual "2977fe3e-f3ec-4986-9d08-00e5b8b7636b"
+    }
+  }
+
+  trait FCMNotificationSenderScope extends Scope {
+
+    def apnsConfigConverter(apnsConfig: Option[ApnsConfig]) = new FCMConfigConverter[ApnsConfig] {
+      override def toFCM(push: Push): Option[ApnsConfig] = apnsConfig
+    }
+    def androidConfigConverter(androidConfig: Option[AndroidConfig]) = new FCMConfigConverter[AndroidConfig] {
+      override def toFCM(push: Push): Option[AndroidConfig] = androidConfig
+    }
+
+    val firebaseMessaging = mock[FirebaseMessaging]
+    firebaseMessaging.send(any[Message]) returns ""
+
+    def fcmNotificationSender(
+      apnsConfig: Option[ApnsConfig] = None,
+      androidConfig: Option[AndroidConfig] = None
+    ): FCMNotificationSender = new FCMNotificationSender(
+      apnsConfigConverter = apnsConfigConverter(apnsConfig),
+      androidConfigConverter = androidConfigConverter(androidConfig),
+      firebaseMessaging = firebaseMessaging,
+      fcmExecutionContext = ee.ec
+    )
+
+    val push = Push(
+      notification = BreakingNewsNotification(
+        id = UUID.randomUUID(),
+        title = "EU to consider plans for migrant processing centres in north Africa",
+        message = "Leaked draft document for upcoming summit says idea could ‘reduce incentive for perilous journeys’",
+        thumbnailUrl = None,
+        sender = "Unit tests",
+        link = Internal("world/2018/jun/19/eu-migrant-processing-centres-north-africa-refugees", None, GITContent),
+        imageUrl = None,
+        importance = Major,
+        topic = Set()
+      ),
+      destination = Right(UniqueDeviceIdentifierImpl(UUID.randomUUID()))
+    )
+  }
+}

--- a/report/test/report/controllers/ReportIntegrationSpec.scala
+++ b/report/test/report/controllers/ReportIntegrationSpec.scala
@@ -71,7 +71,7 @@ class ReportIntegrationSpec(implicit ee: ExecutionEnv) extends PlaySpecification
           link = Internal(s"content/api/id/$prefix", None, GITContent),
           imageUrl = Some(new URI(s"http://some.url/$prefix.jpg")),
           importance = Major,
-          topic = Set(Topic(Breaking, "uk"))
+          topic = List(Topic(Breaking, "uk"))
         ),
         reports = List(
           SenderReport("Firebase", DateTime.now.withZone(UTC), Some(s"hub-$id"), Some(PlatformStatistics(Android, 5)))

--- a/report/test/report/services/NotificationReportEnricherSpec.scala
+++ b/report/test/report/services/NotificationReportEnricherSpec.scala
@@ -38,7 +38,7 @@ class NotificationReportEnricherSpec(implicit ev: ExecutionEnv) extends Specific
       link = Link.External("http://www.theguardian.com"),
       imageUrl = None,
       importance = Major,
-      topic = Set(Topic(TopicTypes.Breaking, "uk"))
+      topic = List(Topic(TopicTypes.Breaking, "uk"))
     )
 
     def createSenderReport(id: String) = SenderReport(


### PR DESCRIPTION
This is the second part of the changes.

Following https://github.com/guardian/mobile-n10n/pull/175 which failed I alread pushed a subset of the changes here: https://github.com/guardian/mobile-n10n/pull/176

The problem we encountered in prod was due to too many topics being sent by the content notification lambda. I've already fixed the client here: https://github.com/guardian/mobile-notifications-api-client/pull/55 and modified Facia and content notification lambda [here](https://github.com/guardian/facia-tool/pull/347) and [here](https://github.com/guardian/mobile-notifications-content/pull/10)

This is the rebased version of what I reverted, I will test on CODE with all notification types