### PR TITLE
(Re)create an unregistration endpoint

### DIFF
--- a/registration/app/registration/controllers/Main.scala
+++ b/registration/app/registration/controllers/Main.scala
@@ -51,6 +51,21 @@ final class Main(
     )
   }
 
+  def unregister(platform: Platform, lastKnownChannelUri: String): Action[AnyContent] = actionWithTimeout {
+
+    def registrarFor(platform: Platform) = EitherT.fromEither[Future](
+      registrarProvider.registrarFor(platform, None)
+    )
+
+    def unregisterFrom(registrar: NotificationRegistrar): EitherT[Future, NotificationsError, Unit] = EitherT(
+      registrar.unregister(lastKnownChannelUri): Future[Either[NotificationsError, Unit]]
+    )
+
+    registrarFor(platform)
+      .flatMap(unregisterFrom)
+      .fold(processErrors, _ => NoContent)
+  }
+
   def newsstandRegister: Action[LegacyNewsstandRegistration] =
     registerWithConverter(legacyNewsstandRegistrationConverter)
 

--- a/registration/app/registration/controllers/Main.scala
+++ b/registration/app/registration/controllers/Main.scala
@@ -51,14 +51,14 @@ final class Main(
     )
   }
 
-  def unregister(platform: Platform, lastKnownChannelUri: String): Action[AnyContent] = actionWithTimeout {
+  def unregister(platform: Platform, pushToken: String): Action[AnyContent] = actionWithTimeout {
 
     def registrarFor(platform: Platform) = EitherT.fromEither[Future](
       registrarProvider.registrarFor(platform, None)
     )
 
     def unregisterFrom(registrar: NotificationRegistrar): EitherT[Future, NotificationsError, Unit] = EitherT(
-      registrar.unregister(lastKnownChannelUri): Future[Either[NotificationsError, Unit]]
+      registrar.unregister(pushToken): Future[Either[NotificationsError, Unit]]
     )
 
     registrarFor(platform)

--- a/registration/app/registration/services/NotificationRegistrar.scala
+++ b/registration/app/registration/services/NotificationRegistrar.scala
@@ -36,7 +36,7 @@ trait NotificationRegistrar {
   type RegistrarResponse[T] = Future[Either[ProviderError, T]]
   val providerIdentifier: String
   def register(oldDeviceId: String, registration: Registration): RegistrarResponse[RegistrationResponse]
-  def unregister(lastKnownChannelUri: String): RegistrarResponse[Unit]
+  def unregister(pushToken: String): RegistrarResponse[Unit]
   def findRegistrations(topic: Topic, cursor: Option[String] = None): Future[Either[ProviderError, Paginated[StoredRegistration]]]
-  def findRegistrations(lastKnownChannelUri: String): Future[Either[ProviderError, List[StoredRegistration]]]
+  def findRegistrations(pushToken: String): Future[Either[ProviderError, List[StoredRegistration]]]
 }

--- a/registration/app/registration/services/NotificationRegistrar.scala
+++ b/registration/app/registration/services/NotificationRegistrar.scala
@@ -36,6 +36,7 @@ trait NotificationRegistrar {
   type RegistrarResponse[T] = Future[Either[ProviderError, T]]
   val providerIdentifier: String
   def register(oldDeviceId: String, registration: Registration): RegistrarResponse[RegistrationResponse]
+  def unregister(lastKnownChannelUri: String): RegistrarResponse[Unit]
   def findRegistrations(topic: Topic, cursor: Option[String] = None): Future[Either[ProviderError, Paginated[StoredRegistration]]]
   def findRegistrations(lastKnownChannelUri: String): Future[Either[ProviderError, List[StoredRegistration]]]
 }

--- a/registration/app/registration/services/azure/NotificationsHubRegistrar.scala
+++ b/registration/app/registration/services/azure/NotificationsHubRegistrar.scala
@@ -32,6 +32,14 @@ class NotificationHubRegistrar(
     }
   }
 
+  override def unregister(lastKnownChannelUri: String): RegistrarResponse[Unit] = {
+    findRegistrationResponses(lastKnownChannelUri).flatMap {
+      case Right(Nil) => Future.successful(Right(()))
+      case Right(manyRegistrations) => deleteRegistrations(manyRegistrations)
+      case Left(e: ProviderError) => Future.successful(Left(e))
+    }
+  }
+
   def findRegistrations(topic: Topic, cursor: Option[String] = None): Future[Either[ProviderError, Paginated[StoredRegistration]]] = {
     EitherT(hubClient.registrationsByTag(Tag.fromTopic(topic).encodedTag, cursor))
       .semiflatMap(responsesToStoredRegistrations)

--- a/registration/conf/routes
+++ b/registration/conf/routes
@@ -1,9 +1,11 @@
-GET         /healthcheck                         registration.controllers.Main.healthCheck
+GET         /healthcheck                            registration.controllers.Main.healthCheck
 
-GET         /registrations                       registration.controllers.Main.registrations(selector: RegistrationsSelector)
+GET         /registrations                          registration.controllers.Main.registrations(selector: RegistrationsSelector)
 
 # Legacy Android/iOS API registration endpoint
-POST        /legacy/device/register              registration.controllers.Main.legacyRegister
+POST        /legacy/device/register                 registration.controllers.Main.legacyRegister
 
 # Legacy Newsstand registration endpoint
-POST        /legacy/newsstand/register           registration.controllers.Main.newsstandRegister
+POST        /legacy/newsstand/register              registration.controllers.Main.newsstandRegister
+
+DELETE      /azure/registrations/:platform/:token   registration.controllers.Main.unregister(platform: Platform, token: String)

--- a/registration/test/registration/controllers/MainControllerSpec.scala
+++ b/registration/test/registration/controllers/MainControllerSpec.scala
@@ -58,6 +58,11 @@ class MainControllerSpec extends PlaySpecification with JsonMatchers with Mockit
       contentAsString(result) must /("results") /#(0) /("deviceId" -> "4027049721A496EA56A4C789B62F2C10B0380427C2A6B0CFC1DE692BDA2CC5D4")
       contentAsString(result) must (/("results") andHave size(1))
     }
+
+    "return 204 when unregistering" in new RegistrationsContext {
+      val Some(register) = route(app, FakeRequest(DELETE, "/azure/registrations/ios/4027049721A496EA56A4C789B62F2C10B0380427C2A6B0CFC1DE692BDA2CC5D4"))
+      status(register) must equalTo(NO_CONTENT)
+    }
   }
 
   trait RegistrationsContext extends RegistrationsBase with withMockedWSClient {
@@ -75,12 +80,12 @@ class MainControllerSpec extends PlaySpecification with JsonMatchers with Mockit
   trait withMockedWSClient { self: RegistrationsBase =>
     override val wsClient = mock[WSClient]
 
-    val deleteRequest = {
+    /*val deleteRequest = {
       val request = mock[WSRequest]
       val response = mock[WSResponse]
       response.status returns 200
       request.delete() returns Future.successful(response)
     }
-    wsClient.url(any[String]) returns deleteRequest
+    wsClient.url(any[String]) returns deleteRequest*/
   }
 }

--- a/registration/test/registration/controllers/MainControllerSpec.scala
+++ b/registration/test/registration/controllers/MainControllerSpec.scala
@@ -79,13 +79,5 @@ class MainControllerSpec extends PlaySpecification with JsonMatchers with Mockit
 
   trait withMockedWSClient { self: RegistrationsBase =>
     override val wsClient = mock[WSClient]
-
-    /*val deleteRequest = {
-      val request = mock[WSRequest]
-      val response = mock[WSResponse]
-      response.status returns 200
-      request.delete() returns Future.successful(response)
-    }
-    wsClient.url(any[String]) returns deleteRequest*/
   }
 }

--- a/registration/test/registration/controllers/RegistrationsFixtures.scala
+++ b/registration/test/registration/controllers/RegistrationsFixtures.scala
@@ -29,6 +29,9 @@ trait DelayedRegistrationsBase extends RegistrationsBase {
       ))
     }
 
+    override def unregister(lastKnownChannelUri: String): Future[Either[ProviderError, Unit]] =
+      Future.successful(Right(()))
+
     override def findRegistrations(topic: Topic, cursor: Option[String]): Future[Either[ProviderError, Paginated[StoredRegistration]]] = ???
 
     override def findRegistrations(lastKnownChannelUri: String): Future[Either[ProviderError, List[StoredRegistration]]] = ???
@@ -67,6 +70,9 @@ trait RegistrationsBase extends WithPlayApp with RegistrationsJson {
         topics = registration.topics
       ))
     }
+
+    override def unregister(lastKnownChannelUri: String): Future[Either[ProviderError, Unit]] =
+      Future.successful(Right(()))
 
     override def findRegistrations(topic: Topic, cursor: Option[String] = None): Future[Either[ProviderError, Paginated[StoredRegistration]]] = {
       val selected = if (cursor.contains("abc")) {

--- a/registration/test/registration/controllers/RegistrationsFixtures.scala
+++ b/registration/test/registration/controllers/RegistrationsFixtures.scala
@@ -29,12 +29,12 @@ trait DelayedRegistrationsBase extends RegistrationsBase {
       ))
     }
 
-    override def unregister(lastKnownChannelUri: String): Future[Either[ProviderError, Unit]] =
+    override def unregister(pushToken: String): Future[Either[ProviderError, Unit]] =
       Future.successful(Right(()))
 
     override def findRegistrations(topic: Topic, cursor: Option[String]): Future[Either[ProviderError, Paginated[StoredRegistration]]] = ???
 
-    override def findRegistrations(lastKnownChannelUri: String): Future[Either[ProviderError, List[StoredRegistration]]] = ???
+    override def findRegistrations(pushToken: String): Future[Either[ProviderError, List[StoredRegistration]]] = ???
 
   }
 }
@@ -71,7 +71,7 @@ trait RegistrationsBase extends WithPlayApp with RegistrationsJson {
       ))
     }
 
-    override def unregister(lastKnownChannelUri: String): Future[Either[ProviderError, Unit]] =
+    override def unregister(pushToken: String): Future[Either[ProviderError, Unit]] =
       Future.successful(Right(()))
 
     override def findRegistrations(topic: Topic, cursor: Option[String] = None): Future[Either[ProviderError, Paginated[StoredRegistration]]] = {
@@ -83,8 +83,8 @@ trait RegistrationsBase extends WithPlayApp with RegistrationsJson {
       Future.successful(Right(Paginated(selected.toList, None)))
     }
 
-    override def findRegistrations(lastKnownChannelUri: String): Future[Either[ProviderError, List[StoredRegistration]]] = {
-      val selected = registrations.filter(_.deviceId == lastKnownChannelUri).map(StoredRegistration.fromRegistration)
+    override def findRegistrations(pushToken: String): Future[Either[ProviderError, List[StoredRegistration]]] = {
+      val selected = registrations.filter(_.deviceId == pushToken).map(StoredRegistration.fromRegistration)
       Future.successful(Right(selected.toList))
     }
 


### PR DESCRIPTION
We use to have a unregistration enpoint, driven by the browser id. That's been removed [here](https://github.com/guardian/mobile-n10n/pull/177)

This PR re-instates a similar endpoint, relying on the device token instead.

I also renamed the `lastKnownChannelUri` we had in a few places. It used to make sense back when we supported w10 push notifications, but nowadays `pushToken` makes much more sense
