### PR TITLE
rename notificationId to id

### DIFF
--- a/notification/app/notification/models/ios/Notification.scala
+++ b/notification/app/notification/models/ios/Notification.scala
@@ -14,7 +14,7 @@ sealed trait Notification {
 }
 
 case class BreakingNewsNotification(
-  notificationId: UUID,
+  id: UUID,
   notificationType: NotificationType = BreakingNews,
   `type`: String = MessageTypes.NewsAlert,
   category: String,
@@ -36,7 +36,7 @@ case class BreakingNewsNotification(
       sound = Some("default")
     ),
     customProperties = LegacyProperties(Map(
-      Keys.UniqueIdentifier -> notificationId.toString,
+      Keys.UniqueIdentifier -> id.toString,
       Keys.Provider -> Provider.Azure,
       Keys.MessageType -> `type`,
       Keys.NotificationType -> notificationType.value,
@@ -49,7 +49,7 @@ case class BreakingNewsNotification(
 }
 
 case class ContentNotification(
-  notificationId: UUID,
+  id: UUID,
   notificationType: NotificationType = Content,
   `type`: String = MessageTypes.NewsAlert,
   category: String,
@@ -68,7 +68,7 @@ case class ContentNotification(
       sound = Some("default")
     ),
     customProperties = LegacyProperties(Map(
-      Keys.UniqueIdentifier -> notificationId.toString,
+      Keys.UniqueIdentifier -> id.toString,
       Keys.Provider -> Provider.Azure,
       Keys.MessageType -> `type`,
       Keys.NotificationType -> notificationType.value,
@@ -141,7 +141,7 @@ case class ElectionNotification(
   )
 }
 
-case class LiveEventNotification(notificationId: UUID, liveEvent: LiveEventProperties) extends Notification {
+case class LiveEventNotification(id: UUID, liveEvent: LiveEventProperties) extends Notification {
   def payload: Body = Body(
     aps = APS(
       alert = None,
@@ -149,7 +149,7 @@ case class LiveEventNotification(notificationId: UUID, liveEvent: LiveEventPrope
       sound = None
     ),
     customProperties = StandardProperties(
-      uniqueIdentifier = notificationId,
+      uniqueIdentifier = id,
       provider = Provider.Azure,
       t = MessageTypes.LiveEventAlert,
       notificationType = LiveEventAlert,
@@ -159,7 +159,7 @@ case class LiveEventNotification(notificationId: UUID, liveEvent: LiveEventPrope
 }
 
 case class FootballMatchStatusNotification(
-  notificationId: UUID,
+  id: UUID,
   title: String,
   body: String,
   matchStatus: FootballMatchStatusProperties,
@@ -173,7 +173,7 @@ case class FootballMatchStatusNotification(
       `mutable-content` = Some(1)
     ),
     customProperties = StandardProperties(
-      uniqueIdentifier = notificationId,
+      uniqueIdentifier = id,
       provider = Provider.Azure,
       t = MessageTypes.FootballMatchStatus,
       notificationType = FootballMatchStatus,

--- a/notification/app/notification/services/azure/APNSPushConverter.scala
+++ b/notification/app/notification/services/azure/APNSPushConverter.scala
@@ -33,7 +33,7 @@ class APNSPushConverter(conf: Configuration) extends AzurePushConverter {
     val link = toPlatformLink(breakingNews.link)
 
     ios.BreakingNewsNotification(
-      notificationId = breakingNews.id,
+      id = breakingNews.id,
       category = breakingNews.link match {
         case _: Link.External => ""
         case _: Link.Internal => "ITEM_CATEGORY"
@@ -52,7 +52,7 @@ class APNSPushConverter(conf: Configuration) extends AzurePushConverter {
     val link = toPlatformLink(cn.link)
 
     ios.ContentNotification(
-      notificationId = cn.id,
+      id = cn.id,
       category = "ITEM_CATEGORY",
       message = if (cn.iosUseMessage.contains(true)) cn.message else cn.title,
       link = toIosLink(cn.link),
@@ -84,7 +84,7 @@ class APNSPushConverter(conf: Configuration) extends AzurePushConverter {
 
   private def toLiveEventAlert(liveEvent: LiveEventNotification) = {
     ios.LiveEventNotification(
-      notificationId = liveEvent.id,
+      id = liveEvent.id,
       liveEvent = LiveEventProperties(
         title = liveEvent.title,
         body = liveEvent.message,
@@ -100,7 +100,7 @@ class APNSPushConverter(conf: Configuration) extends AzurePushConverter {
 
   private def toMatchStatusAlert(matchStatus: FootballMatchStatusNotification) = {
     ios.FootballMatchStatusNotification(
-      notificationId = matchStatus.id,
+      id = matchStatus.id,
       title = matchStatus.title,
       body = matchStatus.message,
       matchStatus = FootballMatchStatusProperties(

--- a/notification/app/notification/services/fcm/APNSConfigConverter.scala
+++ b/notification/app/notification/services/fcm/APNSConfigConverter.scala
@@ -37,7 +37,7 @@ class APNSConfigConverter(conf: Configuration) extends FCMConfigConverter[ApnsCo
   case class FirebaseApsAlert(title: String, body: String)
 
   case class FirebaseApnsNotification(
-    notificationId: UUID,
+    id: UUID,
     category: Option[String],
     alert: Option[Either[String, FirebaseApsAlert]],
     contentAvailable: Option[Boolean],
@@ -68,7 +68,7 @@ class APNSConfigConverter(conf: Configuration) extends FCMConfigConverter[ApnsCo
         .collect { case (key, Some(value)) => key -> value }
         .toMap
         .updated(Keys.Provider, Provider.FCM)
-        .updated(Keys.UniqueIdentifier, notificationId.toString)
+        .updated(Keys.UniqueIdentifier, id.toString)
         .asJava
 
       apnsConfigBuilder.putAllHeaders(Map(
@@ -85,7 +85,7 @@ class APNSConfigConverter(conf: Configuration) extends FCMConfigConverter[ApnsCo
     val link = toPlatformLink(cn.link)
 
     FirebaseApnsNotification(
-      notificationId = cn.id,
+      id = cn.id,
       category = Some("ITEM_CATEGORY"),
       alert = if (cn.iosUseMessage.contains(true)) Some(Left(cn.message)) else Some(Left(cn.title)),
       contentAvailable = Some(true),
@@ -111,7 +111,7 @@ class APNSConfigConverter(conf: Configuration) extends FCMConfigConverter[ApnsCo
     val imageUrl = breakingNews.thumbnailUrl orElse breakingNews.imageUrl
 
     FirebaseApnsNotification(
-      notificationId = breakingNews.id,
+      id = breakingNews.id,
       category = category,
       alert = Some(Left(breakingNews.message)),
       contentAvailable = Some(true),
@@ -130,7 +130,7 @@ class APNSConfigConverter(conf: Configuration) extends FCMConfigConverter[ApnsCo
 
   private def toMatchStatusAlert(matchStatus: FootballMatchStatusNotification): FirebaseApnsNotification = {
     FirebaseApnsNotification(
-      notificationId = matchStatus.id,
+      id = matchStatus.id,
       category = Some("football-match"),
       alert = Some(Right(FirebaseApsAlert(matchStatus.title, matchStatus.message))),
       contentAvailable = Some(true),

--- a/notification/app/notification/services/fcm/AndroidConfigConverter.scala
+++ b/notification/app/notification/services/fcm/AndroidConfigConverter.scala
@@ -22,13 +22,13 @@ class AndroidConfigConverter(conf: Configuration) extends FCMConfigConverter[And
   override def toFCM(push: Push): Option[AndroidConfig] = toFirebaseAndroidNotification(push).map(_.toAndroidConfig)
 
   case class FirebaseAndroidNotification(
-    notificationId: UUID,
+    id: UUID,
     data: Map[String, String]
   ) {
     def toAndroidConfig: AndroidConfig =
       AndroidConfig.builder()
         .putAllData(data
-          .updated(Keys.UniqueIdentifier, notificationId.toString)
+          .updated(Keys.UniqueIdentifier, id.toString)
           .updated(Keys.Provider, Provider.FCM)
           .asJava
         ).setPriority(AndroidConfig.Priority.HIGH)
@@ -69,7 +69,7 @@ class AndroidConfigConverter(conf: Configuration) extends FCMConfigConverter[And
     val keyword = tagLink.map(new URI(_))
 
     FirebaseAndroidNotification(
-      notificationId = breakingNews.id,
+      id = breakingNews.id,
       Map(
         Keys.NotificationType -> breakingNews.`type`.value,
         Keys.Type -> AndroidMessageTypes.Custom,
@@ -95,7 +95,7 @@ class AndroidConfigConverter(conf: Configuration) extends FCMConfigConverter[And
     val link = toPlatformLink(cn.link)
 
     FirebaseAndroidNotification(
-      notificationId = cn.id,
+      id = cn.id,
       Map(
         Keys.Type -> AndroidMessageTypes.Custom,
         Keys.Title -> cn.title,
@@ -113,7 +113,7 @@ class AndroidConfigConverter(conf: Configuration) extends FCMConfigConverter[And
   }
 
   private def toMatchStatusAlert(matchStatusAlert: FootballMatchStatusNotification): FirebaseAndroidNotification = FirebaseAndroidNotification(
-    notificationId = matchStatusAlert.id,
+    id = matchStatusAlert.id,
     Map(
       "type" -> AndroidMessageTypes.FootballMatchAlert,
       "homeTeamName" -> matchStatusAlert.homeTeamName,

--- a/notification/test/notification/services/fcm/APNSConfigConverterSpec.scala
+++ b/notification/test/notification/services/fcm/APNSConfigConverterSpec.scala
@@ -37,7 +37,7 @@ class APNSConfigConverterSpec extends Specification {
 
 
       val expected = apnsConfigConverter.FirebaseApnsNotification(
-        notificationId = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
+        id = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
         category = Some("ITEM_CATEGORY"),
         alert = Some(Left("The message")),
         contentAvailable = Some(true),
@@ -76,7 +76,7 @@ class APNSConfigConverterSpec extends Specification {
 
 
       val expected = apnsConfigConverter.FirebaseApnsNotification(
-        notificationId = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
+        id = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
         category = Some("ITEM_CATEGORY"),
         alert = Some(Left("The message")),
         contentAvailable = Some(true),
@@ -127,7 +127,7 @@ class APNSConfigConverterSpec extends Specification {
       val apnsNotification = convert(push)
 
       val expected = apnsConfigConverter.FirebaseApnsNotification(
-        notificationId = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
+        id = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
         category = Some("football-match"),
         alert = Some(Right(apnsConfigConverter.FirebaseApsAlert("Test notification", "The message"))),
         contentAvailable = Some(true),

--- a/notification/test/notification/services/fcm/AndroidConfigConverterSpec.scala
+++ b/notification/test/notification/services/fcm/AndroidConfigConverterSpec.scala
@@ -35,7 +35,7 @@ class AndroidConfigConverterSpec extends Specification {
       val data = convert(push)
 
       data shouldEqual androidConfigConverter.FirebaseAndroidNotification(
-        notificationId = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
+        id = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
         data = Map(
           Keys.NotificationType -> "news",
           Keys.Type -> "custom",
@@ -73,7 +73,7 @@ class AndroidConfigConverterSpec extends Specification {
       val data = convert(push)
 
       data shouldEqual androidConfigConverter.FirebaseAndroidNotification(
-        notificationId = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
+        id = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
         data = Map(
           Keys.Type -> "custom",
           Keys.Title -> "Test notification",
@@ -122,7 +122,7 @@ class AndroidConfigConverterSpec extends Specification {
       val data = convert(push)
 
       data shouldEqual androidConfigConverter.FirebaseAndroidNotification(
-        notificationId = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
+        id = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
         data = Map(
           "type" -> "footballMatchAlert",
           "homeTeamName" -> "Team2",


### PR DESCRIPTION
Following https://github.com/guardian/mobile-n10n/pull/192 this is to make the property name more clear