### PR TITLE
apns payload: add missing 'uri' custom key for football status payload

### DIFF
--- a/apnsworker/src/main/scala/apnsworker/models/payload/ApnsPayload.scala
+++ b/apnsworker/src/main/scala/apnsworker/models/payload/ApnsPayload.scala
@@ -129,7 +129,8 @@ object ApnsPayload {
             CustomProperty(Keys.MatchStatus -> n.matchStatus),
             CustomProperty(Keys.MatchId -> n.matchId),
             CustomProperty(Keys.MapiUrl -> n.matchInfoUri.toString),
-            CustomProperty(Keys.MatchInfoUri -> n.matchInfoUri.toString)
+            CustomProperty(Keys.MatchInfoUri -> n.matchInfoUri.toString),
+            CustomProperty(Keys.Uri -> "")
           ) ++
             n.articleUri.map(u => CustomProperty(Keys.ArticleUri -> u.toString)).toSeq ++
             n.competitionName.map(c => CustomProperty(Keys.CompetitionName -> c)).toSeq ++

--- a/apnsworker/src/test/scala/apnsworker/models/payload/ApnsPayloadSpec.scala
+++ b/apnsworker/src/test/scala/apnsworker/models/payload/ApnsPayloadSpec.scala
@@ -237,6 +237,7 @@ class ApnsPayloadSpec extends Specification with Matchers {
         |      "articleUri":"https://mobile.guardianapis.com/items/some-liveblog",
         |      "awayTeamName":"Burnley",
         |      "awayTeamScore":"1",
+        |      "uri":"",
         |      "currentMinute":"",
         |      "matchInfoUri":"https://mobile.guardianapis.com/sport/football/match-info/3955232",
         |      "homeTeamId":"1006",


### PR DESCRIPTION
This great document by @jorgeazevedo highlights a missing custom property in the football status payload.