### PR TITLE
Copying registrar

### DIFF
--- a/registration/app/registration/services/CopyingRegistrar.scala
+++ b/registration/app/registration/services/CopyingRegistrar.scala
@@ -11,8 +11,8 @@ import scala.util.{Failure, Success}
 
 class CopyingRegistrar(
   val providerIdentifier: String,
-  mainRegistrar: NotificationRegistrar,
-  copyRegistrar: NotificationRegistrar
+  val mainRegistrar: NotificationRegistrar,
+  val copyRegistrar: NotificationRegistrar
 )(
   implicit ec: ExecutionContext
 ) extends NotificationRegistrar {

--- a/registration/app/registration/services/CopyingRegistrar.scala
+++ b/registration/app/registration/services/CopyingRegistrar.scala
@@ -1,0 +1,60 @@
+package registration.services
+import cats.data.EitherT
+import cats.implicits._
+import models.{DeviceToken, Registration, Topic, UniqueDeviceIdentifier}
+import models.pagination.Paginated
+import play.api.Logger
+import registration.services.NotificationRegistrar.RegistrarResponse
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+class CopyingRegistrar(
+  val providerIdentifier: String,
+  mainRegistrar: NotificationRegistrar,
+  copyRegistrar: NotificationRegistrar
+)(
+  implicit ec: ExecutionContext
+) extends NotificationRegistrar {
+
+  private val logger = Logger(classOf[CopyingRegistrar])
+
+  private def applyToMainAndCopy[A](function: NotificationRegistrar => RegistrarResponse[A]): RegistrarResponse[A] = {
+    val mainResponse = function(mainRegistrar)
+    // the copy is considered a side effect, if there's an error it will be dumped in the logs and swallowed
+    val copyResponse = function(copyRegistrar)
+    copyResponse.onComplete {
+      case Failure(error) => logger.error(s"Unable to duplicate registration operation to ${copyRegistrar.providerIdentifier}", error)
+      case Success(Left(error)) => logger.error(s"Unable to duplicate registration operation to ${copyRegistrar.providerIdentifier}: $error")
+      case _ =>
+    }
+    mainResponse
+  }
+
+  override def register(deviceToken: DeviceToken, registration: Registration): RegistrarResponse[RegistrationResponse] =
+    applyToMainAndCopy(_.register(deviceToken, registration))
+
+  override def unregister(deviceToken: DeviceToken): RegistrarResponse[Unit] =
+    applyToMainAndCopy(_.unregister(deviceToken))
+
+  override def findRegistrations(topic: Topic, cursor: Option[String]): RegistrarResponse[Paginated[StoredRegistration]] = {
+    // rarely used (only by devs) we'll know this is running on the main registrar only
+    mainRegistrar.findRegistrations(topic, cursor)
+  }
+
+  override def findRegistrations(deviceToken: DeviceToken): RegistrarResponse[List[StoredRegistration]] = {
+    val mainResponseF = mainRegistrar.findRegistrations(deviceToken)
+    val copyResponseF = copyRegistrar.findRegistrations(deviceToken)
+
+    for {
+      mainResponse <- EitherT(mainResponseF).getOrElse(Nil)
+      copyResponse <- EitherT(copyResponseF).getOrElse(Nil)
+    } yield Right(mainResponse ++ copyResponse)
+  }
+
+  override def findRegistrations(udid: UniqueDeviceIdentifier): RegistrarResponse[Paginated[StoredRegistration]] = {
+    // this method is here for GDPR compliance, executed on the main registrar as we don't store
+    // the browser ID anymore
+    mainRegistrar.findRegistrations(udid)
+  }
+}

--- a/registration/app/registration/services/CopyingRegistrarProvider.scala
+++ b/registration/app/registration/services/CopyingRegistrarProvider.scala
@@ -1,0 +1,39 @@
+package registration.services
+
+import error.NotificationsError
+import metrics.Metrics
+import models.{DeviceToken, Platform, Provider, Registration}
+
+import scala.concurrent.ExecutionContext
+
+class CopyingRegistrarProvider(
+  delegateRegistrarProvider: RegistrarProvider,
+  copyRegistrar: NotificationRegistrar,
+  metrics: Metrics
+)(implicit executionContext: ExecutionContext) extends RegistrarProvider {
+
+  override def registrarFor(registration: Registration): Either[NotificationsError, NotificationRegistrar] =
+    registrarFor(registration.platform, registration.deviceToken, registration.provider)
+
+  override def withAllRegistrars[T](fn: NotificationRegistrar => T): List[T] =
+    delegateRegistrarProvider.withAllRegistrars(fn)
+
+  override def registrarFor(
+    platform: Platform,
+    deviceToken: DeviceToken,
+    currentProvider: Option[Provider]
+  ): Either[NotificationsError, NotificationRegistrar] = {
+
+    def wrapWithCopyRegistrar(registrar: NotificationRegistrar): NotificationRegistrar = {
+      new CopyingRegistrar(
+        providerIdentifier = "CopyingRegistrar",
+        mainRegistrar = registrar,
+        copyRegistrar = copyRegistrar
+      )
+    }
+
+    delegateRegistrarProvider
+      .registrarFor(platform, deviceToken, currentProvider)
+      .map(wrapWithCopyRegistrar)
+  }
+}

--- a/registration/test/registration/services/CopyingRegistrarProviderSpec.scala
+++ b/registration/test/registration/services/CopyingRegistrarProviderSpec.scala
@@ -1,0 +1,32 @@
+package registration.services
+
+import error.NotificationsError
+import metrics.DummyMetrics
+import models._
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+
+class CopyingRegistrarProviderSpec(implicit ee: ExecutionEnv) extends Specification with Mockito {
+  "The CopyingRegistrar" should {
+    "wrap a registrar with the CopyingRegistrar" in {
+      val copyRegistrar = mock[NotificationRegistrar]
+      val mainRegistrar = mock[NotificationRegistrar]
+      val delegateRegistrarProvider = new RegistrarProvider {
+        override def withAllRegistrars[T](fn: NotificationRegistrar => T): List[T] = ???
+        override def registrarFor(registration: Registration): Either[NotificationsError, NotificationRegistrar] = ???
+        override def registrarFor(platform: Platform, deviceToken: DeviceToken, currentProvider: Option[Provider]): Either[NotificationsError, NotificationRegistrar] = Right(mainRegistrar)
+      }
+
+      val copyingRegistrarProvider = new CopyingRegistrarProvider(delegateRegistrarProvider, copyRegistrar, DummyMetrics)
+
+      val result = copyingRegistrarProvider.registrarFor(iOS, BothTokens("A", "F"), None)
+      result should beRight.which { wrappedRegistrar =>
+        wrappedRegistrar.providerIdentifier shouldEqual "CopyingRegistrar"
+        val copyingRegistrar = wrappedRegistrar.asInstanceOf[CopyingRegistrar]
+        copyingRegistrar.mainRegistrar shouldEqual mainRegistrar
+        copyingRegistrar.copyRegistrar shouldEqual copyRegistrar
+      }
+    }
+  }
+}

--- a/registration/test/registration/services/CopyingRegistrarSpec.scala
+++ b/registration/test/registration/services/CopyingRegistrarSpec.scala
@@ -1,0 +1,97 @@
+package registration.services
+
+import models.pagination.Paginated
+import models.{DeviceToken, Registration, Topic, UniqueDeviceIdentifier}
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import registration.services.fcm.FcmRegistrar
+
+import scala.concurrent.Future
+
+class CopyingRegistrarSpec(implicit ee: ExecutionEnv) extends Specification with Mockito {
+
+  "The copying registrar" should {
+    "register devices with the main and copy registrars" in new CopyingRegistrarScope {
+      val registrationResponse = mock[RegistrationResponse]
+      val deviceToken = mock[DeviceToken]
+      val registration = mock[Registration]
+      mainRegistrar.register(deviceToken, registration) returns Future.successful(Right(registrationResponse))
+      copyRegistrar.register(deviceToken, registration) returns Future.successful(Right(registrationResponse))
+
+      val response = copyingRegistrar.register(deviceToken, registration)
+
+      response should beRight(registrationResponse).await
+      there was one(copyRegistrar).register(deviceToken, registration)
+      there was one(mainRegistrar).register(deviceToken, registration)
+    }
+
+    "unregister devices using both the main and copy registrars" in new CopyingRegistrarScope {
+      val deviceToken = mock[DeviceToken]
+      mainRegistrar.unregister(deviceToken) returns Future.successful(Right(()))
+      copyRegistrar.unregister(deviceToken) returns Future.successful(Right(()))
+
+      val response = copyingRegistrar.unregister(deviceToken)
+
+      response should beRight(()).await
+      there was one(copyRegistrar).unregister(deviceToken)
+      there was one(mainRegistrar).unregister(deviceToken)
+    }
+
+    "only search registrations by topic using the main registrar" in new CopyingRegistrarScope {
+      val topic = mock[Topic]
+      val findResponse = mock[Paginated[StoredRegistration]]
+      mainRegistrar.findRegistrations(topic, None) returns Future.successful(Right(findResponse))
+
+      val response = copyingRegistrar.findRegistrations(topic, None)
+
+      response should beRight(findResponse).await
+      there was one(mainRegistrar).findRegistrations(topic, None)
+      there was no(copyRegistrar).findRegistrations(topic, None)
+    }
+
+    "only find registration by udid in using the main registrar" in new CopyingRegistrarScope {
+      val udid = mock[UniqueDeviceIdentifier]
+      val findResponse = mock[Paginated[StoredRegistration]]
+      mainRegistrar.findRegistrations(udid) returns Future.successful(Right(findResponse))
+
+      val response = copyingRegistrar.findRegistrations(udid)
+
+      response should beRight(findResponse).await
+      there was one(mainRegistrar).findRegistrations(udid)
+      there was no(copyRegistrar).findRegistrations(udid)
+    }
+
+    "find registration using both the main and copy registrar, returning concatenated results" in new CopyingRegistrarScope {
+      val token = mock[DeviceToken]
+      val mainRegistration = mock[StoredRegistration]
+      val copyRegistration = mock[StoredRegistration]
+      val expectedResponse = List(mainRegistration, copyRegistration)
+
+      copyRegistrar.findRegistrations(token) returns Future.successful(Right(List(copyRegistration)))
+      mainRegistrar.findRegistrations(token) returns Future.successful(Right(List(mainRegistration)))
+
+
+      val response = copyingRegistrar.findRegistrations(token)
+
+      response should beRight(expectedResponse).await
+      there was one(mainRegistrar).findRegistrations(token)
+      there was one(copyRegistrar).findRegistrations(token)
+    }
+
+
+  }
+
+  trait CopyingRegistrarScope extends Scope {
+
+    val mainRegistrar = mock[FcmRegistrar]
+    val copyRegistrar = mock[NotificationRegistrar]
+    val copyingRegistrar = new CopyingRegistrar(
+      providerIdentifier = "testRegistrar",
+      mainRegistrar = mainRegistrar,
+      copyRegistrar = copyRegistrar
+    )
+  }
+
+}


### PR DESCRIPTION
_This doesn't affect the production flow yet, it's just additional code that isn't wired in._

I'm adding another layer of abstraction such that we can keep all the existing logic and wrap it in a `CopyingRegistrar`, that will replicate every operation on two data stores (one being our database)