### PR TITLE
Disable the frontend notification

### DIFF
--- a/notification/app/notification/NotificationApplicationLoader.scala
+++ b/notification/app/notification/NotificationApplicationLoader.scala
@@ -54,7 +54,7 @@ class NotificationApplicationComponents(context: Context) extends BuiltInCompone
     gcmNotificationSender,
     apnsNotificationSender,
     newsstandShardNotificationSender,
-    frontendAlerts,
+    //frontendAlerts, //disabled until frontend decides whether to fix this feature or not.
     fcmNotificationSender
   )
   lazy val mainController = wire[Main]


### PR DESCRIPTION
This used to be used to push notification to the website. The website would then use that event to show a banner at the bottom of the page.
Since Garnett that feature has been unmaintained and broke at some point. We have been getting 503s in our logs for months and dotcom isn't quite sure if they will fix it or not.

So for now I'm disabling it until further notice