### PR TITLE
Send token metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,9 +23,10 @@ val minJacksonLibs = Seq(
   "com.fasterxml.jackson.core" % "jackson-annotations" % minJacksonVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % minJacksonVersion
 )
+
 val playJsonVersion = "2.6.9"
 val specsVersion: String = "4.0.3"
-val awsSdkVersion: String = "1.11.388"
+val awsSdkVersion: String = "1.11.400"
 
 val standardSettings = Seq[Setting[_]](
   riffRaffManifestProjectName := s"mobile-n10n:${name.value}",
@@ -64,6 +65,7 @@ lazy val common = project
       "com.gu" %% "pa-client" % "6.1.0",
       "com.gu" %% "simple-configuration-ssm" % "1.5.0",
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
       "com.googlecode.concurrentlinkedhashmap" % "concurrentlinkedhashmap-lru" % "1.4.2",
       "ai.x" %% "play-json-extensions" % "0.10.0"
     ),

--- a/common/src/main/scala/metrics/MetricActor.scala
+++ b/common/src/main/scala/metrics/MetricActor.scala
@@ -1,0 +1,111 @@
+package metrics
+
+import akka.actor.Actor
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
+import com.amazonaws.services.cloudwatch.model.{MetricDatum, PutMetricDataRequest, StandardUnit, StatisticSet}
+import com.gu.{AppIdentity, AwsIdentity}
+
+import collection.JavaConverters._
+import play.api.{Environment, Logger, Mode}
+
+trait MetricActorLogic {
+
+  def cloudWatchClient: AmazonCloudWatchClient
+  def stage: String
+  def appName: String
+
+  private def aggregatePointsPerMetric(metricDataPoints: List[MetricDataPoint], metricName: String): MetricDatum = {
+    val (sum, min, max) = metricDataPoints.foldLeft((0d, Double.MaxValue, Double.MinValue)) { case ((aggSum, aggMin, aggMax), dataPoint) =>
+      (aggSum + dataPoint.value, aggMin.min(dataPoint.value), aggMax.max(dataPoint.value))
+    }
+
+    val stats = new StatisticSet
+    stats.setMaximum(max)
+    stats.setMinimum(min)
+    stats.setSum(sum)
+    stats.setSampleCount(metricDataPoints.size.toDouble)
+
+    val unit = metricDataPoints.headOption.map(_.unit).getOrElse(StandardUnit.None)
+
+    val metric = new MetricDatum()
+    metric.setMetricName(metricName)
+    metric.setUnit(unit)
+    metric.setStatisticValues(stats)
+
+    metric
+  }
+
+  private def aggregatePointsPerNamespaceBatches(points: List[MetricDataPoint]): List[(String, List[MetricDatum])] = {
+    val pointsPerMetric = points.groupBy { point => (point.namespace, point.name) }.toList
+    val allAwsMetrics = pointsPerMetric.map { case ((namespace, metricName), metricPoints) =>
+      namespace -> aggregatePointsPerMetric(metricPoints, metricName)
+    }
+    val metricsPerNamespace = allAwsMetrics.foldLeft(Map.empty[String, List[MetricDatum]]) {
+      case (agg, (namespace, awsPoint)) =>
+        val points = agg.getOrElse(namespace, Nil)
+        agg + (namespace -> (awsPoint :: points))
+    }
+
+    metricsPerNamespace.toList.flatMap { case (namespace, awsMetrics) =>
+      val awsMetricsBatches = awsMetrics.grouped(20)
+      awsMetricsBatches.map { batch =>
+        namespace -> batch
+      }
+    }
+  }
+
+  def aggregatePoints(points: List[MetricDataPoint]): Unit = {
+    if (points.isEmpty) {
+      Logger.debug(s"No metric sent to cloudwatch.")
+    } else {
+      val metricsPerNamespaceBatches = aggregatePointsPerNamespaceBatches(points)
+
+      val metricsCount = metricsPerNamespaceBatches.foldLeft(0) { case (sum, (_, batch)) => sum + batch.size }
+      val batchesCount = metricsPerNamespaceBatches.size
+      val namespacesCount = metricsPerNamespaceBatches.map(_._1).toSet.size
+
+      try {
+        metricsPerNamespaceBatches.foreach { case (namespace, awsMetricBatch) =>
+          val metricRequest = new PutMetricDataRequest()
+          metricRequest.setNamespace(s"$namespace/$stage/$appName")
+          metricRequest.setMetricData(awsMetricBatch.asJava)
+
+          cloudWatchClient.putMetricData(metricRequest)
+        }
+        Logger.info("Sent metrics to cloudwatch. " +
+          s"Data points: ${points.size}, " +
+          s"Metrics: $metricsCount, " +
+          s"Namespaces: $namespacesCount, " +
+          s"Batches: $batchesCount")
+      } catch {
+        case e: Exception => Logger.error(s"Unable to send metrics to cloudwatch", e)
+      }
+    }
+  }
+}
+
+class MetricActor(val cloudWatchClient: AmazonCloudWatchClient, val identity: AppIdentity, val env: Environment) extends Actor with MetricActorLogic {
+  var dataPoints = List.empty[MetricDataPoint]
+
+  override def stage: String = identity match {
+    case AwsIdentity(_, _, stage, _) => stage
+    case _ => "DEV"
+  }
+
+  override def appName: String = identity match {
+    case AwsIdentity(app, _, _, _) => app
+    case _ => "DEV"
+  }
+
+  override def receive: Receive = {
+    case metricDataPoint: MetricDataPoint if env.mode != Mode.Test =>
+      dataPoints = metricDataPoint :: dataPoints
+    case MetricActor.Aggregate =>
+      aggregatePoints(dataPoints)
+      dataPoints = Nil
+  }
+}
+
+object MetricActor {
+  case object Aggregate
+}

--- a/common/src/main/scala/metrics/MetricDataPoint.scala
+++ b/common/src/main/scala/metrics/MetricDataPoint.scala
@@ -1,0 +1,10 @@
+package metrics
+
+import com.amazonaws.services.cloudwatch.model.StandardUnit
+
+case class MetricDataPoint(
+  namespace: String = "Notifications",
+  name: String,
+  value: Double,
+  unit: StandardUnit = StandardUnit.None
+)

--- a/common/src/main/scala/metrics/Metrics.scala
+++ b/common/src/main/scala/metrics/Metrics.scala
@@ -1,0 +1,50 @@
+package metrics
+
+import akka.actor.{ActorSystem, Props}
+import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
+import play.api.Environment
+import play.api.inject.ApplicationLifecycle
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+
+trait Metrics {
+  def send(mdp: MetricDataPoint): Unit
+  def executionContext: ExecutionContext
+}
+
+class CloudWatchMetrics(applicationLifecycle: ApplicationLifecycle, env: Environment, app: App) extends Metrics {
+
+  private val actorSystem: ActorSystem = ActorSystem(
+    name = "Blocking-Cloudwatch-Metrics",
+    config = None,
+    classLoader = Some(env.classLoader),
+    defaultExecutionContext = None
+  )
+
+  applicationLifecycle.addStopHook( () => Future.successful(actorSystem.terminate()))
+
+  implicit val executionContext: ExecutionContext = actorSystem.dispatcher
+
+  private val cloudWatchClient: AmazonCloudWatch = {
+    val region = Option(Regions.getCurrentRegion).getOrElse(Region.getRegion(Regions.EU_WEST_1)).getName
+    AmazonCloudWatchClientBuilder.standard().withRegion(region).build
+  }
+
+  private val metricActor = actorSystem.actorOf(Props(classOf[MetricActor], cloudWatchClient, app, env))
+
+  actorSystem.scheduler.schedule(
+    initialDelay = 0.second,
+    interval = 1.minute,
+    receiver = metricActor,
+    message = MetricActor.Aggregate
+  )
+
+  def send(mdp: MetricDataPoint): Unit = metricActor ! mdp
+}
+
+object DummyMetrics extends Metrics {
+  def send(mdp: MetricDataPoint): Unit = {}
+  def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+}

--- a/common/src/main/scala/metrics/Metrics.scala
+++ b/common/src/main/scala/metrics/Metrics.scala
@@ -3,6 +3,7 @@ package metrics
 import akka.actor.{ActorSystem, Props}
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
+import com.gu.AppIdentity
 import play.api.Environment
 import play.api.inject.ApplicationLifecycle
 
@@ -14,7 +15,7 @@ trait Metrics {
   def executionContext: ExecutionContext
 }
 
-class CloudWatchMetrics(applicationLifecycle: ApplicationLifecycle, env: Environment, app: App) extends Metrics {
+class CloudWatchMetrics(applicationLifecycle: ApplicationLifecycle, env: Environment, identity: AppIdentity) extends Metrics {
 
   private val actorSystem: ActorSystem = ActorSystem(
     name = "Blocking-Cloudwatch-Metrics",
@@ -32,7 +33,7 @@ class CloudWatchMetrics(applicationLifecycle: ApplicationLifecycle, env: Environ
     AmazonCloudWatchClientBuilder.standard().withRegion(region).build
   }
 
-  private val metricActor = actorSystem.actorOf(Props(classOf[MetricActor], cloudWatchClient, app, env))
+  private val metricActor = actorSystem.actorOf(Props(classOf[MetricActor], cloudWatchClient, identity, env))
 
   actorSystem.scheduler.schedule(
     initialDelay = 0.second,

--- a/common/src/main/scala/utils/CustomApplicationLoader.scala
+++ b/common/src/main/scala/utils/CustomApplicationLoader.scala
@@ -8,7 +8,7 @@ import play.api.ApplicationLoader.Context
 import play.api._
 
 abstract class CustomApplicationLoader extends ApplicationLoader {
-  def buildComponents(context: Context): BuiltInComponents
+  def buildComponents(identity: AppIdentity, context: Context): BuiltInComponents
 
   lazy val credentials = new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider("mobile"),
@@ -23,6 +23,6 @@ abstract class CustomApplicationLoader extends ApplicationLoader {
     }
     val loadedConfig = Configuration(config)
     val newContext = context.copy(initialConfiguration = context.initialConfiguration ++ loadedConfig )
-    buildComponents(newContext).application
+    buildComponents(identity, newContext).application
   }
 }

--- a/notification/app/notification/NotificationApplicationLoader.scala
+++ b/notification/app/notification/NotificationApplicationLoader.scala
@@ -14,6 +14,7 @@ import _root_.models.NewsstandShardConfig
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.firebase.messaging.{AndroidConfig, FirebaseMessaging}
 import com.google.firebase.{FirebaseApp, FirebaseOptions}
+import com.gu.AppIdentity
 import com.gu.notificationschedule.dynamo.{NotificationSchedulePersistenceImpl, ScheduleTableConfig}
 import notification.authentication.NotificationAuthAction
 import notification.services.frontend.{FrontendAlerts, FrontendAlertsConfig}
@@ -22,7 +23,7 @@ import notification.services.azure._
 import notification.services.fcm.{APNSConfigConverter, AndroidConfigConverter, FCMConfigConverter, FCMNotificationSender}
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.routing.Router
-import play.api.BuiltInComponentsFromContext
+import play.api.{BuiltInComponents, BuiltInComponentsFromContext}
 import play.api.ApplicationLoader.Context
 import play.api.mvc.EssentialFilter
 import play.filters.HttpFiltersComponents
@@ -34,7 +35,7 @@ import router.Routes
 import scala.concurrent.Future
 
 class NotificationApplicationLoader extends CustomApplicationLoader {
-  def buildComponents(context: Context) = new NotificationApplicationComponents(context)
+  def buildComponents(identity: AppIdentity, context: Context): BuiltInComponents = new NotificationApplicationComponents(context)
 }
 
 class NotificationApplicationComponents(context: Context) extends BuiltInComponentsFromContext(context)

--- a/registration/test/registration/controllers/RegistrationsFixtures.scala
+++ b/registration/test/registration/controllers/RegistrationsFixtures.scala
@@ -1,6 +1,7 @@
 package registration.controllers
 
 import application.WithPlayApp
+import com.gu.DevIdentity
 import error.NotificationsError
 import models.TopicTypes.{Breaking, FootballMatch}
 import models._
@@ -107,7 +108,7 @@ trait RegistrationsBase extends WithPlayApp with RegistrationsJson {
   }
 
   override def configureComponents(context: Context): BuiltInComponents = {
-    new RegistrationApplicationComponents(context)  {
+    new RegistrationApplicationComponents(DevIdentity("notifications"), context)  {
       override lazy val topicValidator = fakeTopicValidator
       override lazy val registrarProvider: RegistrarProvider = fakeRegistrarProvider
       override lazy val migratingRegistrarProvider: RegistrarProvider = fakeRegistrarProvider

--- a/report/app/report/ReportApplicationLoader.scala
+++ b/report/app/report/ReportApplicationLoader.scala
@@ -5,6 +5,7 @@ import akka.actor.ActorSystem
 import aws.AsyncDynamo
 import azure.NotificationHubClient
 import com.amazonaws.regions.Regions.EU_WEST_1
+import com.gu.AppIdentity
 import play.api.routing.Router
 import play.api._
 import play.api.ApplicationLoader.Context
@@ -21,7 +22,7 @@ import utils.{CustomApplicationLoader, MobileAwsCredentialsProvider}
 import router.Routes
 
 class ReportApplicationLoader extends CustomApplicationLoader {
-  def buildComponents(context: Context): BuiltInComponents = new ReportApplicationComponents(context)
+  def buildComponents(identity: AppIdentity, context: Context): BuiltInComponents = new ReportApplicationComponents(context)
 }
 
 class ReportApplicationComponents(context: Context) extends BuiltInComponentsFromContext(context)


### PR DESCRIPTION
Send metrics about the nature of the registration token. Three cases:
 - The registration comes with an Azure token
 - The registration comes with a Firebase token
 - The registration comes with both

The cloudwatch logic is imported from Mapi. I was considering making a library but I'm actually not sure how relevant that would be for the rest of the department (or even ourselves)