### PR TITLE
Add udid back for the purpose of querying only

### DIFF
--- a/common/src/main/scala/azure/Tags.scala
+++ b/common/src/main/scala/azure/Tags.scala
@@ -1,6 +1,6 @@
 package azure
 
-import models.Topic
+import models.{Topic, UniqueDeviceIdentifier}
 
 case class Tag(encodedTag: String)
 
@@ -9,6 +9,10 @@ object Tag {
 
   def fromTopic(t: Topic): Tag = {
     Tag(s"$TopicTagPrefix${t.id}")
+  }
+
+  def fromUserId(u: UniqueDeviceIdentifier): Tag = {
+    Tag(s"$UserTagPrefix${u.id}")
   }
 
 }

--- a/common/src/main/scala/binders/querystringbinders/package.scala
+++ b/common/src/main/scala/binders/querystringbinders/package.scala
@@ -4,12 +4,14 @@ import models._
 import models.pagination.CursorSet
 import org.joda.time.DateTime
 import play.api.mvc.QueryStringBindable
+
 import scala.language.implicitConversions
 import PartialFunction.condOpt
 
 package object querystringbinders {
 
   sealed trait RegistrationsSelector
+  case class RegistrationsByUdidParams(udid: UniqueDeviceIdentifier) extends RegistrationsSelector
   case class RegistrationsByTopicParams(topic: Topic, cursor: Option[CursorSet]) extends RegistrationsSelector
   case class RegistrationsByDeviceToken(platform: Platform, deviceToken: String)extends RegistrationsSelector
 
@@ -27,6 +29,12 @@ package object querystringbinders {
     parse = Topic.fromString(_),
     serialize = _.toString,
     typeName = "Topic"
+  )
+
+  implicit def qsbindableUniqueDeviceIdentifier: QueryStringBindable[UniqueDeviceIdentifier] = new Parsing[UniqueDeviceIdentifier](
+    parse = UniqueDeviceIdentifier.fromString(_).toRight("Invalid udid"),
+    serialize = _.toString,
+    typeName = "udid"
   )
 
   implicit def qsbindablePlatform: QueryStringBindable[Platform] = new Parsing[Platform](
@@ -56,15 +64,25 @@ package object querystringbinders {
   implicit def qsbindableRegistrationsSelector: QueryStringBindable[RegistrationsSelector] = new QueryStringBindable[RegistrationsSelector] {
     override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, RegistrationsSelector]] = {
       List(
+        qsbindableRegistrationsByUdidParams,
         qsbindableRegistrationsByTopicParams,
         qsbindableRegistrationsByDeviceToken).view.map(_.bind(key, params)
       ).collectFirst { case Some(result) => result }
     }
 
     override def unbind(key: String, value: RegistrationsSelector): String = value match {
+      case v: RegistrationsByUdidParams => qsbindableRegistrationsByUdidParams.unbind(key, v)
       case v: RegistrationsByTopicParams => qsbindableRegistrationsByTopicParams.unbind(key, v)
       case v: RegistrationsByDeviceToken => qsbindableRegistrationsByDeviceToken.unbind(key, v)
     }
+  }
+
+  implicit def qsbindableRegistrationsByUdidParams: QueryStringBindable[RegistrationsByUdidParams] = new QueryStringBindable[RegistrationsByUdidParams] {
+    override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, RegistrationsByUdidParams]] =
+      qsbindableUniqueDeviceIdentifier.bind("udid", params).map { _.right.map(RegistrationsByUdidParams.apply) }
+
+    override def unbind(key: String, value: RegistrationsByUdidParams): String =
+      qsbindableUniqueDeviceIdentifier.unbind("udid", value.udid)
   }
 
   implicit def qsbindableRegistrationsByTopicParams: QueryStringBindable[RegistrationsByTopicParams] = new QueryStringBindable[RegistrationsByTopicParams] {

--- a/common/src/main/scala/models/IosUdid.scala
+++ b/common/src/main/scala/models/IosUdid.scala
@@ -1,0 +1,21 @@
+package models
+
+import java.util.UUID
+
+import scala.util.Try
+
+object IosUdid {
+  def fromString(s: String): Option[IosUdid] = {
+    if (s.startsWith("gia:"))
+      uuidFromString(s.stripPrefix("gia:")).map(id => new IosUdid(s, id))
+    else
+      None
+  }
+
+  private def uuidFromString(s: String) = Try(UUID.fromString(s)).toOption
+}
+
+case class IosUdid(underlying: String, id: UUID) extends UniqueDeviceIdentifier {
+
+  override def legacyFormat: String = underlying
+}

--- a/common/src/main/scala/models/NewsstandUdid.scala
+++ b/common/src/main/scala/models/NewsstandUdid.scala
@@ -1,0 +1,14 @@
+package models
+
+import java.util.UUID
+
+object NewsstandUdid {
+  def fromDeviceToken(pushToken: String): NewsstandUdid = new NewsstandUdid(pushToken)
+}
+
+case class NewsstandUdid(pushToken: String) extends UniqueDeviceIdentifier {
+
+  override val id = UUID.nameUUIDFromBytes(pushToken.getBytes)
+
+  override def legacyFormat: String = "newsstand:" + play.api.libs.Codecs.sha1(s"ns-$pushToken")
+}

--- a/common/src/main/scala/models/UniqueDeviceIdentifier.scala
+++ b/common/src/main/scala/models/UniqueDeviceIdentifier.scala
@@ -1,0 +1,40 @@
+package models
+
+import java.util.UUID
+
+import play.api.libs.json._
+
+import scala.util.Try
+
+object UniqueDeviceIdentifier {
+
+  private def uuidFromString(s: String) = Try(UUID.fromString(s)).toOption
+
+  def fromString(s: String): Option[UniqueDeviceIdentifier] = {
+    IosUdid.fromString(s) orElse uuidFromString(s).map(UniqueDeviceIdentifier(_))
+  }
+
+  implicit val readsUserId = new Format[UniqueDeviceIdentifier] {
+
+    override def reads(json: JsValue): JsResult[UniqueDeviceIdentifier] = {
+      val invalid = JsonValidationError(s"User ID is not a valid UUID")
+      json.validate[String].map(UniqueDeviceIdentifier.fromString).collect(invalid) {
+        case Some(udid) => udid
+      }
+    }
+
+    override def writes(o: UniqueDeviceIdentifier): JsValue = JsString(o.legacyFormat)
+  }
+
+  def apply(id: UUID): UniqueDeviceIdentifier =
+    new UniqueDeviceIdentifierImpl(id)
+}
+
+case class UniqueDeviceIdentifierImpl(id: UUID) extends UniqueDeviceIdentifier
+
+trait UniqueDeviceIdentifier {
+
+  def id: UUID
+
+  def legacyFormat: String = id.toString
+}

--- a/common/src/test/scala/azure/TagSpec.scala
+++ b/common/src/test/scala/azure/TagSpec.scala
@@ -1,6 +1,8 @@
 package azure
 
-import models.Topic
+import java.util.UUID
+
+import models.{IosUdid, Topic, UniqueDeviceIdentifier}
 import models.TopicTypes.{Content, FootballMatch, TagContributor}
 import org.specs2.mutable.Specification
 
@@ -35,6 +37,28 @@ class TagSpec extends Specification {
       val tag = Tag.fromTopic(topic)
 
       tag.encodedTag must haveLength(beLessThan(120))
+    }
+
+    "encoded tag must contain user id" in {
+      val uuid = UUID.randomUUID
+      val userId = UniqueDeviceIdentifier(uuid)
+      val tag = Tag.fromUserId(userId)
+
+      tag.encodedTag must endWith(uuid.toString)
+    }
+
+    "encoded tag should not be influenced by 'gia:' prefix" in {
+      val uuid = UUID.randomUUID
+      val userId = UniqueDeviceIdentifier(uuid)
+      val userIdWithPrefix = new IosUdid(s"gia:$uuid", uuid)
+      Tag.fromUserId(userId) must beEqualTo(Tag.fromUserId(userIdWithPrefix))
+    }
+
+    "encoded tag should not be influenced by uuid case" in {
+      val uuid = UUID.randomUUID
+      val userIdUppercase = new IosUdid(s"gia:${uuid.toString.toUpperCase}", uuid)
+      val userIdLowercase = new IosUdid(s"gia:$uuid", uuid)
+      Tag.fromUserId(userIdUppercase) must beEqualTo(Tag.fromUserId(userIdLowercase))
     }
   }
 }

--- a/registration/app/registration/controllers/Main.scala
+++ b/registration/app/registration/controllers/Main.scala
@@ -5,7 +5,7 @@ import akka.pattern.after
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import azure.HubFailure.{HubInvalidConnectionString, HubParseFailed, HubServiceError}
-import binders.querystringbinders.{RegistrationsByDeviceToken, RegistrationsByTopicParams, RegistrationsSelector}
+import binders.querystringbinders.{RegistrationsByDeviceToken, RegistrationsByTopicParams, RegistrationsByUdidParams, RegistrationsSelector}
 import cats.data.EitherT
 import cats.implicits._
 import error.{NotificationsError, RequestError}
@@ -86,7 +86,7 @@ final class Main(
 
   def registrations(selector: RegistrationsSelector): Action[AnyContent] = {
     selector match {
-
+      case v: RegistrationsByUdidParams => registrationsByUdid(v.udid)
       case v: RegistrationsByTopicParams => registrationsByTopic(v.topic, v.cursor)
       case v: RegistrationsByDeviceToken => registrationsByDeviceToken(v.platform, v.deviceToken)
     }
@@ -123,6 +123,21 @@ final class Main(
       registrations <- EitherT(registrar.findRegistrations(deviceToken): Future[Either[NotificationsError, List[StoredRegistration]]])
     } yield registrations
     result.fold(processErrors, res => Ok(Json.toJson(res)))
+  }
+
+  def registrationsByUdid(udid: UniqueDeviceIdentifier): Action[AnyContent] = Action.async {
+    Future.sequence {
+      registrarProvider.withAllRegistrars { registrar =>
+        registrar.findRegistrations(udid)
+      }
+    } map { responses =>
+      val allResults = for {
+        response <- responses
+        successfulResponse <- response.toList
+        result <- successfulResponse.results
+      } yield result
+      Ok(Json.toJson(allResults))
+    }
   }
 
   private def registerCommon(lastKnownDeviceId: String, registration: Registration): Future[Either[NotificationsError, RegistrationResponse]] = {

--- a/registration/app/registration/services/NotificationRegistrar.scala
+++ b/registration/app/registration/services/NotificationRegistrar.scala
@@ -39,4 +39,5 @@ trait NotificationRegistrar {
   def unregister(pushToken: String): RegistrarResponse[Unit]
   def findRegistrations(topic: Topic, cursor: Option[String] = None): Future[Either[ProviderError, Paginated[StoredRegistration]]]
   def findRegistrations(pushToken: String): Future[Either[ProviderError, List[StoredRegistration]]]
+  def findRegistrations(udid: UniqueDeviceIdentifier): Future[Either[ProviderError, Paginated[StoredRegistration]]]
 }

--- a/registration/app/registration/services/azure/NotificationsHubRegistrar.scala
+++ b/registration/app/registration/services/azure/NotificationsHubRegistrar.scala
@@ -56,6 +56,12 @@ class NotificationHubRegistrar(
     hubClient.registrationsByChannelUri(channelUri = pushToken).map(_.right.map(_.distinct))
   }
 
+  def findRegistrations(udid: UniqueDeviceIdentifier): Future[Either[ProviderError, Paginated[StoredRegistration]]] = {
+    EitherT(hubClient.registrationsByTag(Tag.fromUserId(udid).encodedTag))
+      .semiflatMap(responsesToStoredRegistrations)
+      .value
+  }
+
   private def createRegistration(registration: Registration): RegistrarResponse[RegistrationResponse] = {
     logger.debug(s"creating registration $registration")
     hubClient.create(registrationExtractor(registration))

--- a/registration/test/registration/controllers/RegistrationsFixtures.scala
+++ b/registration/test/registration/controllers/RegistrationsFixtures.scala
@@ -36,6 +36,7 @@ trait DelayedRegistrationsBase extends RegistrationsBase {
 
     override def findRegistrations(pushToken: String): Future[Either[ProviderError, List[StoredRegistration]]] = ???
 
+    override def findRegistrations(udid: UniqueDeviceIdentifier): Future[Either[ProviderError, Paginated[StoredRegistration]]] = ???
   }
 }
 
@@ -88,6 +89,7 @@ trait RegistrationsBase extends WithPlayApp with RegistrationsJson {
       Future.successful(Right(selected.toList))
     }
 
+    override def findRegistrations(udid: UniqueDeviceIdentifier): Future[Either[ProviderError, Paginated[StoredRegistration]]] = ???
   }
 
   lazy val fakeRegistrarProvider = new RegistrarProvider {


### PR DESCRIPTION
This is cherry picked out of the git history.

We don't store the udid anymore, but if a device doesn't register again we may still have their udid.

This allows us to fetch a registration via the udid and potentially delete it using the token ID

cc @jorgeazevedo 