### PR TITLE
MSS-426: Add a queue

### DIFF
--- a/eventconsumer/cfn.yaml
+++ b/eventconsumer/cfn.yaml
@@ -149,6 +149,7 @@ Resources:
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 300
+      ReservedConcurrentExecutions: 1
 
   S3Bucket:
     Type: AWS::S3::Bucket

--- a/eventconsumer/cfn.yaml
+++ b/eventconsumer/cfn.yaml
@@ -27,8 +27,35 @@ Mappings:
     PROD:
       BucketStage: prod
 Resources:
+  Sqs:
+    Type: AWS::SQS::Queue
+    Properties:
+      VisibilityTimeout: 300
+  SqsPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+      - Ref: Sqs
+      PolicyDocument:
+        Version: "2012-10-17"
+        Id: !Sub "Sqs${Stage}Policy"
+        Statement:
+        - Resource: !GetAtt Sqs.Arn
+          Effect: "Allow"
+          Sid: "Allow-User-SendMessage"
+          Action:
+          - "sqs:*"
+          Condition:
+            ArnLike:
+              aws:SourceArn:
+              - !Sub
+                - arn:aws:s3:::aws-mobile-event-logs-${BucketStage}
+                - BucketStage: !FindInMap [StageVariables, !Ref Stage, BucketStage]
+          Principal:
+            AWS: "*"
   ExecutionRole:
     Type: AWS::IAM::Role
+    DependsOn: Sqs
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -49,7 +76,9 @@ Resources:
             Action:
             - logs:CreateLogStream
             - logs:PutLogEvents
-            Resource: !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/eventconsumer-${Stage}:*"
+            Resource:
+            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/eventconsumer-${Stage}:*"
+            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/eventconsumer-sqs-${Stage}:*"
 
       - PolicyName: s3
         PolicyDocument:
@@ -71,6 +100,12 @@ Resources:
             Effect: Allow
             Action: dynamodb:*
             Resource: !Sub "arn:aws:dynamodb:eu-west-1:${AWS::AccountId}:table/mobile-notifications-reports-${Stage}"
+      - PolicyName: SQS
+        PolicyDocument:
+          Statement:
+            Effect: Allow
+            Action: sqs:*
+            Resource: !GetAtt Sqs.Arn
 
   Lambda:
     Type: AWS::Lambda::Function
@@ -95,9 +130,32 @@ Resources:
       Runtime: java8
       Timeout: 300
 
+  SqsLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub ${App}-sqs-${Stage}
+      Code:
+        S3Bucket:
+          Ref: DeployBucket
+        S3Key: !Sub ${Stack}/${Stage}/${App}/${App}.jar
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Stack: !Ref Stack
+          App: !Ref App
+      Description: Consumes queue events
+      Handler: com.gu.notifications.events.SqsLambda::handleRequest
+      MemorySize: 384
+      Role: !GetAtt ExecutionRole.Arn
+      Runtime: java8
+      Timeout: 300
+
   S3Bucket:
     Type: AWS::S3::Bucket
-    DependsOn: LambdaPermissionS3Bucket
+    DependsOn:
+    - LambdaPermissionS3Bucket
+    - Sqs
+    - SqsPolicy
     Properties:
       AccessControl: Private
       BucketName: !Sub
@@ -108,9 +166,9 @@ Resources:
           - ExpirationInDays: 7
             Status: Enabled
       NotificationConfiguration:
-        LambdaConfigurations:
+        QueueConfigurations:
         - Event: s3:ObjectCreated:*
-          Function: !GetAtt Lambda.Arn
+          Queue: !GetAtt Sqs.Arn
   LambdaPermissionS3Bucket:
     DependsOn:
     - Lambda
@@ -122,3 +180,14 @@ Resources:
       SourceArn: !Sub
       - arn:aws:s3:::aws-mobile-event-logs-${BucketStage}
       - BucketStage: !FindInMap [StageVariables, !Ref Stage, BucketStage]
+
+  SqsEventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    DependsOn:
+    - Sqs
+    - SqsLambda
+    Properties:
+      BatchSize: 1
+      Enabled: True
+      EventSourceArn: !GetAtt Sqs.Arn
+      FunctionName: !Sub ${App}-sqs-${Stage}

--- a/eventconsumer/riff-raff.yaml
+++ b/eventconsumer/riff-raff.yaml
@@ -6,7 +6,9 @@ deployments:
     type: aws-lambda
     parameters:
       bucket: mobile-notifications-dist
-      functionNames: [eventconsumer-]
+      functionNames:
+      - eventconsumer-
+      - eventconsumer-sqs-
       fileName: eventconsumer.jar
       prefixStack: false
     dependencies: [eventconsumer-cfn]

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/AwsClient.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/AwsClient.scala
@@ -11,7 +11,6 @@ object AwsClient {
     DefaultAWSCredentialsProviderChain.getInstance)
 
 
-
   lazy val s3Client: AmazonS3 = AmazonS3Client.builder()
     .withCredentials(credentials)
     .withRegion("eu-west-1")

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/DynamoConversion.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/DynamoConversion.scala
@@ -37,13 +37,6 @@ object DynamoConversion {
       android = platformMap("android").getN.toInt)
   }
 
-  def toAttributeValue(platform: PlatformCount): AttributeValue = new AttributeValue().withM(Map(
-    "total" -> new AttributeValue().withN(platform.total.toString),
-    "ios" -> new AttributeValue().withN(platform.ios.toString),
-    "android" -> new AttributeValue().withN(platform.android.toString)
-  ).asJava)
-
-
   def toAttributeValue(eventAggregation: EventAggregation, sent: LocalDateTime): AttributeValue = {
     val platform = eventAggregation.platformCounts
     val provider = eventAggregation.providerCounts
@@ -70,5 +63,11 @@ object DynamoConversion {
           }.asJava)
     ).asJava)
   }
+
+  def toAttributeValue(platform: PlatformCount): AttributeValue = new AttributeValue().withM(Map(
+    "total" -> new AttributeValue().withN(platform.total.toString),
+    "ios" -> new AttributeValue().withN(platform.ios.toString),
+    "android" -> new AttributeValue().withN(platform.android.toString)
+  ).asJava)
 
 }

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/RawEvent.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/RawEvent.scala
@@ -12,5 +12,5 @@ case class RawEvent(
 )
 
 object RawEvent {
-  implicit val rawEventJF: Reads[RawEvent] = Json.reads[RawEvent].map(rawEvent => rawEvent.copy(dateTime =  rawEvent.dateTime.truncatedTo(TenSecondUnit)))
+  implicit val rawEventJF: Reads[RawEvent] = Json.reads[RawEvent].map(rawEvent => rawEvent.copy(dateTime = rawEvent.dateTime.truncatedTo(TenSecondUnit)))
 }

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/S3EventModel.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/S3EventModel.scala
@@ -1,13 +1,16 @@
 package com.gu.notifications.events
 
 import play.api.libs.json._
+
 case class S3EventRecordS3Object(key: Option[String])
-object S3EventRecordS3Object{
+
+object S3EventRecordS3Object {
   implicit val jf = Json.format[S3EventRecordS3Object]
 }
 
 case class S3EventRecordS3Bucket(name: Option[String])
-object S3EventRecordS3Bucket{
+
+object S3EventRecordS3Bucket {
   implicit val jf = Json.format[S3EventRecordS3Bucket]
 }
 
@@ -16,19 +19,21 @@ case class S3EventRecordS3(
   bucket: Option[S3EventRecordS3Bucket]
 
 )
-object S3EventRecordS3{
+
+object S3EventRecordS3 {
   implicit val jf = Json.format[S3EventRecordS3]
 }
 
 case class S3EventRecord(
-  s3:Option[S3EventRecordS3]
+  s3: Option[S3EventRecordS3]
 )
 
-object S3EventRecord{
+object S3EventRecord {
   implicit val jf = Json.format[S3EventRecord]
 }
 
 case class S3Event(Records: List[S3EventRecord])
+
 object S3Event {
   implicit val jf = Json.format[S3Event]
 }

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/SqsLambda.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/SqsLambda.scala
@@ -1,0 +1,53 @@
+package com.gu.notifications.events
+
+import java.io.{InputStream, OutputStream}
+
+import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
+import com.amazonaws.util.IOUtils
+import org.apache.logging.log4j.{LogManager, Logger}
+import play.api.libs.json._
+
+
+object SqsLambda extends App {
+  new SqsLambda().handleRequest(System.in, System.out, null)
+}
+case class Record(body: String)
+object Record {
+  implicit val jf = Json.format[Record]
+}
+case class SqsEvent(Records: List[Record])
+object SqsEvent {
+  implicit val jf = Json.format[SqsEvent]
+}
+class SqsLambda extends RequestStreamHandler {
+
+  private val logger: Logger = LogManager.getLogger(classOf[Lambda])
+  private val lambda = new Lambda()
+  override def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
+    try {
+      val inputString = try {
+        IOUtils.toString(input)
+      }
+      finally {
+        input.close()
+      }
+      val sqsEventJson = Json.parse(inputString)
+      SqsEvent.jf.reads(sqsEventJson).foreach(sqsEvent => {
+        sqsEvent.Records.foreach(record => {
+          val s3EventJson = Json.parse(record.body)
+          lambda.processS3EventJson(s3EventJson)
+        })
+      })
+
+    }
+    catch {
+      case t: Throwable =>
+        logger.warn("Error running lambda", t)
+        throw t
+    }
+    finally {
+      output.close()
+    }
+  }
+
+}

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/SqsLambda.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/SqsLambda.scala
@@ -11,18 +11,24 @@ import play.api.libs.json._
 object SqsLambda extends App {
   new SqsLambda().handleRequest(System.in, System.out, null)
 }
+
 case class Record(body: String)
+
 object Record {
   implicit val jf = Json.format[Record]
 }
+
 case class SqsEvent(Records: List[Record])
+
 object SqsEvent {
   implicit val jf = Json.format[SqsEvent]
 }
+
 class SqsLambda extends RequestStreamHandler {
 
   private val logger: Logger = LogManager.getLogger(classOf[Lambda])
   private val lambda = new Lambda()
+
   override def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
     try {
       val inputString = try {


### PR DESCRIPTION
Write the S3 events into a queue.
The queue is then consumed by a lambda with reservedconcurrency of 1.
Hopefully, this should reduce the collisions substantially, also reducing our read and write overhead consumed capacity.

There may be an outage during the migration, as cloudformation did not like me swapping the notification configuration.

Plan is to do another PR to tidy up the old lambda if this works