### PR TITLE
Count registration per topic(s) and platform

### DIFF
--- a/common/src/main/scala/db/PlatformCount.scala
+++ b/common/src/main/scala/db/PlatformCount.scala
@@ -1,0 +1,14 @@
+package db
+
+import play.api.libs.json.{Format, Json}
+
+case class PlatformCount(
+  total: Int,
+  ios: Int,
+  android: Int,
+  newsstand: Int
+)
+
+object PlatformCount {
+  implicit val platformCountJF: Format[PlatformCount] = Json.format[PlatformCount]
+}

--- a/common/src/main/scala/db/RegistrationRepository.scala
+++ b/common/src/main/scala/db/RegistrationRepository.scala
@@ -1,9 +1,13 @@
 package db
 
+import cats.data.NonEmptyList
+
 trait RegistrationRepository[F[_], S[_[_], _]] {
   def findByTopic(topic: Topic): S[F, Registration]
   def findByToken(token: String): S[F, Registration]
   def save(sub: Registration): F[Int]
   def remove(sub: Registration): F[Int]
   def removeByToken(token: String): F[Int]
+  def countPerPlatformForTopic(topic: Topic): F[PlatformCount]
+  def countPerPlatformForTopics(topics: NonEmptyList[Topic]): F[PlatformCount]
 }

--- a/common/src/main/scala/db/RegistrationRepository.scala
+++ b/common/src/main/scala/db/RegistrationRepository.scala
@@ -9,6 +9,5 @@ trait RegistrationRepository[F[_], S[_[_], _]] {
   def save(sub: Registration): F[Int]
   def remove(sub: Registration): F[Int]
   def removeByToken(token: String): F[Int]
-  def countPerPlatformForTopic(topic: Topic): F[PlatformCount]
   def countPerPlatformForTopics(topics: NonEmptyList[Topic]): F[PlatformCount]
 }

--- a/common/src/main/scala/db/RegistrationRepository.scala
+++ b/common/src/main/scala/db/RegistrationRepository.scala
@@ -1,6 +1,7 @@
 package db
 
 import cats.data.NonEmptyList
+import models.PlatformCount
 
 trait RegistrationRepository[F[_], S[_[_], _]] {
   def findByTopic(topic: Topic): S[F, Registration]

--- a/common/src/main/scala/db/RegistrationService.scala
+++ b/common/src/main/scala/db/RegistrationService.scala
@@ -1,5 +1,6 @@
 package db
 
+import cats.data.NonEmptyList
 import cats.effect.internals.IOContextShift
 import cats.effect.{Async, ContextShift, IO}
 import doobie.util.transactor.Transactor
@@ -9,12 +10,17 @@ import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.ExecutionContext
 
-class RegistrationService[F[_], S[_[_], _]](repository: RegistrationRepository[F, S]) {
+class RegistrationService[F[_]: Async, S[_[_], _]](repository: RegistrationRepository[F, S]) {
   def findByToken(token: String): S[F, Registration] = repository.findByToken(token)
   def findByTopic(topic: Topic): S[F, Registration] = repository.findByTopic(topic)
   def save(sub: Registration): F[Int] = repository.save(sub)
   def remove(sub: Registration): F[Int] = repository.remove(sub)
   def removeAllByToken(token: String): F[Int] = repository.removeByToken(token)
+
+  def countPerPlatformForTopics(topics: NonEmptyList[Topic]): F[PlatformCount] = topics match {
+    case NonEmptyList(singleTopic, Nil) => repository.countPerPlatformForTopic(singleTopic)
+    case moreThanOneTopic => repository.countPerPlatformForTopics(moreThanOneTopic)
+  }
 }
 
 
@@ -32,9 +38,9 @@ object RegistrationService {
     val url = config.get[String]("registration.db.url")
     val user = config.get[String]("registration.db.user")
     val password = config.get[String]("registration.db.password")
-    val threads = config.get[String]("registration.db.threads")
+    val threads = config.get[Int]("registration.db.threads")
 
-    val jdbcConfig = JdbcConfig("org.postgresql.Driver", s"jdbc:postgresql://$url", user, password)
+    val jdbcConfig = JdbcConfig("org.postgresql.Driver", s"jdbc:postgresql://$url", user, password, threads)
     val transactor = DatabaseConfig.transactor[IO](jdbcConfig, applicationLifecycle)
 
     apply(transactor)

--- a/common/src/main/scala/db/RegistrationService.scala
+++ b/common/src/main/scala/db/RegistrationService.scala
@@ -11,7 +11,7 @@ import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.ExecutionContext
 
-class RegistrationService[F[_]: Async, S[_[_], _]](repository: RegistrationRepository[F, S]) {
+class RegistrationService[F[_], S[_[_], _]](repository: RegistrationRepository[F, S]) {
   def findByToken(token: String): S[F, Registration] = repository.findByToken(token)
   def findByTopic(topic: Topic): S[F, Registration] = repository.findByTopic(topic)
   def save(sub: Registration): F[Int] = repository.save(sub)

--- a/common/src/main/scala/db/RegistrationService.scala
+++ b/common/src/main/scala/db/RegistrationService.scala
@@ -17,11 +17,7 @@ class RegistrationService[F[_], S[_[_], _]](repository: RegistrationRepository[F
   def save(sub: Registration): F[Int] = repository.save(sub)
   def remove(sub: Registration): F[Int] = repository.remove(sub)
   def removeAllByToken(token: String): F[Int] = repository.removeByToken(token)
-
-  def countPerPlatformForTopics(topics: NonEmptyList[Topic]): F[PlatformCount] = topics match {
-    case NonEmptyList(singleTopic, Nil) => repository.countPerPlatformForTopic(singleTopic)
-    case moreThanOneTopic => repository.countPerPlatformForTopics(moreThanOneTopic)
-  }
+  def countPerPlatformForTopics(topics: NonEmptyList[Topic]): F[PlatformCount] = repository.countPerPlatformForTopics(topics)
 }
 
 

--- a/common/src/main/scala/db/RegistrationService.scala
+++ b/common/src/main/scala/db/RegistrationService.scala
@@ -5,6 +5,7 @@ import cats.effect.internals.IOContextShift
 import cats.effect.{Async, ContextShift, IO}
 import doobie.util.transactor.Transactor
 import fs2.Stream
+import models.PlatformCount
 import play.api.Configuration
 import play.api.inject.ApplicationLifecycle
 

--- a/common/src/main/scala/db/SqlRegistrationRepository.scala
+++ b/common/src/main/scala/db/SqlRegistrationRepository.scala
@@ -5,8 +5,10 @@ import doobie.implicits._
 import doobie.util.transactor.Transactor
 import fs2.Stream
 import Registration._
+import cats.data.NonEmptyList
 import doobie.free.connection.ConnectionIO
 import doobie.postgres.sqlstate
+import doobie.Fragments
 
 class SqlRegistrationRepository[F[_]: Async](xa: Transactor[F])
   extends RegistrationRepository[F, Stream] {
@@ -73,4 +75,46 @@ class SqlRegistrationRepository[F[_]: Async](xa: Transactor[F])
       """
       .update.run
 
+  def countPerPlatformForTopics(topics: NonEmptyList[Topic]): F[PlatformCount] = {
+    val q = fr"""
+      SELECT
+        count(1) as total,
+        coalesce(sum(case platform when 'ios' then 1 else 0 end), 0) as ios,
+        coalesce(sum(case platform when 'android' then 1 else 0 end), 0) as android,
+        coalesce(sum(case platform when 'newsstand' then 1 else 0 end), 0) as newsstand
+      FROM
+        (
+          SELECT DISTINCT
+            token,
+            platform
+          FROM
+            registrations
+          WHERE
+      """ ++
+        Fragments.in(fr"topic", topics) ++
+    fr"""
+        ) as distinct_registrations
+    """
+
+    q.query[PlatformCount]
+      .unique
+      .transact(xa)
+  }
+
+  override def countPerPlatformForTopic(topic: Topic): F[PlatformCount] = {
+    sql"""
+      SELECT
+        count(1) as total,
+        coalesce(sum(case platform when 'ios' then 1 else 0 end), 0) as ios,
+        coalesce(sum(case platform when 'android' then 1 else 0 end), 0) as android,
+        coalesce(sum(case platform when 'newsstand' then 1 else 0 end), 0) as newsstand
+      FROM
+        registrations
+      WHERE
+        topic = $topic
+      """
+      .query[PlatformCount]
+      .unique
+      .transact(xa)
+  }
 }

--- a/common/src/main/scala/db/SqlRegistrationRepository.scala
+++ b/common/src/main/scala/db/SqlRegistrationRepository.scala
@@ -101,21 +101,4 @@ class SqlRegistrationRepository[F[_]: Async](xa: Transactor[F])
       .unique
       .transact(xa)
   }
-
-  override def countPerPlatformForTopic(topic: Topic): F[PlatformCount] = {
-    sql"""
-      SELECT
-        count(1) as total,
-        coalesce(sum(case platform when 'ios' then 1 else 0 end), 0) as ios,
-        coalesce(sum(case platform when 'android' then 1 else 0 end), 0) as android,
-        coalesce(sum(case platform when 'newsstand' then 1 else 0 end), 0) as newsstand
-      FROM
-        registrations
-      WHERE
-        topic = $topic
-      """
-      .query[PlatformCount]
-      .unique
-      .transact(xa)
-  }
 }

--- a/common/src/main/scala/db/SqlRegistrationRepository.scala
+++ b/common/src/main/scala/db/SqlRegistrationRepository.scala
@@ -9,6 +9,7 @@ import cats.data.NonEmptyList
 import doobie.free.connection.ConnectionIO
 import doobie.postgres.sqlstate
 import doobie.Fragments
+import models.PlatformCount
 
 class SqlRegistrationRepository[F[_]: Async](xa: Transactor[F])
   extends RegistrationRepository[F, Stream] {

--- a/common/src/main/scala/models/PlatformCount.scala
+++ b/common/src/main/scala/models/PlatformCount.scala
@@ -1,4 +1,4 @@
-package db
+package models
 
 import play.api.libs.json.{Format, Json}
 

--- a/common/src/test/scala/db/RegistrationServiceTest.scala
+++ b/common/src/test/scala/db/RegistrationServiceTest.scala
@@ -1,5 +1,6 @@
 package db
 
+import cats.data.NonEmptyList
 import org.specs2.mutable.Specification
 import doobie.implicits._
 import cats.effect.IO
@@ -82,6 +83,16 @@ class RegistrationServiceTest(implicit ee: ExecutionEnv) extends Specification w
       run(service.save(reg5.copy(shard = newShard)))
 
       run(service.findByTopic(reg5.topic)).head.shard should equalTo(newShard)
+    }
+    "return 0 if no registration has that topic" in {
+      run(service.countPerPlatformForTopics(NonEmptyList.one(Topic("idontexist")))) shouldEqual PlatformCount(0,0,0,0)
+      run(service.countPerPlatformForTopics(NonEmptyList(Topic("idontexist"), List(Topic("neitherdoi"))))) shouldEqual PlatformCount(0,0,0,0)
+    }
+    "count per platform and per topic with one topic" in {
+      run(service.countPerPlatformForTopics(NonEmptyList.one(Topic("topic3")))) shouldEqual PlatformCount(1,1,0,0)
+    }
+    "count per platform and per topic with two or more topics" in {
+      run(service.countPerPlatformForTopics(NonEmptyList(Topic("topic3"), List(Topic("topic4"))))) shouldEqual PlatformCount(1,1,0,0)
     }
   }
 

--- a/common/src/test/scala/db/RegistrationServiceTest.scala
+++ b/common/src/test/scala/db/RegistrationServiceTest.scala
@@ -6,7 +6,7 @@ import doobie.implicits._
 import cats.effect.IO
 import cats.implicits._
 import doobie.util.transactor.Transactor
-import models.{Android, iOS}
+import models.{Android, PlatformCount, iOS}
 import org.specs2.specification.BeforeAll
 import fs2.Stream
 import org.specs2.concurrent.ExecutionEnv

--- a/report/app/report/ReportApplicationLoader.scala
+++ b/report/app/report/ReportApplicationLoader.scala
@@ -4,6 +4,7 @@ import _root_.controllers.AssetsComponents
 import akka.actor.ActorSystem
 import aws.AsyncDynamo
 import azure.NotificationHubClient
+import cats.effect.IO
 import com.amazonaws.regions.Regions.EU_WEST_1
 import com.gu.AppIdentity
 import play.api.routing.Router
@@ -15,7 +16,7 @@ import play.api.mvc.EssentialFilter
 import play.filters.HttpFiltersComponents
 import play.filters.hosts.AllowedHostsFilter
 import report.authentication.ReportAuthAction
-import report.controllers.Report
+import report.controllers.{RegistrationCount, Report}
 import report.services.{Configuration, NotificationReportEnricher}
 import tracking.{DynamoNotificationReportRepository, SentNotificationReportRepository}
 import utils.{CustomApplicationLoader, MobileAwsCredentialsProvider}
@@ -45,6 +46,10 @@ class ReportApplicationComponents(context: Context) extends BuiltInComponentsFro
     new DynamoNotificationReportRepository(AsyncDynamo(regions = EU_WEST_1, credentialsProvider), appConfig.dynamoReportsTableName)
 
   lazy val defaultHubClient = new NotificationHubClient(appConfig.defaultHub, wsClient)
+
+  lazy val registrationDbService: db.RegistrationService[IO, fs2.Stream] = db.RegistrationService.fromConfig(configuration, applicationLifecycle)
+
+  lazy val registrationCount: RegistrationCount = wire[RegistrationCount]
 
   lazy val reportEnricher = wire[NotificationReportEnricher]
   override lazy val router: Router = wire[Routes]

--- a/report/app/report/controllers/RegistrationCount.scala
+++ b/report/app/report/controllers/RegistrationCount.scala
@@ -1,0 +1,31 @@
+package report.controllers
+
+import authentication.AuthAction
+import cats.data.NonEmptyList
+import cats.effect.IO
+import db.RegistrationService
+import models.Topic
+import play.api.libs.json.Json
+import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
+
+import scala.concurrent.Future
+
+class RegistrationCount(
+  registrationService: RegistrationService[IO, fs2.Stream],
+  controllerComponents: ControllerComponents,
+  authAction: AuthAction
+) extends AbstractController(controllerComponents) {
+
+  def forTopics(topics: List[Topic]): Action[AnyContent] = authAction.async { request =>
+    topics match {
+      case Nil => Future.successful(BadRequest("Couldn't find any valid topic"))
+      case firstTopic :: moreTopics =>
+        val nonEmptyTopics = NonEmptyList(firstTopic, moreTopics)
+        registrationService.countPerPlatformForTopics(nonEmptyTopics.map(topic => db.Topic(topic.toString)))
+          .map(result => Ok(Json.toJson(result)))
+          .unsafeToFuture()
+    }
+
+  }
+
+}

--- a/report/app/report/controllers/RegistrationCount.scala
+++ b/report/app/report/controllers/RegistrationCount.scala
@@ -21,7 +21,7 @@ class RegistrationCount(
       case Nil => Future.successful(BadRequest("Couldn't find any valid topic"))
       case firstTopic :: moreTopics =>
         val nonEmptyTopics = NonEmptyList(firstTopic, moreTopics)
-        registrationService.countPerPlatformForTopics(nonEmptyTopics.map(topic => db.Topic(topic.toString)))
+        registrationService.countPerPlatformForTopics(nonEmptyTopics.map(topic => db.Topic(topic.name)))
           .map(result => Ok(Json.toJson(result)))
           .unsafeToFuture()
     }

--- a/report/conf/routes
+++ b/report/conf/routes
@@ -2,3 +2,5 @@ GET         /healthcheck                         report.controllers.Report.healt
 GET         /notifications                       report.controllers.Report.notifications(`type`: NotificationType, from: Option[DateTime], until: Option[DateTime])
 GET         /notifications/:id                   report.controllers.Report.notification(id: java.util.UUID)
 
+GET         /registration-count                  report.controllers.RegistrationCount.forTopics(topics: List[models.Topic])
+

--- a/report/test/report/controllers/RegistrationCountSpec.scala
+++ b/report/test/report/controllers/RegistrationCountSpec.scala
@@ -1,0 +1,46 @@
+package report.controllers
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import db.{PlatformCount, RegistrationService}
+import models.{Topic, TopicTypes}
+import org.specs2.mock.Mockito
+import org.specs2.specification.Scope
+import play.api.libs.json.{JsDefined, JsNumber}
+import play.api.test.{FakeRequest, Helpers, PlaySpecification}
+import report.authentication.ReportAuthAction
+import play.api.{Configuration => PlayConfig}
+import report.services.Configuration
+
+class RegistrationCountSpec extends PlaySpecification with Mockito {
+  "RegistrationCount controller" should {
+    "return a 400 if there's not topic passed as parameters" in new RegistrationCountScope {
+      registrationService.countPerPlatformForTopics(any[NonEmptyList[db.Topic]]) returns IO.pure(PlatformCount(0,0,0,0))
+      val result = registrationCount.forTopics(Nil).apply(FakeRequest(GET, "/registration-count?api-key=test"))
+      status(result) shouldEqual 400
+      there was no(registrationService).countPerPlatformForTopics(any[NonEmptyList[db.Topic]])
+    }
+    "return 200 if there's a topic passed" in new RegistrationCountScope {
+      registrationService.countPerPlatformForTopics(any[NonEmptyList[db.Topic]]) returns IO.pure(PlatformCount(1,1,0,0))
+      val request = FakeRequest(GET, "/registration-count?api-key=test&topic=breaking/uk")
+      val result = registrationCount.forTopics(List(Topic(TopicTypes.Breaking, "uk"))).apply(request)
+      status(result) shouldEqual 200
+      val json = contentAsJson(result)
+      (json \ "total").get shouldEqual JsNumber(1)
+      there was one(registrationService).countPerPlatformForTopics(any[NonEmptyList[db.Topic]])
+    }
+  }
+
+  trait RegistrationCountScope extends Scope {
+    val playConfig = PlayConfig(
+      "notifications.api.secretKeys" -> List("test"),
+      "notifications.api.electionRestrictedKeys" -> Nil,
+      "notifications.api.reportsOnlyKeys" -> Nil
+    )
+    val configuration = new Configuration(playConfig)
+    val controllerComponents = Helpers.stubControllerComponents()
+    val authAction = new ReportAuthAction(configuration, controllerComponents)
+    val registrationService = mock[RegistrationService[IO, fs2.Stream]]
+    val registrationCount = new RegistrationCount(registrationService, controllerComponents, authAction)
+  }
+}

--- a/report/test/report/controllers/RegistrationCountSpec.scala
+++ b/report/test/report/controllers/RegistrationCountSpec.scala
@@ -2,8 +2,8 @@ package report.controllers
 
 import cats.data.NonEmptyList
 import cats.effect.IO
-import db.{PlatformCount, RegistrationService}
-import models.{Topic, TopicTypes}
+import db.RegistrationService
+import models.{PlatformCount, Topic, TopicTypes}
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
 import play.api.libs.json.{JsDefined, JsNumber}

--- a/report/test/report/controllers/ReportIntegrationSpec.scala
+++ b/report/test/report/controllers/ReportIntegrationSpec.scala
@@ -154,7 +154,6 @@ class ReportIntegrationSpec(implicit ee: ExecutionEnv) extends PlaySpecification
             override def save(sub: db.Registration): IO[Port] = ???
             override def remove(sub: db.Registration): IO[Port] = ???
             override def removeByToken(token: String): IO[Port] = ???
-            override def countPerPlatformForTopic(topic: db.Topic): IO[PlatformCount] = ???
             override def countPerPlatformForTopics(topics: NonEmptyList[db.Topic]): IO[PlatformCount] = ???
           }
         )

--- a/report/test/report/controllers/ReportIntegrationSpec.scala
+++ b/report/test/report/controllers/ReportIntegrationSpec.scala
@@ -5,6 +5,8 @@ import java.util.UUID
 
 import application.WithPlayApp
 import azure.{NotificationDetails, NotificationStates}
+import cats.data.NonEmptyList
+import cats.effect.IO
 import models.Link.Internal
 import models.Importance.Major
 import models.NotificationType.BreakingNews
@@ -22,6 +24,7 @@ import report.services.{Configuration, NotificationReportEnricher}
 import tracking.InMemoryNotificationReportRepository
 import cats.implicits._
 import com.softwaremill.macwire._
+import db.{RegistrationRepository, RegistrationService}
 
 import scala.concurrent.Future
 
@@ -144,6 +147,17 @@ class ReportIntegrationSpec(implicit ee: ExecutionEnv) extends PlaySpecification
         override lazy val reportEnricher = notificationReportEnricherMock
         override lazy val notificationReportRepository = reportRepositoryMock
         override lazy val appConfig = appConfigMock
+        override lazy val registrationDbService: RegistrationService[IO, fs2.Stream] = new RegistrationService(
+          new RegistrationRepository[IO, fs2.Stream] {
+            override def findByTopic(topic: db.Topic): fs2.Stream[IO, db.Registration] = ???
+            override def findByToken(token: String): fs2.Stream[IO, db.Registration] = ???
+            override def save(sub: db.Registration): IO[Port] = ???
+            override def remove(sub: db.Registration): IO[Port] = ???
+            override def removeByToken(token: String): IO[Port] = ???
+            override def countPerPlatformForTopic(topic: db.Topic): IO[PlatformCount] = ???
+            override def countPerPlatformForTopics(topics: NonEmptyList[db.Topic]): IO[PlatformCount] = ???
+          }
+        )
       }
     }
 


### PR DESCRIPTION
The endpoint returns a json:
```json
{
  "total": 20,
  "ios": 15,
  "android": 5,
  "newsstand": 0
}
```

The idea of counting per platform is to be able to cache the request on the client side such that for one breaking news we only count once, and use the result twice.