### PR TITLE
Fixing report parsing

### DIFF
--- a/common/src/main/scala/models/Platform.scala
+++ b/common/src/main/scala/models/Platform.scala
@@ -7,12 +7,15 @@ sealed trait Platform
 case object Android extends Platform { override def toString: String = "android" }
 case object iOS extends Platform { override def toString: String = "ios" }
 case object Newsstand extends Platform { override def toString: String = "newsstand" }
+// only here to parse older notification reports
+case object WindowsMobile extends Platform { override def toString: String = "windows-mobile" }
 
 object Platform {
   def fromString(s: String): Option[Platform] = PartialFunction.condOpt(s) {
     case "android" => Android
     case "ios" => iOS
     case "newsstand" => Newsstand
+    case "windows-mobile" => WindowsMobile
   }
 
   implicit val jf = new Format[Platform] {


### PR DESCRIPTION
We went a bit too far when removing windows from our codebase
We still need to be able to parse notification reports