### PR TITLE
Write notifications to sqs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ val minJacksonLibs = Seq(
 
 val playJsonVersion = "2.6.9"
 val specsVersion: String = "4.0.3"
-val awsSdkVersion: String = "1.11.400"
+val awsSdkVersion: String = "1.11.433"
 val doobieVersion: String = "0.6.0"
 val catsVersion: String = "1.4.0"
 
@@ -155,6 +155,9 @@ lazy val notification = project
       "binders.querystringbinders._",
       "binders.pathbinders._",
       "models._"
+    ),
+    libraryDependencies ++= Seq(
+      "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion
     ),
     riffRaffPackageType := (packageBin in Debian).value,
     packageName in Debian := name.value,

--- a/common/src/main/scala/models/ShardedNotification.scala
+++ b/common/src/main/scala/models/ShardedNotification.scala
@@ -1,6 +1,4 @@
-package notification.services.guardian
-
-import models.Notification
+package models
 
 case class ShardRange(start: Short, end: Short)
 

--- a/notification/app/notification/services/guardian/GuardianNotificationSender.scala
+++ b/notification/app/notification/services/guardian/GuardianNotificationSender.scala
@@ -1,0 +1,88 @@
+package notification.services.guardian
+
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import notification.models.Push
+import notification.services.{NotificationSender, SenderError, SenderResult}
+import aws.AWSAsync._
+import com.amazonaws.services.sqs.model.{SendMessageBatchRequest, SendMessageBatchRequestEntry, SendMessageBatchResult}
+import models.Provider.Guardian
+import models._
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.json.Json
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+
+case class GuardianFailedToQueueShard(
+  senderName: String,
+  reason: String
+) extends SenderError
+
+class GuardianNotificationSender(
+  sqsClient: AmazonSQSAsync,
+  registrationCounter: TopicRegistrationCounter,
+  platform: Platform,
+  sqsArn: String,
+)(implicit ec: ExecutionContext) extends NotificationSender {
+
+  val BATCH_SIZE: Int = 10000
+
+  private val logger: Logger = Logger.apply(classOf[GuardianNotificationSender])
+
+  override def sendNotification(push: Push): Future[SenderResult] = for {
+      topicStats <- registrationCounter.count(push.notification.topic)
+      registrationCount = topicStats.counts.getOrElse(platform, 10)
+      batch = prepareBatch(platform, push.notification, registrationCount)
+      batchResult <- sendBatch(batch)
+  } yield {
+    val failed = Option(batchResult.getFailed).map(_.asScala.toList).getOrElse(Nil)
+    if (failed.isEmpty) {
+      Right(SenderReport(
+        Guardian.value,
+        DateTime.now,
+        None,
+        Some(PlatformStatistics(
+          platform,
+          registrationCount
+        ))
+      ))
+    } else {
+      failed.foreach { failure =>
+        logger.error(s"Unable to queue notification ${push.notification.id} for platform $platform: " +
+          s"${failure.getId} - ${failure.getCode} - ${failure.getMessage}")
+      }
+      Left(GuardianFailedToQueueShard(
+        senderName = s"Guardian $platform",
+        reason = s"Unable to queue notification. Please check the logs for notification ${push.notification.id}")
+      )
+    }
+  }
+
+  def sendBatch(batch: List[SendMessageBatchRequestEntry]): Future[SendMessageBatchResult] = {
+    val request: SendMessageBatchRequest = new SendMessageBatchRequest(sqsArn, batch.asJava)
+    wrapAsyncMethod(sqsClient.sendMessageBatchAsync, request)
+  }
+
+  def shard(registrationCount: Int): List[ShardRange] = {
+    val shardSpace = -Short.MinValue.toInt + Short.MaxValue.toInt
+    val shardCount = Math.ceil(Math.max(1, registrationCount) / BATCH_SIZE.toDouble)
+    val step = Math.ceil(shardSpace / shardCount).toInt
+
+    (Short.MinValue until Short.MaxValue by step).toList.map { i =>
+      ShardRange(
+        start = if (i == Short.MinValue.toInt) Short.MinValue else (i + 1).toShort,
+        end = Math.min(i + step, Short.MaxValue).toShort
+      )
+    }
+  }
+
+  def prepareBatch(platform: Platform, notification: Notification, registrationCount: Int): List[SendMessageBatchRequestEntry] = {
+    val notificationJson = Json.stringify(Notification.jf.writes(notification))
+    shard(registrationCount).map { shard =>
+      ShardedNotification(notification, shard)
+      val messageId = s"${notification.id}-$platform-[${shard.start},${shard.end}]"
+      new SendMessageBatchRequestEntry(messageId, notificationJson)
+    }
+  }
+}

--- a/notification/app/notification/services/guardian/ShardedNotification.scala
+++ b/notification/app/notification/services/guardian/ShardedNotification.scala
@@ -1,0 +1,10 @@
+package notification.services.guardian
+
+import models.Notification
+
+case class ShardRange(start: Short, end: Short)
+
+case class ShardedNotification(
+  notification: Notification,
+  range: ShardRange
+)

--- a/notification/app/notification/services/guardian/TopicRegistrationCounter.scala
+++ b/notification/app/notification/services/guardian/TopicRegistrationCounter.scala
@@ -1,0 +1,9 @@
+package notification.services.guardian
+
+import models.Topic
+
+import scala.concurrent.Future
+
+trait TopicRegistrationCounter {
+  def count(topics: List[Topic]): Future[TopicStats]
+}

--- a/notification/app/notification/services/guardian/TopicStats.scala
+++ b/notification/app/notification/services/guardian/TopicStats.scala
@@ -1,0 +1,5 @@
+package notification.services.guardian
+
+import models.Platform
+
+case class TopicStats(counts: Map[Platform, Int])

--- a/notification/test/notification/services/guardian/GuardianNotificationSenderSpec.scala
+++ b/notification/test/notification/services/guardian/GuardianNotificationSenderSpec.scala
@@ -1,0 +1,74 @@
+package notification.services.guardian
+
+import java.net.URI
+import java.util.UUID
+
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import models.Importance.Major
+import models.Link.Internal
+import models.TopicTypes.Breaking
+import models._
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import scala.concurrent.Future
+
+class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specification with Mockito {
+  "GuardianNotificationSender" should {
+    "prepare shards with inclusive bounds" in new GuardianNotificationSenderScope {
+      val bs = notificationSender.BATCH_SIZE
+      notificationSender.shard(0) shouldEqual List(ShardRange(Short.MinValue, Short.MaxValue))
+      notificationSender.shard(1) shouldEqual List(ShardRange(Short.MinValue, Short.MaxValue))
+      notificationSender.shard(2) shouldEqual List(ShardRange(Short.MinValue, Short.MaxValue))
+      notificationSender.shard(bs - 1) shouldEqual List(ShardRange(Short.MinValue, Short.MaxValue))
+      notificationSender.shard(bs) shouldEqual List(ShardRange(Short.MinValue, Short.MaxValue))
+      notificationSender.shard(bs + 1) shouldEqual List(ShardRange(Short.MinValue, 0), ShardRange(1, Short.MaxValue))
+      notificationSender.shard(bs + 20) shouldEqual List(ShardRange(Short.MinValue, 0), ShardRange(1, Short.MaxValue))
+      notificationSender.shard(2 * bs -1) shouldEqual List(ShardRange(Short.MinValue, 0), ShardRange(1, Short.MaxValue))
+      notificationSender.shard(2 * bs) shouldEqual List(ShardRange(Short.MinValue, 0), ShardRange(1, Short.MaxValue))
+      notificationSender.shard(2 * bs + 1) shouldEqual List(
+        ShardRange(Short.MinValue, -10923),
+        ShardRange(-10922, 10922),
+        ShardRange(10923, Short.MaxValue)
+      )
+      notificationSender.shard(3 * bs + 20) shouldEqual List(
+        ShardRange(Short.MinValue,-16384),
+        ShardRange(-16383,0),
+        ShardRange(1,16384),
+        ShardRange(16385, Short.MaxValue)
+      )
+    }
+  }
+
+  trait GuardianNotificationSenderScope extends Scope {
+
+    val notification = BreakingNewsNotification(
+      id = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
+      title = "Test notification",
+      message = "The message",
+      thumbnailUrl = Some(new URI("https://invalid.url/img.png")),
+      sender = "UnitTests",
+      link = Internal("some/capi/id", None, GITContent),
+      imageUrl = Some(new URI("https://invalid.url/img.png")),
+      importance = Major,
+      topic = List(Topic(`type` = Breaking, name = "uk"))
+    )
+
+    def topicStats(registrationCount: Int): TopicStats = TopicStats(Map(
+      iOS -> registrationCount,
+      Android -> registrationCount,
+      Newsstand -> registrationCount
+    ))
+
+    val notificationSender = new GuardianNotificationSender(
+      sqsClient = mock[AmazonSQSAsync],
+      registrationCounter = new TopicRegistrationCounter {
+        override def count(topics: List[Topic]): Future[TopicStats] = Future.successful(topicStats(1))
+      },
+      platform = iOS,
+      sqsArn = ""
+    )
+  }
+}

--- a/notification/test/notification/services/guardian/GuardianNotificationSenderSpec.scala
+++ b/notification/test/notification/services/guardian/GuardianNotificationSenderSpec.scala
@@ -3,17 +3,23 @@ package notification.services.guardian
 import java.net.URI
 import java.util.UUID
 
+import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.amazonaws.services.sqs.model.{BatchResultErrorEntry, SendMessageBatchRequest, SendMessageBatchResult}
 import models.Importance.Major
 import models.Link.Internal
 import models.TopicTypes.Breaking
 import models._
+import notification.models.Push
+import notification.services.SenderError
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 
-import scala.concurrent.Future
+import scala.concurrent.duration.DurationLong
+import scala.concurrent.{Await, Future}
+import org.apache.commons.lang3.concurrent.ConcurrentUtils
 
 class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specification with Mockito {
   "GuardianNotificationSender" should {
@@ -40,9 +46,41 @@ class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specific
         ShardRange(16385, Short.MaxValue)
       )
     }
+
+    "put batches messages on the queue" in new GuardianNotificationSenderScope {
+      val futureResult = notificationSender.sendNotification(Push(notification, Set()))
+      val result = Await.result(futureResult, 10.seconds)
+
+      there was one(sqsClient).sendMessageBatchAsync(any[SendMessageBatchRequest], any[AsyncHandler[SendMessageBatchRequest, SendMessageBatchResult]])
+
+      result should beRight.which { senderReport =>
+        senderReport.senderName shouldEqual "Guardian"
+        senderReport.sendersId should beNone
+        senderReport.platformStatistics should beSome(PlatformStatistics(iOS, 1))
+      }
+    }
+
+    "return an error if one of the batches couldn't be pushed to the queue" in new GuardianNotificationSenderScope(
+      sendMessageBatchResult = new SendMessageBatchResult().withFailed(
+        new BatchResultErrorEntry().withCode("123").withId("456").withMessage("error")
+      )
+    ) {
+      val futureResult = notificationSender.sendNotification(Push(notification, Set()))
+      val result = Await.result(futureResult, 10.seconds)
+
+      there was one(sqsClient).sendMessageBatchAsync(any[SendMessageBatchRequest], any[AsyncHandler[SendMessageBatchRequest, SendMessageBatchResult]])
+
+      result should beLeft(GuardianFailedToQueueShard(
+        senderName = s"Guardian ios",
+        reason = s"Unable to queue notification. Please check the logs for notification 4c261110-4672-4451-a5b8-3422c6839c42"
+      ): SenderError)
+    }
   }
 
-  trait GuardianNotificationSenderScope extends Scope {
+  class GuardianNotificationSenderScope(
+    registrationCount: Int = 1,
+    sendMessageBatchResult: SendMessageBatchResult = new SendMessageBatchResult()
+  ) extends Scope {
 
     val notification = BreakingNewsNotification(
       id = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
@@ -62,10 +100,24 @@ class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specific
       Newsstand -> registrationCount
     ))
 
+    val sqsClient = {
+      val s = mock[AmazonSQSAsync]
+      s.sendMessageBatchAsync(
+        any[SendMessageBatchRequest],
+        any[AsyncHandler[SendMessageBatchRequest, SendMessageBatchResult]]
+      ) answers { p =>
+        val params = p.asInstanceOf[Array[Object]]
+        val handler = params(1).asInstanceOf[AsyncHandler[SendMessageBatchRequest, SendMessageBatchResult]]
+        handler.onSuccess(params(0).asInstanceOf[SendMessageBatchRequest], sendMessageBatchResult)
+        ConcurrentUtils.constantFuture(sendMessageBatchResult)
+      }
+      s
+    }
+
     val notificationSender = new GuardianNotificationSender(
-      sqsClient = mock[AmazonSQSAsync],
+      sqsClient = sqsClient,
       registrationCounter = new TopicRegistrationCounter {
-        override def count(topics: List[Topic]): Future[TopicStats] = Future.successful(topicStats(1))
+        override def count(topics: List[Topic]): Future[TopicStats] = Future.successful(topicStats(registrationCount))
       },
       platform = iOS,
       sqsArn = ""


### PR DESCRIPTION
This code isn't wired so it won't have any impact in production when merged.

I created a class `GuardianNotificationSender` that will write units of work (notification + range) to one SQS queue for one platform.
When we'll wire that class we'll have to create three instances of it: iOS, Android and Newsstand. Both the newsstand and the iOS will share the same SQS queue as the same worker will pick up the work.

I've also ensured the generated ranges are inclusive on both ends [1, 250], [251, 500] such that we can directly use these values in a `between` sql statement.

The payload is of the following format:

```json
{
  "notification": {...},
  "range": {"start": 1, "end": 250}
}
```

where notification is a serialised `models.Notification`