### PR TITLE
Better notification reports

### DIFF
--- a/report/app/report/controllers/Report.scala
+++ b/report/app/report/controllers/Report.scala
@@ -14,6 +14,7 @@ import scala.concurrent.ExecutionContext
 import cats.data.EitherT
 import cats.implicits._
 import play.mvc.Security.AuthenticatedAction
+import report.models.ExtendedNotificationReport
 
 final class Report(
   configuration: Configuration,
@@ -36,7 +37,7 @@ final class Report(
         from = from.getOrElse(DateTime.now.minusWeeks(1)),
         to = until.getOrElse(DateTime.now)
       ) map {
-        case Right(result) => Ok(Json.toJson(result.map(new NotificationReport(_))))
+        case Right(result) => Ok(Json.toJson(result.map(ExtendedNotificationReport.summary)))
         case Left(error) => InternalServerError(error.message)
       }
     }

--- a/report/app/report/models/ExtendedNotificationReport.scala
+++ b/report/app/report/models/ExtendedNotificationReport.scala
@@ -1,13 +1,13 @@
-package models
+package report.models
 
 import java.time.Instant.ofEpochMilli
 import java.time.LocalDateTime.ofInstant
 import java.time.ZoneOffset.UTC
-import java.time.{Instant, LocalDateTime, ZoneOffset}
 import java.util.UUID
 
 import azure.NotificationDetails
-import com.gu.notifications.events.model.{DynamoEventAggregation, EventAggregation}
+import com.gu.notifications.events.model.EventAggregation
+import models._
 import org.joda.time.DateTime
 import play.api.libs.json.Json
 import play.api.libs.json.JodaWrites._

--- a/report/app/report/models/ExtendedNotificationReport.scala
+++ b/report/app/report/models/ExtendedNotificationReport.scala
@@ -1,25 +1,61 @@
 package report.models
 
 import java.time.Instant.ofEpochMilli
+import java.time.LocalDateTime
 import java.time.LocalDateTime.ofInstant
 import java.time.ZoneOffset.UTC
 import java.util.UUID
 
 import azure.NotificationDetails
-import com.gu.notifications.events.model.EventAggregation
+import com.gu.notifications.events.model._
 import models._
 import org.joda.time.DateTime
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
 
-case class ExtendedNotificationReport(
-  id: UUID,
-  `type`: NotificationType,
-  notification: Notification,
+case class ExtendedEventAggregation(
+  platformCounts: PlatformCount,
+  providerCounts: ProviderCount,
+  timing: Option[List[(LocalDateTime, Int)]]
+)
+
+object ExtendedEventAggregation {
+  implicit val extendedEventAggregationJF: Format[ExtendedEventAggregation] = Json.format[ExtendedEventAggregation]
+
+  def full(dynamoEventAggregation: DynamoEventAggregation, originalSentTime: LocalDateTime): ExtendedEventAggregation = {
+    def toOrderedTiming(timing: List[List[Int]]): Option[List[(LocalDateTime, Int)]] = {
+      val sentTime = originalSentTime.truncatedTo(TenSecondUnit)
+      val (_, orderedTiming) = dynamoEventAggregation.timing.map(timed => (timed.head, timed(1))).foldLeft((sentTime, List[(LocalDateTime, Int)]())) {
+        case ((lastTime, newList), (offset, count)) =>
+          val nextTime = lastTime.plusSeconds(10 * offset)
+          (nextTime, newList :+ (nextTime, count))
+      }
+      if (orderedTiming.isEmpty) None else Some(orderedTiming)
+    }
+
+    ExtendedEventAggregation(
+      platformCounts = dynamoEventAggregation.platform,
+      providerCounts = dynamoEventAggregation.provider,
+      timing = toOrderedTiming(dynamoEventAggregation.timing)
+    )
+  }
+
+  def summary(dynamoEventAggregation: DynamoEventAggregation): ExtendedEventAggregation = {
+    ExtendedEventAggregation(
+      platformCounts = dynamoEventAggregation.platform,
+      providerCounts = dynamoEventAggregation.provider,
+      timing = None
+    )
+  }
+}
+
+case class ExtendedSenderReport(
+  senderName: String,
   sentTime: DateTime,
-  reports: List[ExtendedSenderReport],
-  events: Option[EventAggregation]
+  sendersId: Option[String] = None,
+  platformStatistics: Option[PlatformStatistics] = None,
+  debug: Option[NotificationDetails]
 )
 
 object ExtendedSenderReport {
@@ -34,24 +70,36 @@ object ExtendedSenderReport {
   )
 }
 
+case class ExtendedNotificationReport(
+  id: UUID,
+  `type`: NotificationType,
+  notification: Notification,
+  sentTime: DateTime,
+  reports: List[ExtendedSenderReport],
+  events: Option[ExtendedEventAggregation]
+)
 
 object ExtendedNotificationReport {
   implicit val jf = Json.format[ExtendedNotificationReport]
 
-  def fromNotificationReport(r: DynamoNotificationReport): ExtendedNotificationReport = ExtendedNotificationReport(
+  def full(r: DynamoNotificationReport): ExtendedNotificationReport = {
+    val javaTimeSentTime = ofInstant(ofEpochMilli(r.sentTime.toInstant.getMillis), UTC)
+    ExtendedNotificationReport(
+      id = r.id,
+      `type` = r.`type`,
+      notification = r.notification,
+      sentTime = r.sentTime,
+      reports = r.reports.map(ExtendedSenderReport.fromSenderReport),
+      events = r.events.map(events => ExtendedEventAggregation.full(events, javaTimeSentTime))
+    )
+  }
+
+  def summary(r: DynamoNotificationReport): ExtendedNotificationReport = ExtendedNotificationReport(
     id = r.id,
     `type` = r.`type`,
     notification = r.notification,
     sentTime = r.sentTime,
     reports = r.reports.map(ExtendedSenderReport.fromSenderReport),
-    events = r.events.map(EventAggregation.from(_, ofInstant(ofEpochMilli(r.sentTime.toInstant.getMillis), UTC)))
+    events = r.events.map(ExtendedEventAggregation.summary)
   )
 }
-
-case class ExtendedSenderReport(
-  senderName: String,
-  sentTime: DateTime,
-  sendersId: Option[String] = None,
-  platformStatistics: Option[PlatformStatistics] = None,
-  debug: Option[NotificationDetails]
-)

--- a/report/app/report/services/NotificationReportEnricher.scala
+++ b/report/app/report/services/NotificationReportEnricher.scala
@@ -3,12 +3,13 @@ package report.services
 import java.net.URI
 
 import azure.NotificationHubClient
-import models.{ExtendedNotificationReport, ExtendedSenderReport, DynamoNotificationReport}
+import models.DynamoNotificationReport
+
 import scala.concurrent.ExecutionContext
 import scala.PartialFunction._
 import scala.concurrent.Future
 import scala.util.Try
-import cats.syntax.either._
+import report.models.{ExtendedNotificationReport, ExtendedSenderReport}
 
 class NotificationReportEnricher(hubClient: NotificationHubClient)(implicit ec: ExecutionContext) {
 

--- a/report/app/report/services/NotificationReportEnricher.scala
+++ b/report/app/report/services/NotificationReportEnricher.scala
@@ -14,7 +14,7 @@ import report.models.{ExtendedNotificationReport, ExtendedSenderReport}
 class NotificationReportEnricher(hubClient: NotificationHubClient)(implicit ec: ExecutionContext) {
 
   def enrich(notificationReport: DynamoNotificationReport): Future[ExtendedNotificationReport] = {
-    val extended = ExtendedNotificationReport.fromNotificationReport(notificationReport)
+    val extended = ExtendedNotificationReport.full(notificationReport)
     Future.sequence(extended.reports.map(addDebugField)).map { extendedReports =>
       extended.copy(reports = extendedReports)
     }

--- a/report/conf/gu-conf/DEV.properties
+++ b/report/conf/gu-conf/DEV.properties
@@ -1,1 +1,0 @@
-gu.msnotifications.admin-api-key=test

--- a/report/test/report/controllers/ReportIntegrationSpec.scala
+++ b/report/test/report/controllers/ReportIntegrationSpec.scala
@@ -77,7 +77,7 @@ class ReportIntegrationSpec(implicit ee: ExecutionEnv) extends PlaySpecification
         reports = List(
           SenderReport("Firebase", DateTime.now.withZone(UTC), Some(s"hub-$id"), Some(PlatformStatistics(Android, 5)))
         ),
-        version = Some(UUID.randomUUID()),
+        version = None,
         events = None
       )
     }

--- a/report/test/report/controllers/ReportIntegrationSpec.scala
+++ b/report/test/report/controllers/ReportIntegrationSpec.scala
@@ -116,7 +116,7 @@ class ReportIntegrationSpec(implicit ee: ExecutionEnv) extends PlaySpecification
 
       val report = reportsInRange.head
 
-      val enrichedReport = ExtendedNotificationReport.fromNotificationReport(report)
+      val enrichedReport = ExtendedNotificationReport.full(report)
 
       val details = NotificationDetails(
         state = NotificationStates.Completed,

--- a/report/test/report/controllers/ReportIntegrationSpec.scala
+++ b/report/test/report/controllers/ReportIntegrationSpec.scala
@@ -22,6 +22,7 @@ import report.services.{Configuration, NotificationReportEnricher}
 import tracking.InMemoryNotificationReportRepository
 import cats.implicits._
 import com.softwaremill.macwire._
+import report.models.ExtendedNotificationReport
 
 import scala.concurrent.Future
 

--- a/report/test/report/services/NotificationReportEnricherSpec.scala
+++ b/report/test/report/services/NotificationReportEnricherSpec.scala
@@ -12,6 +12,7 @@ import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import cats.implicits._
+import report.models.{ExtendedNotificationReport, ExtendedSenderReport}
 
 import scala.concurrent.Future
 

--- a/report/test/report/services/NotificationReportEnricherSpec.scala
+++ b/report/test/report/services/NotificationReportEnricherSpec.scala
@@ -85,7 +85,7 @@ class NotificationReportEnricherSpec(implicit ev: ExecutionEnv) extends Specific
     )
 
     val expected = {
-      val enriched = ExtendedNotificationReport.fromNotificationReport(report)
+      val enriched = ExtendedNotificationReport.full(report)
       enriched.copy(reports = senderReportsWithDetails.map { case (_, senderReport, details) =>
         ExtendedSenderReport.fromSenderReport(senderReport).copy(debug = Some(details))
       })


### PR DESCRIPTION
The report.notifications.guardianapis.com/notifications? endpoint now lists counts without timmings, but the detailed endpoint lists all the metrics