### PR TITLE
Mss 426/tidy query for UUID to get

### DIFF
--- a/common/src/main/scala/aws/AsyncDynamo.scala
+++ b/common/src/main/scala/aws/AsyncDynamo.scala
@@ -40,5 +40,6 @@ class AsyncDynamo(val client: AmazonDynamoDBAsync) {
   // These work but are red because Intellij is broken
   def putItem(request: PutItemRequest): Future[PutItemResult] = wrapAsyncMethod(client.putItemAsync, request)
   def query(request: QueryRequest): Future[QueryResult] = wrapAsyncMethod(client.queryAsync, request)
+  def get(request: GetItemRequest): Future[GetItemResult] = wrapAsyncMethod(client.getItemAsync, request)
   def updateItem(request: UpdateItemRequest): Future[UpdateItemResult] = wrapAsyncMethod(client.updateItemAsync, request)
 }

--- a/common/src/main/scala/tracking/DynamoNotificationReportRepository.scala
+++ b/common/src/main/scala/tracking/DynamoNotificationReportRepository.scala
@@ -92,6 +92,7 @@ class DynamoNotificationReportRepository(client: AsyncDynamo, tableName: String)
   }
 
   private def updateNotificationReport(report: DynamoNotificationReport, lastNotificationReport: DynamoNotificationReport): Future[Right[Nothing, Unit]] = {
+    logger.warn(s"Report: $report")
     val updateItemRequest = new UpdateItemRequest()
       .withKey(Map("id" -> new AttributeValue().withS(report.id.toString)).asJava)
       .withTableName(tableName)

--- a/common/src/main/scala/tracking/DynamoNotificationReportRepository.scala
+++ b/common/src/main/scala/tracking/DynamoNotificationReportRepository.scala
@@ -92,7 +92,6 @@ class DynamoNotificationReportRepository(client: AsyncDynamo, tableName: String)
   }
 
   private def updateNotificationReport(report: DynamoNotificationReport, lastNotificationReport: DynamoNotificationReport): Future[Right[Nothing, Unit]] = {
-    logger.warn(s"Report: $report")
     val updateItemRequest = new UpdateItemRequest()
       .withKey(Map("id" -> new AttributeValue().withS(report.id.toString)).asJava)
       .withTableName(tableName)

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/S3EventProcessor.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/S3EventProcessor.scala
@@ -48,10 +48,8 @@ class S3EventProcessorImpl extends S3EventProcessor {
       }
     }
 
-    def toRawEvent(string: String): Option[RawEvent] = {
-      logger.info(string)
-      Json.parse(string).validate[RawEvent].asOpt
-    }
+    def toRawEvent(string: String): Option[RawEvent] = Json.parse(string).validate[RawEvent].asOpt
+
 
     def toEvent(rawEvent: RawEvent): Option[EventsPerNotification] = {
       val parsed = URLEncodedUtils.parse(rawEvent.queryString.dropWhile(_ == '?'), Charset.forName("UTF-8"))


### PR DESCRIPTION
Get item is a more natural dynamodb request than query for single item by primary key.

The query statistics will hopefully also be more representative of genuine queries that return a range of results, like listing notifications.
Hopefully, the minimum and average query latencies will noticeably increase after this change.