### PR TITLE
Report: Add timing percentiles

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,8 @@ val log4j2Version: String = "2.10.0"
 lazy val commoneventconsumer = project
   .settings(Seq(
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-json" % playJsonVersion
+      "com.typesafe.play" %% "play-json" % playJsonVersion,
+      "org.specs2" %% "specs2-core" % specsVersion % "test"
     )
   ))
 

--- a/commoneventconsumer/src/main/scala/com/gu/notifications/events/model/EventAggregation.scala
+++ b/commoneventconsumer/src/main/scala/com/gu/notifications/events/model/EventAggregation.scala
@@ -4,13 +4,54 @@ import java.time.temporal.{ChronoUnit, Temporal, TemporalUnit}
 import java.time.{Duration, LocalDateTime}
 import java.util.UUID
 
-import play.api.libs.json.{JsValue, Json, OFormat}
+import com.gu.notifications.events.utils.Percentiles
+import play.api.libs.json.{JsValue, Json, OFormat, Writes}
+import com.gu.notifications.events.utils.OWriteOps._
+
+case class TimingPercentiles(
+  `10th`: LocalDateTime,
+  `20th`: LocalDateTime,
+  `30th`: LocalDateTime,
+  `40th`: LocalDateTime,
+  `50th`: LocalDateTime,
+  `60th`: LocalDateTime,
+  `70th`: LocalDateTime,
+  `80th`: LocalDateTime,
+  `90th`: LocalDateTime,
+  `95th`: LocalDateTime,
+  `99th`: LocalDateTime
+)
+
+object TimingPercentiles {
+  implicit val jf = Json.format[TimingPercentiles]
+}
 
 case class EventAggregation(
   platformCounts: PlatformCount,
   providerCounts: ProviderCount,
   timing: Map[LocalDateTime, Int]
-)
+) {
+
+  def timingPercentiles: Option[TimingPercentiles] = {
+    val allTimings: Seq[LocalDateTime] = timing
+      .toSeq
+      .flatMap { case (t, count) =>
+        Seq.fill(count)(t)
+      }
+      .view
+    Seq(10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99)
+      .flatMap { p =>
+        Percentiles
+          .percentile(p)(allTimings)(_ compareTo _)
+          .toOption
+      } match {
+      case Seq(d10, d20, d30, d40, d50, d60, d70, d80, d90, d95, d99) =>
+        Some(TimingPercentiles(d10, d20, d30, d40, d50, d60, d70, d80, d90, d95, d99))
+      case _ => None
+    }
+  }
+
+}
 
 // based on SECONDS so adopts same properties. Else functions copied from ChronoUnit
 object TenSecondUnit extends TemporalUnit {
@@ -79,6 +120,12 @@ object EventAggregation {
     (value: JsValue) => value.validate[Map[String, Int]].map(_.map { case (k, v) => (LocalDateTime.parse(k), v) }),
     (dateTimeMap: Map[LocalDateTime, Int]) => Json.toJsObject(dateTimeMap.map { case (k, v) => (k.toString, v) })
   )
-  implicit val jf = Json.format[EventAggregation]
+
+  implicit val jreads = Json.reads[EventAggregation]
+  implicit val jwrites: Writes[EventAggregation] =
+    Json
+      .writes[EventAggregation]
+      .addField("timingPercentiles", _.timingPercentiles)
+      .removeField("timing")
 
 }

--- a/commoneventconsumer/src/main/scala/com/gu/notifications/events/utils/OWritesOps.scala
+++ b/commoneventconsumer/src/main/scala/com/gu/notifications/events/utils/OWritesOps.scala
@@ -1,0 +1,20 @@
+package com.gu.notifications.events.utils
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
+object OWriteOps {
+
+  implicit class OWritesOps[A](writes: OWrites[A]) {
+    def addField[T: Writes](fieldName: String, field: A => T): OWrites[A] =
+      (writes ~ (__ \ fieldName).write[T])((a: A) => (a, field(a)))
+
+    def removeField(fieldName: String): OWrites[A] = OWrites { a: A =>
+      val transformer = (__ \ fieldName).json.prune
+      Json.toJson(a)(writes).validate(transformer).get
+    }
+  }
+
+}
+
+

--- a/commoneventconsumer/src/main/scala/com/gu/notifications/events/utils/Percentiles.scala
+++ b/commoneventconsumer/src/main/scala/com/gu/notifications/events/utils/Percentiles.scala
@@ -1,0 +1,25 @@
+package com.gu.notifications.events.utils
+
+object Percentiles {
+
+  sealed trait PercentilesException extends RuntimeException
+  case object InvalidPercentile extends PercentilesException {
+    override def getLocalizedMessage: String = s"Percentile should be between 0 and 100"
+  }
+  case object EmptyValues extends PercentilesException {
+    override def getLocalizedMessage: String = s"Cannot calculate percentile of no values"
+  }
+
+  def percentile[A](perc: Int)(as: Seq[A])(implicit ord: Ordering[A]): Either[PercentilesException, A] = {
+    (perc, as) match {
+      case (p, _) if p < 0 || p > 100 => Left(InvalidPercentile)
+      case (_, Nil) => Left(EmptyValues)
+      case (p, v) =>
+        val percIndex = as.length * p / 100
+        val maxIndex = as.length - 1
+        Right(v.sorted.apply(Math.min(percIndex, maxIndex)))
+    }
+  }
+
+}
+

--- a/commoneventconsumer/src/test/scala/com/gu/notifications/events/model/EventAggregationTest.scala
+++ b/commoneventconsumer/src/test/scala/com/gu/notifications/events/model/EventAggregationTest.scala
@@ -1,0 +1,42 @@
+package com.gu.notifications.events.model
+
+import org.specs2.mutable.Specification
+import java.time.LocalDateTime
+
+class EventAggregationTest extends Specification {
+
+  val mockPlatformCount = PlatformCount(10, 10, 10)
+  val mockProviderCount = ProviderCount(10, mockPlatformCount, mockPlatformCount)
+  def mockEventAggregation(timing: Map[LocalDateTime, Int]) = EventAggregation(mockPlatformCount, mockProviderCount, timing)
+
+  "timingPercentiles" should {
+    "return None if no timing" in {
+      mockEventAggregation(Map.empty).timingPercentiles should equalTo(None)
+    }
+    "return return all deciles plus 95th and 99th percentiles" in {
+      val now = LocalDateTime.now
+      val timings = Map(
+        now.plusSeconds(1) -> 12,
+        now.plusSeconds(2) -> 68,
+        now.plusSeconds(10) -> 20
+      )
+      val expected = Some(
+        TimingPercentiles(
+          now.plusSeconds(1),
+          now.plusSeconds(2),
+          now.plusSeconds(2),
+          now.plusSeconds(2),
+          now.plusSeconds(2),
+          now.plusSeconds(2),
+          now.plusSeconds(2),
+          now.plusSeconds(10),
+          now.plusSeconds(10),
+          now.plusSeconds(10),
+          now.plusSeconds(10)
+        )
+      )
+      mockEventAggregation(timings).timingPercentiles should equalTo(expected)
+    }
+  }
+
+}

--- a/commoneventconsumer/src/test/scala/com/gu/notifications/events/utils/PercentilesTest.scala
+++ b/commoneventconsumer/src/test/scala/com/gu/notifications/events/utils/PercentilesTest.scala
@@ -39,4 +39,38 @@ class PercentilesTest extends Specification {
     }
   }
 
+  "percentileBucket" should {
+    "return correct error if percentile value is less or equal to 0" in {
+      percentileBuckets(-1)(Map("a" -> 1)) should equalTo(Left[PercentilesException, Int](InvalidPercentile))
+    }
+    "return correct error if percentile value is greater than 100" in {
+      percentileBuckets(101)(Map("a" -> 1)) should equalTo(Left[PercentilesException, Int](InvalidPercentile))
+    }
+    "return correct error if buckets is empty" in {
+      percentileBuckets(50)(Map.empty[String, Int]) should equalTo(Left[PercentilesException, Int](EmptyValues))
+    }
+    "return lowest bucket when asking for the 0th percentile" in {
+      percentileBuckets(0)(Map("a" -> 1, "b" -> 1, "c" -> 1)) should equalTo(Right("a"))
+    }
+    "return highest bucket when asking for the 100th percentile" in {
+      percentileBuckets(100)(Map("a" -> 1, "b" -> 1, "c" -> 1, "d" -> 1)) should equalTo(Right("d"))
+    }
+    "return correct bucket" in {
+      val buckets = Map("a" -> 1, "b" -> 1, "c" -> 1, "d" -> 1, "e" -> 1, "f" -> 1, "g" -> 1, "h" -> 1, "i" -> 1, "j" -> 1)
+      percentileBuckets(10)(buckets) should equalTo(Right("a"))
+      percentileBuckets(20)(buckets) should equalTo(Right("b"))
+      percentileBuckets(30)(buckets) should equalTo(Right("c"))
+      percentileBuckets(40)(buckets) should equalTo(Right("d"))
+      percentileBuckets(50)(buckets) should equalTo(Right("e"))
+      percentileBuckets(60)(buckets) should equalTo(Right("f"))
+      percentileBuckets(70)(buckets) should equalTo(Right("g"))
+      percentileBuckets(80)(buckets) should equalTo(Right("h"))
+      percentileBuckets(90)(buckets) should equalTo(Right("i"))
+
+      val moreBuckets = Map("a" -> 1, "b" -> 1, "c" -> 1, "d" -> 1, "e" -> 1, "f" -> 5)
+      percentileBuckets(50)(moreBuckets) should equalTo(Right("e"))
+      percentileBuckets(99)(moreBuckets) should equalTo(Right("f"))
+    }
+  }
+
 }

--- a/commoneventconsumer/src/test/scala/com/gu/notifications/events/utils/PercentilesTest.scala
+++ b/commoneventconsumer/src/test/scala/com/gu/notifications/events/utils/PercentilesTest.scala
@@ -1,0 +1,42 @@
+package com.gu.notifications.events.utils
+
+import com.gu.notifications.events.utils.Percentiles.{EmptyValues, InvalidPercentile, PercentilesException}
+import org.specs2.mutable.Specification
+import com.gu.notifications.events.utils.Percentiles._
+
+class PercentilesTest extends Specification {
+
+  "percentile" should {
+    "return correct error if percentile value is less or equal to 0" in {
+      percentile(-1)(Seq(1)) should equalTo(Left[PercentilesException, Int](InvalidPercentile))
+    }
+    "return correct error if percentile value is greater than 100" in {
+      percentile(101)(Seq(1)) should equalTo(Left[PercentilesException, Int](InvalidPercentile))
+    }
+    "return correct error if list of values is empty" in {
+      percentile(50)(Seq.empty[Int]) should equalTo(Left[PercentilesException, Int](EmptyValues))
+    }
+    "return lowest value when asking for the 0th percentile" in {
+      percentile(0)(Seq(3, 1, 3)) should equalTo(Right(1))
+    }
+    "return highest value when asking for the 100th percentile" in {
+      percentile(100)(Seq(3, 4, 1, 3)) should equalTo(Right(4))
+    }
+    "calculate correct values" in {
+      val ints = Seq(9, 8, 7, 6, 5, 4, 3, 2, 1)
+      percentile(10)(ints) should equalTo(Right(1))
+      percentile(20)(ints) should equalTo(Right(2))
+      percentile(30)(ints) should equalTo(Right(3))
+      percentile(40)(ints) should equalTo(Right(4))
+      percentile(50)(ints) should equalTo(Right(5))
+      percentile(60)(ints) should equalTo(Right(6))
+      percentile(70)(ints) should equalTo(Right(7))
+      percentile(80)(ints) should equalTo(Right(8))
+      percentile(90)(ints) should equalTo(Right(9))
+
+      percentile(50)(Seq(1, 1, 1, 1, 1, 1, 8)) should equalTo(Right(1))
+      percentile(99)(Seq(1, 1, 1, 1, 1, 1, 8)) should equalTo(Right(8))
+    }
+  }
+
+}


### PR DESCRIPTION
Notification report endpoins now returns the timing percentiles rather than a map of all timings 10secs slots

![screen shot 2018-10-15 at 11 11 01](https://user-images.githubusercontent.com/233326/46944828-0512db00-d06b-11e8-933a-6bbe7b4838a1.png)
