### PR TITLE
Hide log nuisance

### DIFF
--- a/notification/conf/logback.xml
+++ b/notification/conf/logback.xml
@@ -11,7 +11,7 @@
     </rollingPolicy>
 
     <encoder>
-      <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+      <pattern>%date [%level] [%logger] [%thread] - %message%n%xException</pattern>
     </encoder>
   </appender>
 

--- a/report/conf/logback.xml
+++ b/report/conf/logback.xml
@@ -2,6 +2,8 @@
 
     <contextName>report</contextName>
 
+    <logger name="akka.actor.ActorSystemImpl" level="ERROR" />
+
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/application.log</file>
 
@@ -11,7 +13,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+      <pattern>%date [%level] [%logger] [%thread] - %message%n%xException</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
ActorSystemImpl is way too verbose and prints every single dropped connection by clients.
We expect connections to drop, especially on mobile, so I set it to only trace on error