### PR TITLE
Mss 426/ignore null items

### DIFF
--- a/eventconsumer/src/main/scala/com/gu/notifications/events/ReportUpdater.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/ReportUpdater.scala
@@ -22,9 +22,11 @@ class ReportUpdater(stage: String, scheduledExecutorService: ScheduledExecutorSe
   private val newEventsKey = ":newevents"
   private val oldVersionKey = ":oldversion"
   private val logger = LogManager.getLogger(classOf[ReportUpdater])
+
   def nextVersion = UUID.randomUUID().toString
 
   private val tableName: String = s"mobile-notifications-reports-$stage"
+
   def update(eventAggregations: List[NotificationReportEvent])(implicit executionContext: ExecutionContext): List[Future[Unit]] = {
     eventAggregations.map(aggregation => {
 


### PR DESCRIPTION
Get item might return null, in which case the update flow has to support optional.
Only signifacant change is the addition of the Option, but tidied to refactor update from previous aggregations into its own function