### PR TITLE
Stabilise android notifications

### DIFF
--- a/common/src/main/scala/azure/RawGCMRegistration.scala
+++ b/common/src/main/scala/azure/RawGCMRegistration.scala
@@ -5,7 +5,7 @@ import models.Registration
 object RawGCMRegistration {
   def fromMobileRegistration(m: Registration): RawGCMRegistration = {
     RawGCMRegistration(
-      gcmRegistrationId = m.deviceToken.azureToken,
+      gcmRegistrationId = m.deviceToken.fcmToken,
       tags = Tags()
         .withTopics(m.topics)
         .asSet

--- a/common/src/test/scala/azure/RawGCMRegistrationSpec.scala
+++ b/common/src/test/scala/azure/RawGCMRegistrationSpec.scala
@@ -1,7 +1,7 @@
 package azure
 
 import models.TopicTypes.FootballMatch
-import models.{Android, AzureToken, Registration, Topic}
+import models._
 import org.specs2.mutable.Specification
 
 class RawGCMRegistrationSpec extends Specification {
@@ -11,7 +11,7 @@ class RawGCMRegistrationSpec extends Specification {
     "be created from mobile registration with topics as tags" in {
       val topic = Topic(`type` = FootballMatch, "arsenal-chelsea")
       val registration = Registration(
-        deviceToken = AzureToken("device2"),
+        deviceToken = FcmToken("device2"),
         platform = Android,
         topics = Set(topic),
         buildTier = None,
@@ -21,6 +21,19 @@ class RawGCMRegistrationSpec extends Specification {
       val rawRegistration = RawGCMRegistration.fromMobileRegistration(registration)
 
       rawRegistration.tags must contain(Tag.fromTopic(topic).encodedTag)
+    }
+
+    "throw an exception if trying to create a registration with an azure token" in {
+      val topic = Topic(`type` = FootballMatch, "arsenal-chelsea")
+      val registration = Registration(
+        deviceToken = AzureToken("device2"),
+        platform = Android,
+        topics = Set(topic),
+        buildTier = None,
+        provider = None
+      )
+
+      RawGCMRegistration.fromMobileRegistration(registration) should throwA[RuntimeException]
     }
   }
 

--- a/registration/app/registration/services/azure/GCMNotificationRegistrar.scala
+++ b/registration/app/registration/services/azure/GCMNotificationRegistrar.scala
@@ -2,9 +2,13 @@ package registration.services.azure
 
 import azure.{NotificationHubClient, RawGCMRegistration}
 import metrics.Metrics
+import models.DeviceToken
 import tracking.SubscriptionTracker
 
 import scala.concurrent.ExecutionContext
 
 class GCMNotificationRegistrar(hubClient: NotificationHubClient, subscriptionTracker: SubscriptionTracker, metrics: Metrics)(implicit ec: ExecutionContext)
-  extends NotificationHubRegistrar(hubClient, subscriptionTracker, RawGCMRegistration.fromMobileRegistration, metrics)(ec)
+  extends NotificationHubRegistrar(hubClient, subscriptionTracker, RawGCMRegistration.fromMobileRegistration, metrics)(ec) {
+  // forcing the FCM token on azure as all devices have migrated to azure
+  override def token(deviceToken: DeviceToken): String = deviceToken.fcmToken
+}

--- a/registration/test/registration/services/MigratingRegistrarProviderSpec.scala
+++ b/registration/test/registration/services/MigratingRegistrarProviderSpec.scala
@@ -8,30 +8,51 @@ import models._
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import org.specs2.specification.mutable.ExecutionEnvironment
 import registration.services.NotificationRegistrar.RegistrarResponse
 
 class MigratingRegistrarProviderSpec(implicit ee: ExecutionEnv) extends Specification {
 
   "Migrating registrar" should {
-    "register with azure if an iOS registration has only one Azure Token" in new IosMigratingRegistrarScope {
+    "register with azure if an iOS registration has only one Azure Token" in new MigratingRegistrarScope {
       migratingRegistrarProvider.registrarFor(iOS, AzureToken("a"), None) should beRight(dummyAzureRegistrar)
     }
-    "register with firebase if an iOS registration has only one Firebase Token" in new IosMigratingRegistrarScope {
+    "register with firebase if an iOS registration has only one Firebase Token" in new MigratingRegistrarScope {
       migratingRegistrarProvider.registrarFor(iOS, FcmToken("f"), None) should beRight(dummyFirebaseRegistrar)
     }
-    "register with azure if an iOS registration has both tokens, the provider is Azure or unknown" in new IosMigratingRegistrarScope {
+    "register with azure if an iOS registration has both tokens, the provider is Azure or unknown" in new MigratingRegistrarScope {
       migratingRegistrarProvider.registrarFor(iOS, BothTokens("a", "f"), None) should beRight(dummyAzureRegistrar)
       migratingRegistrarProvider.registrarFor(iOS, BothTokens("a", "f"), Some(Azure)) should beRight(dummyAzureRegistrar)
     }
-    "migrate to azure if an iOS registration has both tokens, the provider is FCM" in new IosMigratingRegistrarScope {
+    "migrate to azure if an iOS registration has both tokens, the provider is FCM" in new MigratingRegistrarScope {
       val result = migratingRegistrarProvider.registrarFor(iOS, BothTokens("a", "f"), Some(FCM))
       result should beRight.which(_ should haveClass[MigratingRegistrar])
-      result should beRight.which(_.providerIdentifier shouldEqual "FirebaseToAzureRegistrar")
+      result should beRight.which(_.providerIdentifier shouldEqual "IosFirebaseToAzureRegistrar")
+    }
+
+    "register with azure if an Android registration has only one Azure Token" in new MigratingRegistrarScope {
+      migratingRegistrarProvider.registrarFor(Android, AzureToken("a"), None) should beRight(dummyAzureRegistrar)
+    }
+    "migrate to azure if an Android registration has only one Firebase Token" in new MigratingRegistrarScope {
+      val result = migratingRegistrarProvider.registrarFor(Android, FcmToken("f"), None)
+      result should beRight.which(_ should haveClass[MigratingRegistrar])
+      result should beRight.which(_.providerIdentifier shouldEqual "AndroidFirebaseToAzureRegistrar")
+    }
+    "migrate to azure if an Android registration has both tokens, the provider is Azure or unknown" in new MigratingRegistrarScope {
+      val result1 = migratingRegistrarProvider.registrarFor(Android, BothTokens("a", "f"), None)
+      val result2 = migratingRegistrarProvider.registrarFor(Android, BothTokens("a", "f"), Some(Azure))
+      result1 should beRight.which(_ should haveClass[MigratingRegistrar])
+      result1 should beRight.which(_.providerIdentifier shouldEqual "AndroidFirebaseToAzureRegistrar")
+      result2 should beRight.which(_ should haveClass[MigratingRegistrar])
+      result2 should beRight.which(_.providerIdentifier shouldEqual "AndroidFirebaseToAzureRegistrar")
+    }
+    "migrate to azure if an Android registration has both tokens, the provider is FCM" in new MigratingRegistrarScope {
+      val result = migratingRegistrarProvider.registrarFor(Android, BothTokens("a", "f"), Some(FCM))
+      result should beRight.which(_ should haveClass[MigratingRegistrar])
+      result should beRight.which(_.providerIdentifier shouldEqual "AndroidFirebaseToAzureRegistrar")
     }
   }
 
-  trait IosMigratingRegistrarScope extends Scope {
+  trait MigratingRegistrarScope extends Scope {
     val dummyFirebaseRegistrar = new NotificationRegistrar {
       override def findRegistrations(topic: Topic, cursor: Option[String]): RegistrarResponse[Paginated[StoredRegistration]] = ???
       override def findRegistrations(deviceToken: DeviceToken): RegistrarResponse[List[StoredRegistration]] = ???


### PR DESCRIPTION
Replaces https://github.com/guardian/mobile-n10n/pull/214

A simplified version of the migration back. It re-uses the existing notification hub, pointing it to firebase. This requires a configuration change before being pushed to prod, and will cut off