### PR TITLE
MSS-313: Adding mobile-notifications-api-client project as a sub module

### DIFF
--- a/api-client/LICENSE
+++ b/api-client/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2014 Guardian News & Media
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/api-client/README.markdown
+++ b/api-client/README.markdown
@@ -1,0 +1,87 @@
+# Mobile Notifications API Client
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.gu/mobile-notifications-client_2.11.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/mobile-notifications-client_2.11)
+[![Project status](https://img.shields.io/badge/status-active-brightgreen.svg)](#status)
+
+Scala client for the Guardian Mobile Notifications API.
+
+## Integrating with your application
+Add to build.sbt: `libraryDependencies += "com.gu" %% "mobile-notifications-client" % "0.6.0"`
+## Configure API Client
+### Implement `HttpProvider` trait methods. 
+This provider will be used by API Client to make an actual calls from your service. Example trait implementation:
+
+```scala
+import com.gu.mobile.notifications.client.HttpProvider
+
+object NotificationHttpProvider extends HttpProvider {
+
+  private def extract(response: Response): HttpResponse = {
+    if (response.status >= 200 && response.status < 300)
+      HttpOk(response.status, response.body)
+    else
+      HttpError(response.status, response.body)
+  }
+  
+  override def post(url: String, contentType: ContentType, body: Array[Byte]): Future[HttpResponse] = {
+    WS.url(url)
+      .withHeaders("Content-Type" -> s"${contentType.mediaType}; charset=${contentType.charset}")
+      .post(body)
+      .map(extract)
+  }
+
+  override def get(url: String): Future[HttpResponse] = WS.url(url).get().map(extract)
+}
+```
+Hint: *it is recommended to prefix name of this implementation with your application/service/artifact name to avoid name collisions*.
+### Create configured Notifications API Client
+
+```scala
+import com.gu.mobile.notifications.client.ApiClient
+
+val httpProvider = <your http provider instance>
+val client = ApiClient(
+  host = "http://notifications-host.com", 
+  apiKey = "API-KEY", 
+  httpProvider = httpProvider, 
+  legacyHost = "http://old-notifications-host.com",
+  legacyApiKey = "OLD-API-KEY"
+)
+```
+## Using client
+### Sending notification
+You have to construct notification payload using one of the case classes from `com.gu.mobile.notifications.client.models.NotificationPayload` hierarchy
+and send that object through the wire using `ApiClient.send` method. 
+#### Example: sending Breaking News alert
+```scala
+val payload = BreakingNewsPayload(
+  message = "195 countries and nearly 150 world leaders including Barack Obama and Xi Jinping meet in Paris for COP21 UN climate change conference",
+  sender = "test sender",
+  imageUrl = None,
+  thumbnailUrl = None,
+  link = ExternalLink("http://mylink"),
+  importance = Importance.Major,
+  topic = Set(BreakingNewsUk, "environment/climate-change"))
+)
+
+client.send(payload)
+```
+### Error handling
+If you take a look at `ApiClient.send` method signature, you can spot its return type:
+
+```scala
+def send(notificationPayload: NotificationPayload): Future[Either[ApiClientError, Unit]]
+```
+
+If you're interesed in root error cause, you can pattern match on Either's `Left` side and errors from `com.gu.mobile.notifications.client.ApiClientError` hierarchy.
+For instance:
+
+```scala
+client.send(...).map { case Left(e: CompositeApiError) => ... }
+```
+## Releasing the library
+
+Because of the incompatibility of the play-json module between version 2.3 and 2.4, a different branch has been created.
+Each change that has been merged into ````master```` MUST be merged into the ````play-2.4```` branch
+
+Once this is done, make sure to run ````sbt release```` on both branches

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/ApiClient.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/ApiClient.scala
@@ -1,0 +1,69 @@
+package com.gu.mobile.notifications.client
+
+import com.gu.mobile.notifications.client.models._
+import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+sealed trait ApiClientError {
+  def description: String
+}
+
+case class ApiHttpError(status: Int, body: Option[String] = None ) extends ApiClientError {
+  val description = body match {
+    case Some(b) => s"Http error: status: $status body: $b "
+    case _ => s"Http error: status: $status"
+  }
+}
+
+case class HttpProviderError(throwable: Throwable) extends ApiClientError {
+  def description = throwable.getMessage
+}
+
+case class UnexpectedApiResponseError(serverResponse: String) extends ApiClientError {
+  val description = s"Unexpected response from server: $serverResponse"
+}
+
+trait ApiClient {
+  def clientId: String
+  def send(notificationPayload: NotificationPayload)(implicit ec: ExecutionContext): Future[Either[ApiClientError, Unit]]
+}
+
+protected trait SimpleHttpApiClient extends ApiClient {
+  def host: String
+  def httpProvider: HttpProvider
+  def apiKey: String
+
+  def healthcheck(implicit ec: ExecutionContext): Future[Healthcheck] = {
+    httpProvider.get(s"$host/healthcheck").map {
+      case HttpOk(200, body) => Ok
+      case HttpOk(code, _) => Unhealthy(Some(code))
+      case HttpError(code, _) => Unhealthy(Some(code))
+    }
+  }
+
+  protected def postJson(destUrl: String, json: String) = {
+    httpProvider.post(
+      url = destUrl,
+      contentType = ContentType("application/json", "UTF-8"),
+      body = json.getBytes("UTF-8")
+    )
+  }
+  protected def validateFormat[T](jsonBody: String)(implicit jr: Reads[T]): Either[ApiClientError, Unit] = {
+    try {
+      Json.parse(jsonBody).validate[T] match {
+        case _: JsSuccess[T] => Right(())
+        case _: JsError => Left(UnexpectedApiResponseError(jsonBody))
+      }
+    }
+    catch {
+      case _: Exception => Left(UnexpectedApiResponseError(jsonBody))
+    }
+  }
+}
+
+object ApiClient {
+  def apply(host: String, apiKey: String, httpProvider: HttpProvider) =
+    new NextGenApiClient(host, apiKey, httpProvider)
+}
+

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/HttpProvider.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/HttpProvider.scala
@@ -1,0 +1,19 @@
+package com.gu.mobile.notifications.client
+
+import scala.concurrent.Future
+
+sealed trait HttpResponse
+
+case class HttpOk(status: Int, body: String) extends HttpResponse {
+  require(status >= 200 && status < 300)
+}
+
+case class HttpError(status: Int, body: String) extends HttpResponse
+
+case class ContentType(mediaType: String, charset: String)
+
+trait HttpProvider {
+  def post(url: String, contentType: ContentType, body: Array[Byte]): Future[HttpResponse]
+
+  def get(url: String): Future[HttpResponse]
+}

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/NextGenApiClient.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/NextGenApiClient.scala
@@ -1,0 +1,58 @@
+package com.gu.mobile.notifications.client
+
+import java.util.UUID
+
+import com.gu.mobile.notifications.client.models.{BreakingNewsPayload, NotificationPayload, Topic}
+import play.api.libs.json.Json
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class NextGenResponse(id: String)
+
+object NextGenResponse {
+  implicit val jf = Json.format[NextGenResponse]
+}
+
+protected class NextGenApiClient(
+  val host: String,
+  val apiKey: String,
+  val httpProvider: HttpProvider,
+  val clientId: String = "nextGen"
+) extends SimpleHttpApiClient {
+
+  private val url = s"$host/push/topic?api-key=$apiKey"
+
+  override def send(notificationPayload: NotificationPayload)(implicit ec: ExecutionContext): Future[Either[ApiClientError, Unit]] = {
+
+    def doSend(payload: NotificationPayload): Future[Either[ApiClientError, Unit]] = {
+      val json = Json.stringify(Json.toJson(payload))
+      postJson(url, json) map {
+        case error: HttpError => Left(ApiHttpError(error.status, Some(error.body)))
+        case HttpOk(201, body) => validateFormat[NextGenResponse](body)
+        case HttpOk(code, body) => Left(UnexpectedApiResponseError(s"Server returned status code $code and body:$body"))
+      } recover {
+        case e: Exception => Left(HttpProviderError(e))
+      }
+    }
+
+    def doSendOncePerTopic(payload: BreakingNewsPayload): Future[Either[ApiClientError, Unit]] = {
+      val results = payload.topic
+        .map(topic => payload.copy(topic = List(topic), id = UUID.randomUUID()))
+        .map(doSend)
+      Future.sequence(results).map { responses =>
+        responses.collect { case Left(error) => error } match {
+          case Nil => Right(())
+          case onlyOneError :: Nil => Left(onlyOneError)
+          case errors: List[ApiClientError] => Left(UnexpectedApiResponseError(errors.map(_.description).mkString(", ")))
+        }
+      }
+    }
+
+    notificationPayload match {
+      case breakingNews: BreakingNewsPayload if breakingNews.topic.size > 1 => doSendOncePerTopic(breakingNews)
+      case _ => doSend(notificationPayload)
+    }
+  }
+
+}
+

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/lib/JsonFormatsHelper.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/lib/JsonFormatsHelper.scala
@@ -1,0 +1,72 @@
+package com.gu.mobile.notifications.client.lib
+
+import java.net.URI
+
+import play.api.libs.json._
+import play.api.libs.json.JsObject
+import play.api.libs.json.JsString
+
+import scala.util.Try
+
+object JsonFormatsHelper {
+  implicit class RichJsObject(obj: JsObject) {
+    def +:(kv: (String, JsValue)): JsObject = obj match {
+      case JsObject(entries) => JsObject(entries + kv)
+    }
+    def ++:(kv: Map[String, JsValue]): JsObject = obj match {
+      case JsObject(entries) => JsObject(kv ++: entries)
+    }
+  }
+
+  implicit class RichWrites[A](writes: Writes[A]) {
+    def withTypeString(typ: String): Writes[A] = writes transform { _ match {
+      case obj: JsObject => ("type" -> JsString(typ)) +: obj
+      case x: JsValue => x
+    }}
+
+    def withAdditionalFields(fields: Map[String, JsValue]): Writes[A] = writes transform { _ match {
+      case obj: JsObject => fields ++: obj
+      case x: JsValue => x
+    }}
+
+    def withAdditionalStringFields(fields: Map[String, String]): Writes[A] = withAdditionalFields(fields.mapValues(JsString))
+  }
+
+  implicit class RichReads[A](innerReads: Reads[A]) {
+    def withTypeString(typ: String): Reads[A] = new Reads[A] {
+      def reads(json: JsValue): JsResult[A] = json match {
+        case obj: JsObject if obj.value.get("type") == Some(JsString(typ)) => innerReads.reads(obj - "type")
+        case _: JsObject => JsError(s"Not of type $typ")
+        case _ => JsError("Not an object")
+      }
+    }
+  }
+
+  implicit class RichFormat[A](format: Format[A]) {
+    def withTypeString(typ: String): Format[A] = new Format[A] {
+      private val richWrites = new RichWrites[A](format).withTypeString(typ)
+      private val richReads = new RichReads[A](format).withTypeString(typ)
+      override def writes(o: A): JsValue = richWrites.writes(o)
+      override def reads(json: JsValue): JsResult[A] = richReads.reads(json)
+    }
+  }
+
+  class TypedSubclassReads[A](val subClassReads: List[Reads[_ <: A]]) extends Reads[A] {
+    def reads(json: JsValue): JsResult[A] = {
+      def iter(reads: List[Reads[_ <: A]]): JsResult[A] = reads match {
+        case x :: xs => x.reads(json) orElse iter(xs)
+        case Nil => JsError("No match for typed subclasses")
+      }
+
+      iter(subClassReads)
+    }
+  }
+
+  implicit val urlFormat = new Format[URI] {
+    override def writes(o: URI): JsValue = JsString(o.toString)
+    override def reads(json: JsValue): JsResult[URI] = json match {
+      case JsString(uri) => Try(JsSuccess(new URI(uri))).getOrElse(JsError(s"Invalid uri: $uri"))
+      case _ => JsError("Invalid url type")
+    }
+  }
+}

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/models/Editions.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/models/Editions.scala
@@ -1,0 +1,53 @@
+package com.gu.mobile.notifications.client.models
+
+import com.gu.mobile.notifications.client.models.Topic._
+import com.gu.mobile.notifications.client.models.TopicTypes.Breaking
+import play.api.libs.json._
+
+object Editions {
+
+  val regions: Map[String, Edition] = Map(
+    "uk" -> UK,
+    "us" -> US,
+    "au" -> AU,
+    "international" -> International
+  )
+
+  sealed trait Edition
+
+  case object UK extends Edition {
+    override val toString = "uk"
+  }
+
+  case object US extends Edition {
+    override val toString = "us"
+  }
+
+  case object AU extends Edition {
+    override val toString = "au"
+  }
+
+  case object International extends Edition {
+    override val toString = "international"
+  }
+
+  object Edition {
+
+    def fromTopic(t: Topic): Option[Edition] = t match {
+      case Topic(Breaking, x) => regions.get(x)
+      case _ => None
+    }
+
+    implicit val jf = new Format[Edition] {
+      override def reads(json: JsValue): JsResult[Edition] = json match {
+        case JsString("uk") => JsSuccess(UK)
+        case JsString("us") => JsSuccess(US)
+        case JsString("au") => JsSuccess(AU)
+        case JsString("international") => JsSuccess(International)
+        case JsString(unknown) => JsError(s"Unkown region [$unknown]")
+        case _ => JsError(s"Unknown type $json")
+      }
+      override def writes(region: Edition): JsValue = JsString(region.toString)
+    }
+  }
+}

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/models/Healthcheck.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/models/Healthcheck.scala
@@ -1,0 +1,5 @@
+package com.gu.mobile.notifications.client.models
+
+sealed trait Healthcheck
+case object Ok extends Healthcheck
+case class Unhealthy(errorCode: Option[Int] = None) extends Healthcheck

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/models/Importance.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/models/Importance.scala
@@ -1,0 +1,16 @@
+package com.gu.mobile.notifications.client.models
+
+import play.api.libs.json.{JsValue, JsString, Writes}
+
+object Importance {
+  sealed trait Importance
+  case object Minor extends Importance
+  case object Major extends Importance
+
+  implicit val jf = new Writes[Importance] {
+    override def writes(o: Importance): JsValue = o match {
+      case Minor => JsString("Minor")
+      case Major => JsString("Major")
+    }
+  }
+}

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/models/NotificationPayloadType.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/models/NotificationPayloadType.scala
@@ -1,0 +1,24 @@
+package com.gu.mobile.notifications.client.models
+
+import play.api.libs.json._
+
+sealed trait NotificationPayloadType
+
+object NotificationPayloadType {
+
+  case object BreakingNews extends NotificationPayloadType {
+    override def toString = "news"
+  }
+
+  case object ContentAlert extends NotificationPayloadType {
+    override def toString = "content"
+  }
+
+  case object FootballMatchStatus extends NotificationPayloadType {
+    override def toString = "football-match-status"
+  }
+
+  implicit val jf = new Writes[NotificationPayloadType] {
+    override def writes(nType: NotificationPayloadType): JsValue = JsString(nType.toString)
+  }
+}

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/models/Payloads.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/models/Payloads.scala
@@ -1,0 +1,201 @@
+package com.gu.mobile.notifications.client.models
+
+import java.net.URI
+import java.util.UUID
+
+import com.gu.mobile.notifications.client.lib.JsonFormatsHelper._
+import com.gu.mobile.notifications.client.models.Importance.Importance
+import play.api.libs.json._
+import NotificationPayloadType._
+sealed case class GuardianItemType(mobileAggregatorPrefix: String)
+object GuardianItemType {
+  implicit val jf = Json.writes[GuardianItemType]
+}
+
+object GITSection extends GuardianItemType("section")
+object GITTag extends GuardianItemType("latest")
+object GITContent extends GuardianItemType("item-trimmed")
+
+sealed trait Link
+object Link {
+  implicit val jf = new Writes[Link] {
+    override def writes(o: Link): JsValue = o match {
+      case l: ExternalLink => ExternalLink.jf.writes(l)
+      case l: GuardianLinkDetails => GuardianLinkDetails.jf.writes(l)
+    }
+  }
+}
+
+object ExternalLink { implicit val jf = Json.writes[ExternalLink] }
+case class ExternalLink(url: String) extends Link {
+  override val toString = url
+}
+case class GuardianLinkDetails(
+  contentApiId: String,
+  shortUrl: Option[String],
+  title: String,
+  thumbnail: Option[String],
+  git: GuardianItemType,
+  blockId: Option[String] = None) extends Link {
+  val webUrl = s"http://www.theguardian.com/$contentApiId"
+  override val toString = webUrl
+}
+
+object GuardianLinkDetails {
+  implicit val jf = Json.writes[GuardianLinkDetails]
+}
+
+sealed trait GoalType
+object OwnGoalType extends GoalType
+object PenaltyGoalType extends GoalType
+object DefaultGoalType extends GoalType
+
+object GoalType {
+  implicit val jf = new Writes[GoalType] {
+    override def writes(o: GoalType): JsValue = o match {
+      case OwnGoalType => JsString("Own")
+      case PenaltyGoalType => JsString("Penalty")
+      case DefaultGoalType => JsString("Default")
+    }
+  }
+}
+
+sealed trait NotificationPayload {
+  def id: UUID
+  def title: String
+  def `type`: NotificationPayloadType
+  def message: String
+  def thumbnailUrl: Option[URI]
+  def sender: String
+  def importance: Importance
+  def topic: List[Topic]
+  def debug: Boolean
+}
+
+object NotificationPayload {
+  implicit val jf = new Writes[NotificationPayload] {
+    override def writes(o: NotificationPayload): JsValue = o match {
+      case n: BreakingNewsPayload => BreakingNewsPayload.jf.writes(n)
+      case n: ContentAlertPayload => ContentAlertPayload.jf.writes(n)
+      case n: FootballMatchStatusPayload => FootballMatchStatusPayload.jf.writes(n)
+    }
+  }
+}
+sealed trait NotificationWithLink extends NotificationPayload {
+  def link: Link
+}
+
+object BreakingNewsPayload { val jf = Json.writes[BreakingNewsPayload] withTypeString BreakingNews.toString }
+case class BreakingNewsPayload(
+  id: UUID = UUID.randomUUID,
+  title: String = "The Guardian",
+  message: String,
+  thumbnailUrl: Option[URI],
+  sender: String,
+  link: Link,
+  imageUrl: Option[URI],
+  importance: Importance,
+  topic: List[Topic],
+  debug: Boolean
+) extends NotificationWithLink {
+  val `type` = BreakingNews
+}
+
+object ContentAlertPayload {
+  implicit val jf = new Writes[ContentAlertPayload] {
+    override def writes(o: ContentAlertPayload) = (Json.writes[ContentAlertPayload] withAdditionalStringFields Map("type" -> ContentAlert.toString, "id" -> o.id.toString)).writes(o)
+  }
+}
+
+case class ContentAlertPayload(
+  title: String,
+  message: String,
+  thumbnailUrl: Option[URI],
+  sender: String,
+  link: Link,
+  imageUrl: Option[URI] = None,
+  importance: Importance,
+  topic: List[Topic],
+  debug: Boolean
+) extends NotificationWithLink with derivedId {
+  val `type` = ContentAlert
+
+  override val derivedId: String = {
+    def newContentIdentifier(contentApiId: String) = s"contentNotifications/newArticle/$contentApiId"
+    def newBlockIdentifier(contentApiId: String, blockId: String) = s"contentNotifications/newBlock/$contentApiId/$blockId"
+
+    val contentCoordinates = link match {
+      case GuardianLinkDetails(contentApiId, _, _, _, _, blockId) => (Some(contentApiId), blockId)
+      case _ => (None, None)
+    }
+
+    contentCoordinates match {
+      case (Some(contentApiId), Some(blockId)) => newBlockIdentifier(contentApiId, blockId)
+      case (Some(contentApiId), None) => newContentIdentifier(contentApiId)
+      case (None, _) => UUID.randomUUID.toString
+    }
+  }
+}
+
+object FootballMatchStatusPayload {
+  implicit val jf = new Writes[FootballMatchStatusPayload] {
+    // more than 22 fields so I have to define that manually
+    override def writes(o: FootballMatchStatusPayload): JsValue = Json.obj(
+      "id" -> o.id,
+      "type" -> FootballMatchStatus.toString,
+      "title" -> o.title,
+      "message" -> o.message,
+      "thumbnailUrl" -> o.thumbnailUrl,
+      "sender" -> o.sender,
+      "awayTeamName" -> o.awayTeamName,
+      "awayTeamScore" -> o.awayTeamScore,
+      "awayTeamMessage" -> o.awayTeamMessage,
+      "awayTeamId" -> o.awayTeamId,
+      "homeTeamName" -> o.homeTeamName,
+      "homeTeamScore" -> o.homeTeamScore,
+      "homeTeamMessage" -> o.homeTeamMessage,
+      "homeTeamId" -> o.homeTeamId,
+      "competitionName" -> o.competitionName,
+      "venue" -> o.venue,
+      "matchId" -> o.matchId,
+      "matchInfoUri" -> o.matchInfoUri,
+      "articleUri" -> o.articleUri,
+      "importance" -> o.importance,
+      "topic" -> o.topic,
+      "matchStatus" -> o.matchStatus,
+      "eventId" -> o.eventId,
+      "debug" -> o.debug
+    )
+  }
+}
+case class FootballMatchStatusPayload(
+  title: String,
+  message: String,
+  thumbnailUrl: Option[URI] = None,
+  sender: String,
+  awayTeamName: String,
+  awayTeamScore: Int,
+  awayTeamMessage: String,
+  awayTeamId: String,
+  homeTeamName: String,
+  homeTeamScore: Int,
+  homeTeamMessage: String,
+  homeTeamId: String,
+  competitionName: Option[String],
+  venue: Option[String],
+  matchId: String,
+  matchInfoUri: URI,
+  articleUri: Option[URI],
+  importance: Importance,
+  topic: List[Topic],
+  matchStatus: String,
+  eventId: String,
+  debug: Boolean
+) extends NotificationPayload with derivedId {
+  val `type` = FootballMatchStatus
+  override val derivedId = s"football-match-status/$matchId/$eventId"
+}
+trait derivedId {
+  val derivedId: String
+  lazy val id = UUID.nameUUIDFromBytes(derivedId.getBytes)
+}

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/models/SendNotificationReply.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/models/SendNotificationReply.scala
@@ -1,0 +1,10 @@
+package com.gu.mobile.notifications.client.models
+
+import play.api.libs.json.Json
+
+/** Acknowledgement of notification with a message ID for looking up statistics on that message */
+case class SendNotificationReply(messageId: String)
+
+object SendNotificationReply {
+  implicit val jf = Json.format[SendNotificationReply]
+}

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/models/Topic.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/models/Topic.scala
@@ -1,0 +1,40 @@
+package com.gu.mobile.notifications.client.models
+
+import com.gu.mobile.notifications.client.models.Editions._
+import com.gu.mobile.notifications.client.models.TopicTypes._
+import play.api.libs.json._
+
+sealed trait TopicType
+
+object TopicType {
+  implicit val jf = new Writes[TopicType] {
+    override def writes(o: TopicType): JsValue = JsString(o.toString)
+  }
+}
+
+object TopicTypes {
+  case object Breaking extends TopicType { override val toString = "breaking" }
+  case object Content extends TopicType { override val toString = "content" }
+  case object TagContributor extends TopicType { override val toString = "tag-contributor" }
+  case object TagKeyword extends TopicType { override val toString = "tag-keyword" }
+  case object TagSeries extends TopicType { override val toString = "tag-series" }
+  case object TagBlog extends TopicType { override val toString = "tag-blog" }
+  case object FootballTeam extends TopicType { override val toString = "football-team" }
+  case object FootballMatch extends TopicType { override val toString = "football-match" }
+  case object User extends TopicType { override val toString = "user-type" }
+  case object Newsstand extends TopicType { override val toString = "newsstand" }
+}
+
+case class Topic(`type`: TopicType, name: String) {
+  def toTopicString = `type`.toString + "//" + name
+}
+object Topic {
+  implicit val jf = Json.writes[Topic]
+  val BreakingNewsUk = Topic(Breaking, UK.toString)
+  val BreakingNewsUs = Topic(Breaking, US.toString)
+  val BreakingNewsAu = Topic(Breaking, AU.toString)
+  val BreakingNewsInternational = Topic(Breaking, International.toString)
+  val BreakingNewsSport = Topic(Breaking, "sport")
+  val NewsstandIos = Topic(Newsstand, "newsstandIos")
+}
+

--- a/api-client/src/test/scala/com/gu/mobile/notifications/client/ApiClientSpec.scala
+++ b/api-client/src/test/scala/com/gu/mobile/notifications/client/ApiClientSpec.scala
@@ -1,0 +1,37 @@
+package com.gu.mobile.notifications.client
+
+import org.specs2.execute.Result
+import org.specs2.mock.Mockito
+import org.specs2.mock.mockito.ArgumentCapture
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+
+import scala.concurrent.Future
+
+
+trait ApiClientSpec[C <: ApiClient] extends Specification with Mockito {
+  val host = "http://host.co.uk"
+  val apiKey = "apiKey"
+
+  def getTestApiClient(httpProvider: HttpProvider): C
+  def expectedPostUrl: String
+  def expectedPostBody: String
+
+  def apiTest(serverResponse: HttpResponse)(test: C => Unit): Result = {
+    val fakeHttpProvider = mock[HttpProvider]
+    fakeHttpProvider.post(anyString, any[ContentType], any[Array[Byte]]) returns Future.successful(serverResponse)
+
+    val testApiClient = getTestApiClient(fakeHttpProvider)
+   
+    test(testApiClient)
+
+    val bodyCapture = new ArgumentCapture[Array[Byte]]
+    val urlCapture = new ArgumentCapture[String]
+    val contentTypeCapture = new ArgumentCapture[ContentType]
+
+    there was one(fakeHttpProvider).post(urlCapture, contentTypeCapture, bodyCapture)
+    urlCapture.value mustEqual expectedPostUrl
+    contentTypeCapture.value mustEqual ContentType("application/json", "UTF-8")
+    Json.parse(bodyCapture.value) mustEqual Json.parse(expectedPostBody)
+  }
+}

--- a/api-client/src/test/scala/com/gu/mobile/notifications/client/NextGenApiClientSpec.scala
+++ b/api-client/src/test/scala/com/gu/mobile/notifications/client/NextGenApiClientSpec.scala
@@ -1,0 +1,89 @@
+package com.gu.mobile.notifications.client
+
+import com.gu.mobile.notifications.client.models.TopicTypes._
+import com.gu.mobile.notifications.client.models._
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.execute.Result
+import org.specs2.mock.mockito.ArgumentCapture
+import play.api.libs.json.Json
+import scala.collection.JavaConverters._
+
+import scala.concurrent.Future
+
+
+class NextGenApiClientSpec(implicit ee: ExecutionEnv) extends ApiClientSpec[NextGenApiClient] {
+
+  val payload = BreakingNewsPayload(
+    title = "myTitle",
+    message = "myMessage",
+    sender = "test sender",
+    imageUrl = None,
+    thumbnailUrl = None,
+    link = ExternalLink("http://mylink"),
+    importance = Importance.Major,
+    topic = List(Topic(Breaking, "n1")),
+    debug = true
+  )
+
+  val expectedPostUrl = s"$host/push/topic?api-key=$apiKey"
+  val expectedPostBody = Json.stringify(Json.toJson(payload))
+
+  override def getTestApiClient(httpProvider: HttpProvider) = new NextGenApiClient(
+    apiKey = apiKey,
+    httpProvider = httpProvider,
+    host = host
+  )
+  def apiTest(test: NextGenApiClient => Unit): Result = {
+    val successServerResponse = HttpOk(201, """{"id":"someId"}""")
+    apiTest(successServerResponse)(test)
+  }
+
+  "NextGenApiClient" should {
+    "successfully send payload" in apiTest {
+      client => client.send(payload) must beRight.await
+    }
+    "successfully send multiple HTTP calls for breaking news with more than one tag" in {
+      val payLoadMultipleTopics = payload.copy(topic = List(Topic(Breaking, "n1"), Topic(Breaking, "n2")))
+
+      val fakeHttpProvider = mock[HttpProvider]
+      fakeHttpProvider.post(anyString, any[ContentType], any[Array[Byte]]) returns Future.successful(HttpOk(201, """{"id":"someId"}"""))
+
+      val testApiClient = getTestApiClient(fakeHttpProvider)
+      testApiClient.send(payLoadMultipleTopics)
+
+      val bodyCapture = new ArgumentCapture[Array[Byte]]
+      val urlCapture = new ArgumentCapture[String]
+      val contentTypeCapture = new ArgumentCapture[ContentType]
+
+      there was two(fakeHttpProvider).post(urlCapture, contentTypeCapture, bodyCapture)
+      urlCapture.value mustEqual expectedPostUrl
+      contentTypeCapture.value mustEqual ContentType("application/json", "UTF-8")
+      val ids = bodyCapture.values
+        .asScala.toList
+        .map(Json.parse)
+        .map(_ \ "id")
+      ids(0) mustNotEqual ids(1)
+    }
+    "return HttpApiError error if http provider returns ApiHttpError" in apiTest(serverResponse = HttpError(500, "")) {
+      client => client.send(payload) must beEqualTo(Left(ApiHttpError(status = 500, Some("")))).await
+    }
+    "return UnexpectedApiResponseError if server returns invalid json" in apiTest(serverResponse = HttpOk(201, "not valid json at all")) {
+      client => client.send(payload) must beEqualTo(Left(UnexpectedApiResponseError("not valid json at all"))).await
+    }
+    "return UnexpectedApiResponseError if server returns wrong json format" in apiTest(serverResponse = HttpOk(201, """{"unexpected":"yes"}""")) {
+      client => client.send(payload) must beEqualTo(Left(UnexpectedApiResponseError("""{"unexpected":"yes"}"""))).await
+    }
+    "return UnexpectedApiResponseError if server returns wrong success status code" in apiTest(serverResponse = HttpOk(200, "success but not code 201!")) {
+      client => client.send(payload) must beEqualTo(Left(UnexpectedApiResponseError("Server returned status code 200 and body:success but not code 201!"))).await
+    }
+
+    "return HttpProviderError if http provider throws exception" in {
+      val throwable = new RuntimeException("something went wrong!!")
+      val fakeHttpProvider = mock[HttpProvider]
+      fakeHttpProvider.post(anyString, any[ContentType], any[Array[Byte]]) returns Future.failed(throwable)
+      val client = getTestApiClient(fakeHttpProvider)
+      client.send(payload) must beEqualTo(Left(HttpProviderError(throwable))).await
+    }
+  }
+
+}

--- a/api-client/src/test/scala/com/gu/mobile/notifications/client/models/LinkTest.scala
+++ b/api-client/src/test/scala/com/gu/mobile/notifications/client/models/LinkTest.scala
@@ -1,0 +1,19 @@
+package com.gu.mobile.notifications.client.models
+
+import org.specs2.mutable.Specification
+
+class LinkTest extends Specification {
+
+  "toString" should {
+    "return the url if the Link is of type ExternalLink" in {
+      val link = ExternalLink("myLink")
+      link.toString mustEqual "myLink"
+    }
+
+    "return the correct link if the Link is of type GuardianLinkDetails" in {
+      val link = GuardianLinkDetails("myLink1", Some("http://shortUrl"),"myTitle", None, GITContent)
+      link.toString mustEqual link.webUrl
+    }
+  }
+
+}

--- a/api-client/src/test/scala/com/gu/mobile/notifications/client/models/PayloadsSpec.scala
+++ b/api-client/src/test/scala/com/gu/mobile/notifications/client/models/PayloadsSpec.scala
@@ -1,0 +1,146 @@
+package com.gu.mobile.notifications.client.models
+
+import java.net.URI
+import java.util.UUID
+
+import com.gu.mobile.notifications.client.models.TopicTypes._
+import com.gu.mobile.notifications.client.models.Topic._
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import play.api.libs.json.Json
+
+
+class PayloadsSpec extends Specification {
+
+
+  "NotificationPayload" should {
+    def verifySerialization(payload: NotificationPayload, expectedJson: String) = Json.toJson(payload) shouldEqual Json.parse(expectedJson)
+
+    "define serializable Breaking News payload" in {
+
+      val payload = BreakingNewsPayload(
+        id = UUID.fromString("30aac5f5-34bb-4a88-8b69-97f995a4907b"),
+        title = "The Guardian",
+        message = "Mali hotel attack: UN counts 27 bodies as hostage situation ends",
+        sender = "test",
+        imageUrl = Some(new URI("https://mobile.guardianapis.com/img/media/a5fb401022d09b2f624a0cc0484c563fd1b6ad93/0_308_4607_2764/master/4607.jpg/6ad3110822bdb2d1d7e8034bcef5dccf?width=800&height=-&quality=85")),
+        thumbnailUrl = Some(new URI("http://media.guim.co.uk/09951387fda453719fe1fee3e5dcea4efa05e4fa/0_181_3596_2160/140.jpg")),
+        link = ExternalLink("http://mylink"),
+        importance = Importance.Major,
+        topic = List(BreakingNewsUk),
+        debug = true
+      )
+      val expectedJson =
+        """
+          |{
+          |  "id" : "30aac5f5-34bb-4a88-8b69-97f995a4907b",
+          |  "title" : "The Guardian",
+          |  "type" : "news",
+          |  "message" : "Mali hotel attack: UN counts 27 bodies as hostage situation ends",
+          |  "thumbnailUrl" : "http://media.guim.co.uk/09951387fda453719fe1fee3e5dcea4efa05e4fa/0_181_3596_2160/140.jpg",
+          |  "sender": "test",
+          |  "link" : {
+          |    "url": "http://mylink"
+          |  },
+          |  "imageUrl" : "https://mobile.guardianapis.com/img/media/a5fb401022d09b2f624a0cc0484c563fd1b6ad93/0_308_4607_2764/master/4607.jpg/6ad3110822bdb2d1d7e8034bcef5dccf?width=800&height=-&quality=85",
+          |  "importance" : "Major",
+          |  "topic" : [ {
+          |    "type" : "breaking",
+          |    "name" : "uk"
+          |  } ],
+          |  "debug":true
+          |}
+        """.stripMargin
+
+      verifySerialization(payload, expectedJson)
+    }
+
+    "define derived id for new article" in new ContentAlertScope {
+      payload.derivedId mustEqual ("contentNotifications/newArticle/environment/ng-interactive/2015/oct/16/which-countries-are-doing-the-most-to-stop-dangerous-global-warming")
+    }
+
+    "define derived id for new liveblog block" in new ContentAlertScope {
+      val liveBlogLink = internalLink.copy(blockId = Some("block123456"))
+      val liveblogPayload = payload.copy(link = liveBlogLink)
+      liveblogPayload.derivedId mustEqual ("contentNotifications/newBlock/environment/ng-interactive/2015/oct/16/which-countries-are-doing-the-most-to-stop-dangerous-global-warming/block123456")
+    }
+
+    "define serializable Content Alert payload" in new ContentAlertScope{
+      val expectedJson =
+        """
+          |{
+          |  "id" : "7c555802-2658-3656-9fda-b4f044a241cc",
+          |  "title" : "Follow",
+          |  "type" : "content",
+          |  "message" : "Which countries are doing the most to stop dangerous global warming?",
+          |  "thumbnailUrl" : "http://media.guim.co.uk/a07334e4ed5d13d3ecf4c1ac21145f7f4a099f18/127_0_3372_2023/140.jpg",
+          |  "sender" : "test",
+          |  "link" : {
+          |    "contentApiId" : "environment/ng-interactive/2015/oct/16/which-countries-are-doing-the-most-to-stop-dangerous-global-warming",
+          |    "shortUrl":"http:short.com",
+          |    "title":"linkTitle",
+          |    "thumbnail":"http://thumb.om",
+          |    "git":{"mobileAggregatorPrefix":"item-trimmed"}
+          |  },
+          |  "importance" : "Minor",
+          |  "topic" : [ {
+          |    "type" : "tag-series",
+          |    "name" : "environment/series/keep-it-in-the-ground"
+          |  },{
+          |    "type" : "breaking",
+          |    "name" : "n2"
+          |    }],
+          |    "debug" : false
+          |}
+        """.stripMargin
+      verifySerialization(payload, expectedJson)
+    }
+
+    "define seriazable goal types" in {
+      def verifySerialization(gType: GoalType, expectedJson: String) = Json.toJson(gType) shouldEqual Json.parse(expectedJson)
+      verifySerialization(OwnGoalType, "\"Own\"")
+      verifySerialization(PenaltyGoalType, "\"Penalty\"")
+      verifySerialization(DefaultGoalType, "\"Default\"")
+    }
+    "define serializable guardian link details" in {
+      def verifySerialization(link: GuardianLinkDetails, expectedJson: String) = Json.toJson(link) shouldEqual Json.parse(expectedJson)
+
+      verifySerialization(
+        link = GuardianLinkDetails("cApiId", Some("url"), "someTitle", Some("thumb"), GITSection),
+        expectedJson = """{"contentApiId":"cApiId","shortUrl":"url","title":"someTitle","thumbnail":"thumb","git":{"mobileAggregatorPrefix":"section"}}"""
+      )
+
+      verifySerialization(
+        link = GuardianLinkDetails("cApiId", Some("url"), "someOtherTitle", Some("thumb"), GITTag),
+        expectedJson = """{"contentApiId":"cApiId","shortUrl":"url","title":"someOtherTitle","thumbnail":"thumb","git":{"mobileAggregatorPrefix":"latest"}}"""
+      )
+
+      verifySerialization(
+        link = GuardianLinkDetails("cApiId", Some("url"), "someTitle", Some("thumb"), GITContent),
+        expectedJson = """{"contentApiId":"cApiId","shortUrl":"url","title":"someTitle","thumbnail":"thumb","git":{"mobileAggregatorPrefix":"item-trimmed"}}"""
+      )
+
+    }
+  }
+}
+
+trait ContentAlertScope extends Scope {
+
+  val internalLink = GuardianLinkDetails(
+    contentApiId = "environment/ng-interactive/2015/oct/16/which-countries-are-doing-the-most-to-stop-dangerous-global-warming",
+    shortUrl = Some("http:short.com"),
+    title = "linkTitle",
+    thumbnail = Some("http://thumb.om"),
+    git = GITContent)
+
+  val payload = ContentAlertPayload(
+    title = "Follow",
+    message = "Which countries are doing the most to stop dangerous global warming?",
+    thumbnailUrl = Some(new URI("http://media.guim.co.uk/a07334e4ed5d13d3ecf4c1ac21145f7f4a099f18/127_0_3372_2023/140.jpg")),
+    sender = "test",
+    link = internalLink,
+    importance = Importance.Minor,
+    topic = List(Topic(TagSeries, "environment/series/keep-it-in-the-ground"), Topic(Breaking, "n2")),
+    debug = false)
+
+}

--- a/api-client/version.sbt
+++ b/api-client/version.sbt
@@ -1,0 +1,1 @@
+version := "1.3-SNAPSHOT"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,3 +19,9 @@ libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.10.0"
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.1")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.1")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")


### PR DESCRIPTION
Moving mobile-notifications-api-client into mobile-n10n a sub project
Only slight concern is whether release still works.
` sbt "project api-client" release` does start the release process, but not completed it yet.