### PR TITLE
MSS-487: Efficient timing conversion

### DIFF
--- a/commoneventconsumer/src/main/scala/com/gu/notifications/events/model/EventAggregation.scala
+++ b/commoneventconsumer/src/main/scala/com/gu/notifications/events/model/EventAggregation.scala
@@ -6,8 +6,6 @@ import java.util.UUID
 
 import play.api.libs.json.{JsValue, Json, OFormat}
 
-import scala.collection.mutable.ListBuffer
-
 case class EventAggregation(
   platformCounts: PlatformCount,
   providerCounts: ProviderCount,


### PR DESCRIPTION
Converting the timings was taking upto 7 seconds!
It seems this is because of the repeated rebuilding of the list, so amended to use a mutabe list (ListBuffer) which has a much smaller overhead to build as it doens't have to be rebuilt.
