### PR TITLE
Stop ios migration

### DIFF
--- a/common/src/main/scala/models/Provider.scala
+++ b/common/src/main/scala/models/Provider.scala
@@ -1,7 +1,30 @@
 package models
 
+import ai.x.play.json.Jsonx
+import play.api.libs.json._
+
+trait Provider {
+  def value: String
+}
+
 object Provider {
-  val Azure = "azure"
-  val FCM = "FCM"
-  val Unknown = "unknown"
+
+  implicit val providerJF: Format[Provider] = new Format[Provider] {
+    override def reads(json: JsValue): JsResult[Provider] = json match {
+      case JsString("azure") => JsSuccess(Azure)
+      case JsString("FCM") => JsSuccess(FCM)
+      case _ => JsSuccess(Unknown)
+    }
+    override def writes(o: Provider): JsValue = JsString(o.value)
+  }
+
+  case object Azure extends Provider {
+    val value = "azure"
+  }
+  case object FCM extends Provider {
+    val value = "FCM"
+  }
+  case object Unknown extends Provider {
+    val value = "unknown"
+  }
 }

--- a/common/src/main/scala/models/Registration.scala
+++ b/common/src/main/scala/models/Registration.scala
@@ -5,5 +5,6 @@ case class Registration(
   deviceToken: DeviceToken,
   platform: Platform,
   topics: Set[Topic],
-  buildTier: Option[String]
+  buildTier: Option[String],
+  provider: Option[Provider]
 )

--- a/common/src/test/scala/azure/RawGCMRegistrationSpec.scala
+++ b/common/src/test/scala/azure/RawGCMRegistrationSpec.scala
@@ -14,7 +14,8 @@ class RawGCMRegistrationSpec extends Specification {
         deviceToken = AzureToken("device2"),
         platform = Android,
         topics = Set(topic),
-        buildTier = None
+        buildTier = None,
+        provider = None
       )
 
       val rawRegistration = RawGCMRegistration.fromMobileRegistration(registration)

--- a/notification/app/notification/models/android/Notification.scala
+++ b/notification/app/notification/models/android/Notification.scala
@@ -35,7 +35,7 @@ case class BreakingNewsNotification(
   def payload: Map[String, String] = Map(
     Keys.NotificationType -> notificationType.value,
     Keys.UniqueIdentifier -> id.toString,
-    Keys.Provider -> Provider.Azure,
+    Keys.Provider -> Provider.Azure.value,
     Keys.Type -> `type`,
     Keys.Title -> title,
     Keys.Ticker -> ticker,
@@ -69,7 +69,7 @@ case class ContentNotification(
   def payload: Map[String, String] = Map(
     Keys.Type -> `type`,
     Keys.UniqueIdentifier -> id.toString,
-    Keys.Provider -> Provider.Azure,
+    Keys.Provider -> Provider.Azure.value,
     Keys.Title -> title,
     Keys.Ticker -> ticker,
     Keys.Message -> message,
@@ -101,7 +101,7 @@ case class GoalAlertNotification(
   def payload: Map[String, String] = Map(
     Keys.Type -> `type`,
     Keys.UniqueIdentifier -> id.toString,
-    Keys.Provider -> Provider.Azure,
+    Keys.Provider -> Provider.Azure.value,
     Keys.AwayTeamName -> awayTeamName,
     Keys.AwayTeamScore -> awayTeamScore.toString,
     Keys.HomeTeamName -> homeTeamName,
@@ -146,7 +146,7 @@ case class ElectionNotification(
   def payload: Map[String, String] = Map(
     Keys.Type -> `type`,
     Keys.UniqueIdentifier -> id.toString,
-    Keys.Provider -> Provider.Azure,
+    Keys.Provider -> Provider.Azure.value,
     Keys.ExpandedMessage -> expandedMessage,
     Keys.ShortMessage -> shortMessage,
     Keys.Debug -> debug.toString,

--- a/notification/app/notification/models/ios/Notification.scala
+++ b/notification/app/notification/models/ios/Notification.scala
@@ -37,7 +37,7 @@ case class BreakingNewsNotification(
     ),
     customProperties = LegacyProperties(Map(
       Keys.UniqueIdentifier -> notificationId.toString,
-      Keys.Provider -> Provider.Azure,
+      Keys.Provider -> Provider.Azure.value,
       Keys.MessageType -> `type`,
       Keys.NotificationType -> notificationType.value,
       Keys.Link -> legacyLink,
@@ -69,7 +69,7 @@ case class ContentNotification(
     ),
     customProperties = LegacyProperties(Map(
       Keys.UniqueIdentifier -> notificationId.toString,
-      Keys.Provider -> Provider.Azure,
+      Keys.Provider -> Provider.Azure.value,
       Keys.MessageType -> `type`,
       Keys.NotificationType -> notificationType.value,
       Keys.Link -> legacyLink,
@@ -124,7 +124,7 @@ case class ElectionNotification(
     ),
     customProperties = StandardProperties(
       uniqueIdentifier = id,
-      provider = Provider.Azure,
+      provider = Provider.Azure.value,
       t = `type`,
       notificationType = notificationType,
       election = Some(ElectionProperties(
@@ -150,7 +150,7 @@ case class LiveEventNotification(notificationId: UUID, liveEvent: LiveEventPrope
     ),
     customProperties = StandardProperties(
       uniqueIdentifier = notificationId,
-      provider = Provider.Azure,
+      provider = Provider.Azure.value,
       t = MessageTypes.LiveEventAlert,
       notificationType = LiveEventAlert,
       liveEvent = Some(liveEvent)
@@ -174,7 +174,7 @@ case class FootballMatchStatusNotification(
     ),
     customProperties = StandardProperties(
       uniqueIdentifier = notificationId,
-      provider = Provider.Azure,
+      provider = Provider.Azure.value,
       t = MessageTypes.FootballMatchStatus,
       notificationType = FootballMatchStatus,
       footballMatch = Some(matchStatus)

--- a/notification/app/notification/services/azure/GCMPushConverter.scala
+++ b/notification/app/notification/services/azure/GCMPushConverter.scala
@@ -131,7 +131,7 @@ class GCMPushConverter(conf: Configuration) extends AzurePushConverter {
   private def toLiveEventAlert(innovationAlert: LiveEventNotification) = android.LiveEventAlert(
     payload = Map(
       Keys.UniqueIdentifier -> Some(innovationAlert.id.toString),
-      Keys.Provider -> Some(Provider.Azure),
+      Keys.Provider -> Some(Provider.Azure.value),
       Keys.Message -> Some(innovationAlert.message),
       Keys.ShortMessage -> Some(innovationAlert.shortMessage.getOrElse(innovationAlert.message)),
       Keys.ExpandedMessage -> Some(innovationAlert.expandedMessage.getOrElse(innovationAlert.message)),
@@ -149,7 +149,7 @@ class GCMPushConverter(conf: Configuration) extends AzurePushConverter {
   private def toMatchStatusAlert(matchStatusAlert: FootballMatchStatusNotification) = android.FootballMatchStatusNotification(
     payload = Map(
       Keys.UniqueIdentifier -> Some(matchStatusAlert.id.toString),
-      Keys.Provider -> Some(Provider.Azure),
+      Keys.Provider -> Some(Provider.Azure.value),
       "type" -> Some(AndroidMessageTypes.FootballMatchAlert),
       "homeTeamName" -> Some(matchStatusAlert.homeTeamName),
       "homeTeamId" -> Some(matchStatusAlert.homeTeamId),

--- a/notification/app/notification/services/fcm/APNSConfigConverter.scala
+++ b/notification/app/notification/services/fcm/APNSConfigConverter.scala
@@ -67,7 +67,7 @@ class APNSConfigConverter(conf: Configuration) extends FCMConfigConverter[ApnsCo
       val allCustomData = customData
         .collect { case (key, Some(value)) => key -> value }
         .toMap
-        .updated(Keys.Provider, Provider.FCM)
+        .updated(Keys.Provider, Provider.FCM.value)
         .updated(Keys.UniqueIdentifier, notificationId.toString)
         .asJava
 

--- a/notification/app/notification/services/fcm/AndroidConfigConverter.scala
+++ b/notification/app/notification/services/fcm/AndroidConfigConverter.scala
@@ -29,7 +29,7 @@ class AndroidConfigConverter(conf: Configuration) extends FCMConfigConverter[And
       AndroidConfig.builder()
         .putAllData(data
           .updated(Keys.UniqueIdentifier, notificationId.toString)
-          .updated(Keys.Provider, Provider.FCM)
+          .updated(Keys.Provider, Provider.FCM.value)
           .asJava
         ).setPriority(AndroidConfig.Priority.HIGH)
         .setTtl(86400000L) // 24 hours

--- a/notification/app/notification/services/fcm/FCMNotificationSender.scala
+++ b/notification/app/notification/services/fcm/FCMNotificationSender.scala
@@ -49,7 +49,7 @@ class FCMNotificationSender(
 
     // FCM's async calls doesn't come with its own thread pool, so we may as well block in a separate thread pool
     Future(firebaseMessaging.send(firebaseNotification))(fcmExecutionContext)
-      .map(messageId => Right(SenderReport(Provider.FCM, DateTime.now(), sendersId = Some(messageId), None)))
+      .map(messageId => Right(SenderReport(Provider.FCM.value, DateTime.now(), sendersId = Some(messageId), None)))
 
   }
 

--- a/notification/test/notification/models/azure/iOSNotificationSpec.scala
+++ b/notification/test/notification/models/azure/iOSNotificationSpec.scala
@@ -304,7 +304,7 @@ class iOSNotificationSpec extends Specification with Mockito {
       ),
       customProperties = StandardProperties(
         uniqueIdentifier = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
-        provider = Provider.Azure,
+        provider = Provider.Azure.value,
         t = "us-election",
         notificationType = ElectionsAlert,
         election = Some(ElectionProperties(
@@ -348,7 +348,7 @@ class iOSNotificationSpec extends Specification with Mockito {
       customProperties = StandardProperties(
         t = "live",
         uniqueIdentifier = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
-        provider = Provider.Azure,
+        provider = Provider.Azure.value,
         notificationType = LiveEventAlert,
         liveEvent = Some(LiveEventProperties(
           title = "Some live event",
@@ -403,7 +403,7 @@ class iOSNotificationSpec extends Specification with Mockito {
       customProperties = StandardProperties(
         t = "football-match-status",
         uniqueIdentifier = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
-        provider = Provider.Azure,
+        provider = Provider.Azure.value,
         notificationType = FootballMatchStatus,
         footballMatch = Some(FootballMatchStatusProperties(
           homeTeamName = "Arsenal",

--- a/registration/app/registration/RegistrationApplicationLoader.scala
+++ b/registration/app/registration/RegistrationApplicationLoader.scala
@@ -76,7 +76,7 @@ class RegistrationApplicationComponents(identity: AppIdentity, context: Context)
 
   lazy val defaultHubClient = new NotificationHubClient(appConfig.defaultHub, wsClient)
 
-  lazy val registrarProvider: RegistrarProvider = new NotificationRegistrarProvider(gcmNotificationRegistrar, apnsNotificationRegistrar, newsstandNotificationRegistrar)
+  lazy val registrarProvider: RegistrarProvider = new AzureRegistrarProvider(gcmNotificationRegistrar, apnsNotificationRegistrar, newsstandNotificationRegistrar)
   lazy val metrics: Metrics = new CloudWatchMetrics(applicationLifecycle, environment, identity)
   lazy val migratingRegistrarProvider: RegistrarProvider = new MigratingRegistrarProvider(registrarProvider, fcmNotificationRegistrar, metrics)
   lazy val gcmNotificationRegistrar: GCMNotificationRegistrar = new GCMNotificationRegistrar(defaultHubClient, subscriptionTracker, metrics)

--- a/registration/app/registration/controllers/Main.scala
+++ b/registration/app/registration/controllers/Main.scala
@@ -54,7 +54,7 @@ final class Main(
   def unregister(selector: RegistrationsByDeviceToken): Action[AnyContent] = actionWithTimeout {
 
     def registrarForSelector = EitherT.fromEither[Future](
-      registrarProvider.registrarFor(selector.platform, selector.deviceToken)
+      registrarProvider.registrarFor(selector.platform, selector.deviceToken, None)
     )
 
     def unregisterFrom(registrar: NotificationRegistrar): EitherT[Future, NotificationsError, Unit] = EitherT(
@@ -119,7 +119,7 @@ final class Main(
 
   def registrationsByDeviceToken(platform: Platform, deviceToken: DeviceToken): Action[AnyContent] = Action.async {
     val result = for {
-      registrar <- EitherT.fromEither[Future](registrarProvider.registrarFor(platform, deviceToken))
+      registrar <- EitherT.fromEither[Future](registrarProvider.registrarFor(platform, deviceToken, None))
       registrations <- EitherT(registrar.findRegistrations(deviceToken): Future[Either[NotificationsError, List[StoredRegistration]]])
     } yield registrations
     result.fold(processErrors, res => Ok(Json.toJson(res)))

--- a/registration/app/registration/models/LegacyRegistration.scala
+++ b/registration/app/registration/models/LegacyRegistration.scala
@@ -3,6 +3,7 @@ package registration.models
 import play.api.libs.json._
 import play.api.libs.json.JodaReads._
 import LegacyJodaFormat._
+import models.Provider
 
 object LegacyJodaFormat {
   val DateTimePattern = "yyyy-MM-dd'T'HH:mm:ss'Z'"
@@ -54,7 +55,8 @@ case class LegacyPreferences(
   edition: String,
   teams: Option[Seq[String]],
   matches: Option[Seq[LegacyMatch]],
-  topics: Option[Seq[LegacyTopic]]
+  topics: Option[Seq[LegacyTopic]],
+  provider: Option[Provider]
 ) {
   def hasNewsstand: Boolean = topics.exists(_.contains(LegacyTopic.NewsstandIos))
   def withNewsstand: LegacyPreferences = {

--- a/registration/app/registration/services/AzureRegistrarProvider.scala
+++ b/registration/app/registration/services/AzureRegistrarProvider.scala
@@ -11,21 +11,7 @@ import com.amazonaws.services.cloudwatch.model.StandardUnit
 import metrics.{MetricDataPoint, Metrics}
 import registration.services.fcm.FcmRegistrar
 
-trait RegistrarProvider {
-  def registrarFor(registration: Registration): Either[NotificationsError, NotificationRegistrar]
 
-  def registrarFor(platform: Platform, deviceToken: DeviceToken): Either[NotificationsError, NotificationRegistrar]
-
-  def withAllRegistrars[T](fn: (NotificationRegistrar => T)): List[T]
-}
-
-case class UnsupportedPlatform(platform: String) extends RequestError {
-  override def reason: String = s"Platform '$platform' is not supported"
-}
-
-case class MalformattedRegistration(description: String) extends RequestError {
-  override def reason: String = s"Malformatred request: $reason"
-}
 
 final class AzureRegistrarProvider(
   gcmRegistrar: GCMNotificationRegistrar,
@@ -42,9 +28,9 @@ final class AzureRegistrarProvider(
 
 
   override def registrarFor(registration: Registration): Either[NotificationsError, NotificationRegistrar] =
-    registrarFor(registration.platform, registration.deviceToken)
+    registrarFor(registration.platform, registration.deviceToken, registration.provider)
 
-  override def registrarFor(platform: Platform, deviceToken: DeviceToken): Either[NotificationsError, NotificationRegistrar] = {
+  override def registrarFor(platform: Platform, deviceToken: DeviceToken, currentProvider: Option[Provider]): Either[NotificationsError, NotificationRegistrar] = {
     platform match {
       case Android => Right(gcmRegistrar)
       case `iOS` => Right(apnsRegistrar)

--- a/registration/app/registration/services/LegacyNewsstandRegistrationConverter.scala
+++ b/registration/app/registration/services/LegacyNewsstandRegistrationConverter.scala
@@ -20,7 +20,8 @@ class LegacyNewsstandRegistrationConverter(config: NewsstandShardConfig) extends
       deviceToken = AzureToken(legacyRegistration.pushToken),
       platform = Newsstand,
       topics = Set(Topic(TopicTypes.NewsstandShard, newstandShardTopic)),
-      buildTier = None
+      buildTier = None,
+      provider = None
     ))
   }
 

--- a/registration/app/registration/services/LegacyRegistrationConverter.scala
+++ b/registration/app/registration/services/LegacyRegistrationConverter.scala
@@ -33,7 +33,8 @@ class LegacyRegistrationConverter extends RegistrationConverter[LegacyRegistrati
       deviceToken = deviceToken,
       platform = platform,
       topics = topics(legacyRegistration),
-      buildTier = Some(legacyRegistration.device.buildTier)
+      buildTier = Some(legacyRegistration.device.buildTier),
+      provider = None
     )
   }
 
@@ -42,7 +43,10 @@ class LegacyRegistrationConverter extends RegistrationConverter[LegacyRegistrati
       LegacyTopic(topic.`type`.toString, topic.name)
     }
 
-    val preferences = legacyRegistration.preferences.copy(topics = Some(topics.toSeq))
+    val preferences = legacyRegistration.preferences.copy(
+      topics = Some(topics.toSeq),
+      provider = Some(response.provider)
+    )
 
     legacyRegistration.copy(preferences = preferences)
   }

--- a/registration/app/registration/services/MigratingRegistrar.scala
+++ b/registration/app/registration/services/MigratingRegistrar.scala
@@ -2,7 +2,6 @@ package registration.services
 
 import models.{DeviceToken, Registration, Topic, UniqueDeviceIdentifier}
 import models.pagination.Paginated
-import registration.services.fcm.FcmRegistrar
 import cats.implicits._
 
 import scala.concurrent.ExecutionContext
@@ -10,10 +9,10 @@ import NotificationRegistrar.RegistrarResponse
 import cats.data.EitherT
 
 class MigratingRegistrar(
-  fcmRegistrar: FcmRegistrar,
+  val providerIdentifier: String,
+  fcmRegistrar: NotificationRegistrar,
   legacyRegistrar: NotificationRegistrar
 )(implicit ec: ExecutionContext) extends NotificationRegistrar {
-  override val providerIdentifier: String = "AzureToFirebaseRegistrar"
 
   override def register(deviceToken: DeviceToken, registration: Registration): RegistrarResponse[RegistrationResponse] = {
     for {

--- a/registration/app/registration/services/MigratingRegistrar.scala
+++ b/registration/app/registration/services/MigratingRegistrar.scala
@@ -10,38 +10,38 @@ import cats.data.EitherT
 
 class MigratingRegistrar(
   val providerIdentifier: String,
-  fcmRegistrar: NotificationRegistrar,
-  legacyRegistrar: NotificationRegistrar
+  fromRegistrar: NotificationRegistrar,
+  toRegistrar: NotificationRegistrar
 )(implicit ec: ExecutionContext) extends NotificationRegistrar {
 
   override def register(deviceToken: DeviceToken, registration: Registration): RegistrarResponse[RegistrationResponse] = {
     for {
-      _ <- legacyRegistrar.unregister(deviceToken)
-      result <- fcmRegistrar.register(deviceToken, registration)
+      _ <- fromRegistrar.unregister(deviceToken)
+      result <- toRegistrar.register(deviceToken, registration)
     } yield result
   }
 
   override def unregister(deviceToken: DeviceToken): RegistrarResponse[Unit] = {
     val response = for {
-      legacyResponse <- legacyRegistrar.unregister(deviceToken)
-      fcmResponse <- fcmRegistrar.unregister(deviceToken)
+      legacyResponse <- fromRegistrar.unregister(deviceToken)
+      fcmResponse <- toRegistrar.unregister(deviceToken)
     } yield fcmResponse
 
     response
   }
 
   override def findRegistrations(topic: Topic, cursor: Option[String]): RegistrarResponse[Paginated[StoredRegistration]] =
-    legacyRegistrar.findRegistrations(topic, cursor)
+    fromRegistrar.findRegistrations(topic, cursor)
 
   override def findRegistrations(deviceToken: DeviceToken): RegistrarResponse[List[StoredRegistration]] = {
     val registrations = for {
-      fcmRegistrations <- EitherT(fcmRegistrar.findRegistrations(deviceToken))
-      legacyRegistrations <- EitherT(legacyRegistrar.findRegistrations(deviceToken))
+      fcmRegistrations <- EitherT(toRegistrar.findRegistrations(deviceToken))
+      legacyRegistrations <- EitherT(fromRegistrar.findRegistrations(deviceToken))
     } yield fcmRegistrations ++ legacyRegistrations
 
     registrations.value
   }
 
   override def findRegistrations(udid: UniqueDeviceIdentifier): RegistrarResponse[Paginated[StoredRegistration]] =
-    legacyRegistrar.findRegistrations(udid)
+    fromRegistrar.findRegistrations(udid)
 }

--- a/registration/app/registration/services/MigratingRegistrarProvider.scala
+++ b/registration/app/registration/services/MigratingRegistrarProvider.scala
@@ -1,0 +1,37 @@
+package registration.services
+
+import com.amazonaws.services.cloudwatch.model.StandardUnit
+import error.NotificationsError
+import metrics.{MetricDataPoint, Metrics}
+import models._
+import registration.services.fcm.FcmRegistrar
+
+import scala.concurrent.ExecutionContext
+
+class MigratingRegistrarProvider(
+  standardRegistrarProvider: RegistrarProvider,
+  fcmRegistrar: FcmRegistrar,
+  metrics: Metrics
+)(implicit executionContext: ExecutionContext) extends RegistrarProvider {
+  override def registrarFor(platform: Platform, deviceToken: DeviceToken): Either[NotificationsError, NotificationRegistrar] = deviceToken match {
+    case AzureToken(_) =>
+      metrics.send(MetricDataPoint(name = "RegistrationAzure", value = 1d, unit = StandardUnit.Count))
+      standardRegistrarProvider.registrarFor(platform, deviceToken)
+    case FcmToken(_) =>
+      metrics.send(MetricDataPoint(name = "RegistrationFcm", value = 1d, unit = StandardUnit.Count))
+      Right(fcmRegistrar)
+    case BothTokens(_, _) =>
+      metrics.send(MetricDataPoint(name = "RegistrationBoth", value = 1d, unit = StandardUnit.Count))
+      standardRegistrarProvider
+        .registrarFor(platform, deviceToken)
+        .map(legacyRegistrar => new MigratingRegistrar("AzureToFirebaseRegistrar", fcmRegistrar, legacyRegistrar))
+  }
+
+  // delegate to the registrar provider
+  override def registrarFor(registration: Registration): Either[NotificationsError, NotificationRegistrar] =
+    registrarFor(registration.platform, registration.deviceToken)
+
+  // delegate to the registrar provider
+  override def withAllRegistrars[T](fn: NotificationRegistrar => T): List[T] =
+    standardRegistrarProvider.withAllRegistrars(fn)
+}

--- a/registration/app/registration/services/NotificationRegistrar.scala
+++ b/registration/app/registration/services/NotificationRegistrar.scala
@@ -6,7 +6,12 @@ import providers.ProviderError
 import scala.concurrent.Future
 import models.pagination.Paginated
 
-case class RegistrationResponse(deviceId: String, platform: Platform, topics: Set[Topic])
+case class RegistrationResponse(
+  deviceId: String,
+  platform: Platform,
+  topics: Set[Topic],
+  provider: Provider
+)
 
 object RegistrationResponse {
   import play.api.libs.json._

--- a/registration/app/registration/services/NotificationRegistrar.scala
+++ b/registration/app/registration/services/NotificationRegistrar.scala
@@ -33,7 +33,7 @@ object StoredRegistration {
       platform = registration.platform,
       tagIds = registration.topics.map(_.id),
       topics = registration.topics,
-      provider = Provider.Unknown
+      provider = Provider.Unknown.value
     )
   }
 }

--- a/registration/app/registration/services/NotificationRegistrarProvider.scala
+++ b/registration/app/registration/services/NotificationRegistrarProvider.scala
@@ -73,7 +73,18 @@ class MigratingRegistrarProvider(
       metrics.send(MetricDataPoint(name = "RegistrationBoth", value = 1d, unit = StandardUnit.Count))
       standardRegistrarProvider
         .registrarFor(platform, deviceToken)
-        .map(legacyRegistrar => new MigratingRegistrar(fcmRegistrar, legacyRegistrar))
+        .map(legacyRegistrar => new MigratingRegistrar("AzureToFirebaseRegistrar", fcmRegistrar, legacyRegistrar))
+  }
+
+  private def decideWhichIosMigrationToExecute(platform: Platform, deviceToken: DeviceToken): Either[NotificationsError, NotificationRegistrar] = {
+    val migrationState: Option[Int] = Some(1)
+    migrationState match {
+      case Some(1) =>
+        standardRegistrarProvider
+          .registrarFor(platform, deviceToken)
+          .map(azureRegistrar => new MigratingRegistrar("FirebaseToAzureRegistrar", azureRegistrar, fcmRegistrar))
+      case _ => standardRegistrarProvider.registrarFor(platform, deviceToken)
+    }
   }
 
   // delegate to the registrar provider

--- a/registration/app/registration/services/RegistrarProvider.scala
+++ b/registration/app/registration/services/RegistrarProvider.scala
@@ -1,0 +1,20 @@
+package registration.services
+
+import error.{NotificationsError, RequestError}
+import models.{DeviceToken, Platform, Provider, Registration}
+
+trait RegistrarProvider {
+  def registrarFor(registration: Registration): Either[NotificationsError, NotificationRegistrar]
+
+  def registrarFor(platform: Platform, deviceToken: DeviceToken, currentProvider: Option[Provider]): Either[NotificationsError, NotificationRegistrar]
+
+  def withAllRegistrars[T](fn: (NotificationRegistrar => T)): List[T]
+}
+
+case class UnsupportedPlatform(platform: String) extends RequestError {
+  override def reason: String = s"Platform '$platform' is not supported"
+}
+
+case class MalformattedRegistration(description: String) extends RequestError {
+  override def reason: String = s"Malformatred request: $reason"
+}

--- a/registration/app/registration/services/azure/NotificationsHubRegistrar.scala
+++ b/registration/app/registration/services/azure/NotificationsHubRegistrar.scala
@@ -14,6 +14,7 @@ import cats.syntax.either._
 import cats.instances.future._
 import com.amazonaws.services.cloudwatch.model.StandardUnit
 import metrics.{MetricDataPoint, Metrics}
+import models.Provider.Azure
 import models.pagination.{Paginated, ProviderCursor}
 import registration.services.NotificationRegistrar.RegistrarResponse
 
@@ -147,7 +148,8 @@ class NotificationHubRegistrar(
     RegistrationResponse(
       deviceId = registration.deviceId,
       platform = registration.platform,
-      topics = topicsRegisteredFor
+      topics = topicsRegisteredFor,
+      provider = Azure
     )
   }
 

--- a/registration/app/registration/services/azure/NotificationsHubRegistrar.scala
+++ b/registration/app/registration/services/azure/NotificationsHubRegistrar.scala
@@ -25,7 +25,7 @@ class NotificationHubRegistrar(
 )(implicit ec: ExecutionContext)
   extends NotificationRegistrar {
 
-  override val providerIdentifier = Provider.Azure
+  override val providerIdentifier = Provider.Azure.value
   val logger = Logger(classOf[NotificationHubRegistrar])
 
 
@@ -137,7 +137,7 @@ class NotificationHubRegistrar(
           platform = response.platform,
           tagIds = tags.asSet,
           topics = topics,
-          provider = Provider.Azure
+          provider = Provider.Azure.value
         )
       }
     })

--- a/registration/app/registration/services/fcm/FcmRegistrar.scala
+++ b/registration/app/registration/services/fcm/FcmRegistrar.scala
@@ -19,11 +19,11 @@ import com.amazonaws.services.cloudwatch.model.StandardUnit
 import metrics.{MetricDataPoint, Metrics}
 
 case class FcmProviderError(reason: String) extends ProviderError {
-  override val providerName: String = Provider.FCM
+  override val providerName: String = Provider.FCM.value
 }
 
 case object InstanceNotFound extends ProviderError {
-  override val providerName: String = Provider.FCM
+  override val providerName: String = Provider.FCM.value
   override val reason: String = "Instance not found"
 }
 
@@ -37,7 +37,7 @@ class FcmRegistrar(
 
   val logger = Logger(classOf[FcmRegistrar])
 
-  override val providerIdentifier: String = Provider.FCM
+  override val providerIdentifier: String = Provider.FCM.value
 
   case class Instance(topics: List[Topic], platform: Platform)
   object Instance {
@@ -153,7 +153,7 @@ class FcmRegistrar(
 
   override def findRegistrations(deviceToken: DeviceToken): RegistrarResponse[List[StoredRegistration]] = {
     def instanceToStoredRegistrations(instance: Instance): List[StoredRegistration] =
-      List(StoredRegistration(deviceToken.fcmToken, instance.platform, Set(), instance.topics.toSet, Provider.FCM))
+      List(StoredRegistration(deviceToken.fcmToken, instance.platform, Set(), instance.topics.toSet, Provider.FCM.value))
 
     fetchInstance(deviceToken).map(_.map(instanceToStoredRegistrations))
   }

--- a/registration/app/registration/services/fcm/FcmRegistrar.scala
+++ b/registration/app/registration/services/fcm/FcmRegistrar.scala
@@ -17,6 +17,7 @@ import scala.util.control.NonFatal
 import cats.implicits._
 import com.amazonaws.services.cloudwatch.model.StandardUnit
 import metrics.{MetricDataPoint, Metrics}
+import models.Provider.FCM
 
 case class FcmProviderError(reason: String) extends ProviderError {
   override val providerName: String = Provider.FCM.value
@@ -127,7 +128,12 @@ class FcmRegistrar(
       _ <- EitherT(forEachTopic(topicsToDelete)(unsubscribeFromTopic(deviceToken)))
       topicsToAdd = registration.topics -- existingTopics
       _ <- EitherT(forEachTopic(topicsToAdd)(subscribeToTopic(deviceToken)))
-    } yield RegistrationResponse(deviceToken.fcmToken, registration.platform, registration.topics)
+    } yield RegistrationResponse(
+      deviceId = deviceToken.fcmToken,
+      platform = registration.platform,
+      topics = registration.topics,
+      provider = FCM
+    )
 
     result.value
   }

--- a/registration/test/registration/controllers/RegistrationsFixtures.scala
+++ b/registration/test/registration/controllers/RegistrationsFixtures.scala
@@ -3,6 +3,7 @@ package registration.controllers
 import application.WithPlayApp
 import com.gu.DevIdentity
 import error.NotificationsError
+import models.Provider.Unknown
 import models.TopicTypes.{Breaking, FootballMatch}
 import models._
 import models.pagination.Paginated
@@ -28,7 +29,8 @@ trait DelayedRegistrationsBase extends RegistrationsBase {
       Right(RegistrationResponse(
         deviceId = "deviceAA",
         platform = Android,
-        topics = registration.topics
+        topics = registration.topics,
+        provider = Unknown
       ))
     }
 
@@ -72,7 +74,8 @@ trait RegistrationsBase extends WithPlayApp with RegistrationsJson {
       Right(RegistrationResponse(
         deviceId = "deviceAA",
         platform = Android,
-        topics = registration.topics
+        topics = registration.topics,
+        provider = Unknown
       ))
     }
 
@@ -99,10 +102,10 @@ trait RegistrationsBase extends WithPlayApp with RegistrationsJson {
 
   lazy val fakeRegistrarProvider = new RegistrarProvider {
 
-    override def registrarFor(platform: Platform, deviceToken: DeviceToken): Either[NotificationsError, NotificationRegistrar] = Right(fakeNotificationRegistrar)
+    override def registrarFor(platform: Platform, deviceToken: DeviceToken, currentProvider: Option[Provider]): Either[NotificationsError, NotificationRegistrar] = Right(fakeNotificationRegistrar)
 
     override def registrarFor(registration: Registration): Either[NotificationsError, NotificationRegistrar] =
-      registrarFor(registration.platform, registration.deviceToken)
+      registrarFor(registration.platform, registration.deviceToken, registration.provider)
 
     override def withAllRegistrars[T](fn: (NotificationRegistrar) => T): List[T] = List(fn(fakeNotificationRegistrar))
   }

--- a/registration/test/registration/services/LegacyNewsstandRegistrationConverterSpec.scala
+++ b/registration/test/registration/services/LegacyNewsstandRegistrationConverterSpec.scala
@@ -1,5 +1,6 @@
 package registration.services
 
+import models.Provider.Unknown
 import models.TopicTypes.NewsstandShard
 import models._
 import org.specs2.mutable.Specification
@@ -15,14 +16,14 @@ class LegacyNewsstandRegistrationConverterSpec extends Specification {
         case (pushToken, shardExpected) =>
           val legacyNewsstandRegistration = LegacyNewsstandRegistration(pushToken)
           legacyNewsstandRegistrationConverter.toRegistration(legacyNewsstandRegistration) must beRight(
-            Registration(AzureToken(pushToken), Newsstand, Set(Topic(NewsstandShard, s"newsstand-shard-$shardExpected")), None))
+            Registration(AzureToken(pushToken), Newsstand, Set(Topic(NewsstandShard, s"newsstand-shard-$shardExpected")), None, None))
       }
       ok
     }
     "fromResponse" in {
       val legacyNewsstandRegistrationConverter = new LegacyNewsstandRegistrationConverter(NewsstandShardConfig(10))
       val inputLegacyNewsstandRegistration = LegacyNewsstandRegistration("pushToken")
-      val registrationResponse = RegistrationResponse("deviceId", Newsstand, Set(Topic(NewsstandShard, "newsstand-shard-0")))
+      val registrationResponse = RegistrationResponse("deviceId", Newsstand, Set(Topic(NewsstandShard, "newsstand-shard-0")), Unknown)
       val outputNewstandRegistration: LegacyNewsstandRegistration = legacyNewsstandRegistrationConverter.fromResponse(inputLegacyNewsstandRegistration, registrationResponse)
       outputNewstandRegistration must beEqualTo(inputLegacyNewsstandRegistration)
     }

--- a/registration/test/registration/services/LegacyRegistrationConverterSpec.scala
+++ b/registration/test/registration/services/LegacyRegistrationConverterSpec.scala
@@ -56,14 +56,16 @@ class LegacyRegistrationConverterSpec extends Specification {
         edition = "uk",
         teams = None,
         matches = None,
-        topics = None
+        topics = None,
+        provider = None,
       )
     )
     val expectedDefaultRegistration = Registration(
       deviceToken = AzureToken("abc"),
       platform = iOS,
       topics = Set(Topic(TopicTypes.Breaking, "uk")),
-      buildTier = Some("test")
+      buildTier = Some("test"),
+      provider = None
     )
   }
 }

--- a/registration/test/registration/services/LegacyRegistrationConverterSpec.scala
+++ b/registration/test/registration/services/LegacyRegistrationConverterSpec.scala
@@ -1,5 +1,6 @@
 package registration.services
 
+import models.Provider.Azure
 import models._
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
@@ -57,7 +58,7 @@ class LegacyRegistrationConverterSpec extends Specification {
         teams = None,
         matches = None,
         topics = None,
-        provider = None,
+        provider = Some(Azure),
       )
     )
     val expectedDefaultRegistration = Registration(
@@ -65,7 +66,7 @@ class LegacyRegistrationConverterSpec extends Specification {
       platform = iOS,
       topics = Set(Topic(TopicTypes.Breaking, "uk")),
       buildTier = Some("test"),
-      provider = None
+      provider = Some(Azure)
     )
   }
 }

--- a/registration/test/registration/services/MigratingRegistrarProviderSpec.scala
+++ b/registration/test/registration/services/MigratingRegistrarProviderSpec.scala
@@ -1,0 +1,61 @@
+package registration.services
+
+import error.NotificationsError
+import metrics.DummyMetrics
+import models.Provider.{Azure, FCM}
+import models.pagination.Paginated
+import models._
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import org.specs2.specification.mutable.ExecutionEnvironment
+import registration.services.NotificationRegistrar.RegistrarResponse
+
+class MigratingRegistrarProviderSpec(implicit ee: ExecutionEnv) extends Specification {
+
+  "Migrating registrar" should {
+    "register with azure if an iOS registration has only one Azure Token" in new IosMigratingRegistrarScope {
+      migratingRegistrarProvider.registrarFor(iOS, AzureToken("a"), None) should beRight(dummyAzureRegistrar)
+    }
+    "register with firebase if an iOS registration has only one Firebase Token" in new IosMigratingRegistrarScope {
+      migratingRegistrarProvider.registrarFor(iOS, FcmToken("f"), None) should beRight(dummyFirebaseRegistrar)
+    }
+    "register with azure if an iOS registration has both tokens, the provider is Azure or unknown" in new IosMigratingRegistrarScope {
+      migratingRegistrarProvider.registrarFor(iOS, BothTokens("a", "f"), None) should beRight(dummyAzureRegistrar)
+      migratingRegistrarProvider.registrarFor(iOS, BothTokens("a", "f"), Some(Azure)) should beRight(dummyAzureRegistrar)
+    }
+    "migrate to azure if an iOS registration has both tokens, the provider is FCM" in new IosMigratingRegistrarScope {
+      val result = migratingRegistrarProvider.registrarFor(iOS, BothTokens("a", "f"), Some(FCM))
+      result should beRight.which(_ should haveClass[MigratingRegistrar])
+      result should beRight.which(_.providerIdentifier shouldEqual "FirebaseToAzureRegistrar")
+    }
+  }
+
+  trait IosMigratingRegistrarScope extends Scope {
+    val dummyFirebaseRegistrar = new NotificationRegistrar {
+      override def findRegistrations(topic: Topic, cursor: Option[String]): RegistrarResponse[Paginated[StoredRegistration]] = ???
+      override def findRegistrations(deviceToken: DeviceToken): RegistrarResponse[List[StoredRegistration]] = ???
+      override def findRegistrations(udid: UniqueDeviceIdentifier): RegistrarResponse[Paginated[StoredRegistration]] = ???
+      override def unregister(deviceToken: DeviceToken): RegistrarResponse[Unit] = ???
+      override def register(deviceToken: DeviceToken, registration: Registration): RegistrarResponse[RegistrationResponse] = ???
+      override val providerIdentifier: String = ""
+    }
+
+    val dummyAzureRegistrar = new NotificationRegistrar {
+      override def findRegistrations(topic: Topic, cursor: Option[String]): RegistrarResponse[Paginated[StoredRegistration]] = ???
+      override def findRegistrations(deviceToken: DeviceToken): RegistrarResponse[List[StoredRegistration]] = ???
+      override def findRegistrations(udid: UniqueDeviceIdentifier): RegistrarResponse[Paginated[StoredRegistration]] = ???
+      override def unregister(deviceToken: DeviceToken): RegistrarResponse[Unit] = ???
+      override def register(deviceToken: DeviceToken, registration: Registration): RegistrarResponse[RegistrationResponse] = ???
+      override val providerIdentifier: String = ""
+    }
+
+    val dummyAzureRegistrarProvider = new RegistrarProvider {
+      override def withAllRegistrars[T](fn: NotificationRegistrar => T): List[T] = ???
+      override def registrarFor(registration: Registration): Either[NotificationsError, NotificationRegistrar] = Right(dummyAzureRegistrar)
+      override def registrarFor(platform: Platform, deviceToken: DeviceToken, currentProvider: Option[Provider]): Either[NotificationsError, NotificationRegistrar] = Right(dummyAzureRegistrar)
+    }
+
+    val migratingRegistrarProvider = new MigratingRegistrarProvider(dummyAzureRegistrarProvider, dummyFirebaseRegistrar, DummyMetrics)
+  }
+}

--- a/registration/test/registration/services/MigratingRegistrarSpec.scala
+++ b/registration/test/registration/services/MigratingRegistrarSpec.scala
@@ -87,7 +87,7 @@ class MigratingRegistrarSpec(implicit ee: ExecutionEnv) extends Specification wi
 
     val fcmRegistrar = mock[FcmRegistrar]
     val azureRegistrar = mock[NotificationRegistrar]
-    val migratingRegistrar = new MigratingRegistrar(fcmRegistrar, azureRegistrar)
+    val migratingRegistrar = new MigratingRegistrar("testRegistrar", fcmRegistrar, azureRegistrar)
   }
 
 }

--- a/registration/test/registration/services/MigratingRegistrarSpec.scala
+++ b/registration/test/registration/services/MigratingRegistrarSpec.scala
@@ -87,7 +87,11 @@ class MigratingRegistrarSpec(implicit ee: ExecutionEnv) extends Specification wi
 
     val fcmRegistrar = mock[FcmRegistrar]
     val azureRegistrar = mock[NotificationRegistrar]
-    val migratingRegistrar = new MigratingRegistrar("testRegistrar", fcmRegistrar, azureRegistrar)
+    val migratingRegistrar = new MigratingRegistrar(
+      providerIdentifier = "testRegistrar",
+      fromRegistrar = azureRegistrar,
+      toRegistrar = fcmRegistrar
+    )
   }
 
 }

--- a/report/test/report/services/NotificationReportEnricherSpec.scala
+++ b/report/test/report/services/NotificationReportEnricherSpec.scala
@@ -43,7 +43,7 @@ class NotificationReportEnricherSpec(implicit ev: ExecutionEnv) extends Specific
     )
 
     def createSenderReport(id: String) = SenderReport(
-      senderName = Provider.Azure,
+      senderName = Provider.Azure.value,
       sentTime = sentTime,
       sendersId = Some(s"https://guardian-windows-10-live-ns.servicebus.windows.net/guardian-notification-prod/messages/$id?api-version=2015-01"),
       platformStatistics = None


### PR DESCRIPTION
Add provider on the request and the response in order to help the server side decide how to migrate. We can also infer the provider by looking at how many tokens are received.

For ios:
 - if we have two tokens, and the provider is Firebase, we now migrate back to Azure
 - any other case, we keep registering to azure

For Android:
 - no change in the logic, if we have both tokens we migrate the user to firebase (for now)