### PR TITLE
Wire notification to sqs

### DIFF
--- a/notification/app/notification/NotificationApplicationLoader.scala
+++ b/notification/app/notification/NotificationApplicationLoader.scala
@@ -12,15 +12,15 @@ import com.softwaremill.macwire._
 import controllers.Main
 import _root_.models.NewsstandShardConfig
 import com.google.auth.oauth2.GoogleCredentials
-import com.google.firebase.messaging.{AndroidConfig, FirebaseMessaging}
+import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.{FirebaseApp, FirebaseOptions}
 import com.gu.AppIdentity
-import com.gu.notificationschedule.dynamo.{NotificationSchedulePersistenceImpl, ScheduleTableConfig}
+import com.gu.notificationschedule.dynamo.NotificationSchedulePersistenceImpl
 import notification.authentication.NotificationAuthAction
 import notification.services.frontend.{FrontendAlerts, FrontendAlertsConfig}
 import notification.services._
 import notification.services.azure._
-import notification.services.fcm.{APNSConfigConverter, AndroidConfigConverter, FCMConfigConverter, FCMNotificationSender}
+import notification.services.fcm.{APNSConfigConverter, AndroidConfigConverter, FCMNotificationSender}
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.routing.Router
 import play.api.{BuiltInComponents, BuiltInComponentsFromContext}
@@ -43,6 +43,8 @@ class NotificationApplicationComponents(context: Context) extends BuiltInCompone
   with HttpFiltersComponents
   with AssetsComponents {
 
+  lazy val prefix: String = "/"
+
   override def httpFilters: Seq[EssentialFilter] = super.httpFilters.filterNot{ filter => filter.getClass == classOf[AllowedHostsFilter] }
 
   implicit lazy val implicitActorSystem: ActorSystem = actorSystem
@@ -51,29 +53,18 @@ class NotificationApplicationComponents(context: Context) extends BuiltInCompone
 
   lazy val authAction = wire[NotificationAuthAction]
 
-  lazy val notificationSenders = List(
-    gcmNotificationSender,
-    apnsNotificationSender,
-    newsstandShardNotificationSender,
-    //frontendAlerts, //disabled until frontend decides whether to fix this feature or not.
-    fcmNotificationSender
-  )
-  lazy val mainController = wire[Main]
-  lazy val router: Router = wire[Routes]
-
-  lazy val prefix: String = "/"
-
-  lazy val hubClient = new NotificationHubClient(appConfig.defaultHub, wsClient)
-
   val credentialsProvider = new MobileAwsCredentialsProvider()
 
   val asyncDynamo: AsyncDynamo = AsyncDynamo(EU_WEST_1, credentialsProvider)
+
   lazy val topicSubscriptionsRepository: TopicSubscriptionsRepository = {
     val underlying = new DynamoTopicSubscriptionsRepository(asyncDynamo, appConfig.dynamoTopicsTableName)
     val batching = new BatchingTopicSubscriptionsRepository(underlying)
     batching.scheduleFlush(appConfig.dynamoTopicsFlushInterval)
     batching
   }
+
+  lazy val hubClient = new NotificationHubClient(appConfig.defaultHub, wsClient)
 
   lazy val notificationReportRepository = new DynamoNotificationReportRepository(asyncDynamo, appConfig.dynamoReportsTableName)
 
@@ -89,7 +80,7 @@ class NotificationApplicationComponents(context: Context) extends BuiltInCompone
   }
   lazy val newsstandShardNotificationSender: NewsstandShardSender = new NewsstandShardSender(newsstandHubClient,appConfig, topicSubscriptionsRepository)
 
-  lazy val firebaseMessaging = {
+  lazy val firebaseMessaging: FirebaseMessaging = {
     val firebaseOptions: FirebaseOptions = new FirebaseOptions.Builder()
       .setCredentials(GoogleCredentials.fromStream(new ByteArrayInputStream(appConfig.firebaseServiceAccountKey.getBytes)))
       .setDatabaseUrl(appConfig.firebaseDatabaseUrl)
@@ -113,6 +104,17 @@ class NotificationApplicationComponents(context: Context) extends BuiltInCompone
     val frontendConfig = FrontendAlertsConfig(new URI(appConfig.frontendNewsAlertEndpoint), appConfig.frontendNewsAlertApiKey)
     new FrontendAlerts(frontendConfig, wsClient)
   }
+
+  lazy val notificationSenders = List(
+    gcmNotificationSender,
+    apnsNotificationSender,
+    newsstandShardNotificationSender,
+    //frontendAlerts, //disabled until frontend decides whether to fix this feature or not.
+    fcmNotificationSender
+  )
+
+  lazy val mainController = wire[Main]
+  lazy val router: Router = wire[Routes]
 
 }
 

--- a/notification/app/notification/NotificationApplicationLoader.scala
+++ b/notification/app/notification/NotificationApplicationLoader.scala
@@ -147,11 +147,11 @@ class NotificationApplicationComponents(context: Context) extends BuiltInCompone
     withFilter(guardianIosNotificationSender, invertCondition = false),
     withFilter(guardianAndroidNotificationSender, invertCondition = false),
     withFilter(guardianNewsstandNotificationSender, invertCondition = false),
-    withFilter(gcmNotificationSender, invertCondition = true),
-    withFilter(apnsNotificationSender, invertCondition = true),
-    withFilter(newsstandShardNotificationSender, invertCondition = true),
+    gcmNotificationSender,
+    apnsNotificationSender,
+    newsstandShardNotificationSender,
     //frontendAlerts, //disabled until frontend decides whether to fix this feature or not.
-    withFilter(fcmNotificationSender, invertCondition = true)
+    fcmNotificationSender
   )
 
   lazy val mainController = wire[Main]

--- a/notification/app/notification/services/FilteredNotificationSender.scala
+++ b/notification/app/notification/services/FilteredNotificationSender.scala
@@ -1,16 +1,20 @@
 package notification.services
 import models._
 import notification.models.Push
-import notification.services.guardian.TopicRegistrationCounter
+import notification.services.guardian.{GuardianNotificationSender, TopicRegistrationCounter}
 import org.joda.time.DateTime
+import play.api.Logger
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
 
 class FilteredNotificationSender(
   notificationSender: NotificationSender,
   topicRegistrationCounter: TopicRegistrationCounter,
   invertCondition: Boolean
 )(implicit ec: ExecutionContext) extends NotificationSender {
+
+  private val logger: Logger = Logger.apply(classOf[FilteredNotificationSender])
 
   val ALLOWED_TOPICS: Set[TopicType] = Set(TopicTypes.Content, TopicTypes.TagContributor, TopicTypes.TagSeries)
 
@@ -30,8 +34,17 @@ class FilteredNotificationSender(
       }
     }
 
+    def defaultCountRecovery: PartialFunction[Throwable, PlatformCount] = {
+      case NonFatal(e) if push.notification.topic.exists(_.`type` == TopicTypes.Breaking) =>
+        logger.error(s"Unable to count registration for topics ${push.notification.topic}, falling back to default value", e)
+        PlatformCount(1500000, 750000, 750000, 0)
+      case NonFatal(e) =>
+        logger.error(s"Unable to count registration for topics ${push.notification.topic}, falling back to default value", e)
+        PlatformCount(1, 1, 1, 0)
+    }
+
     for {
-      count <- topicRegistrationCounter.count(push.notification.topic)
+      count <- topicRegistrationCounter.count(push.notification.topic).recover(defaultCountRecovery)
       result <- sendOrFilter(count, push.notification.topic)
     } yield result
   }

--- a/notification/app/notification/services/FilteredNotificationSender.scala
+++ b/notification/app/notification/services/FilteredNotificationSender.scala
@@ -1,0 +1,38 @@
+package notification.services
+import models._
+import notification.models.Push
+import notification.services.guardian.TopicRegistrationCounter
+import org.joda.time.DateTime
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FilteredNotificationSender(
+  notificationSender: NotificationSender,
+  topicRegistrationCounter: TopicRegistrationCounter,
+  invertCondition: Boolean
+)(implicit ec: ExecutionContext) extends NotificationSender {
+
+  val ALLOWED_TOPICS: Set[TopicType] = Set(TopicTypes.Content, TopicTypes.TagContributor, TopicTypes.TagSeries)
+
+  override def sendNotification(push: Push): Future[SenderResult] = {
+    def shouldSend(count: PlatformCount, topics: List[Topic]): Boolean = {
+      count.total <= 10 && topics.forall(t => ALLOWED_TOPICS.contains(t.`type`))
+    }
+
+    def sendOrFilter(count: PlatformCount, topics: List[Topic]): Future[SenderResult] = {
+      // ^ is a XOR, which means we invert the condition if invertCondition is true
+      if (shouldSend(count, topics) ^ invertCondition) {
+        notificationSender.sendNotification(push)
+      } else {
+        Future.successful {
+          Right(SenderReport(senderName = "Filtered", sentTime = DateTime.now))
+        }
+      }
+    }
+
+    for {
+      count <- topicRegistrationCounter.count(push.notification.topic)
+      result <- sendOrFilter(count, push.notification.topic)
+    } yield result
+  }
+}

--- a/notification/app/notification/services/FilteredNotificationSender.scala
+++ b/notification/app/notification/services/FilteredNotificationSender.scala
@@ -20,7 +20,7 @@ class FilteredNotificationSender(
 
   override def sendNotification(push: Push): Future[SenderResult] = {
     def shouldSend(count: PlatformCount, topics: List[Topic]): Boolean = {
-      count.total <= 10 && topics.forall(t => ALLOWED_TOPICS.contains(t.`type`))
+      count.total <= 100 && topics.forall(t => ALLOWED_TOPICS.contains(t.`type`))
     }
 
     def sendOrFilter(count: PlatformCount, topics: List[Topic]): Future[SenderResult] = {

--- a/notification/app/notification/services/FilteredNotificationSender.scala
+++ b/notification/app/notification/services/FilteredNotificationSender.scala
@@ -16,11 +16,12 @@ class FilteredNotificationSender(
 
   private val logger: Logger = Logger.apply(classOf[FilteredNotificationSender])
 
-  val ALLOWED_TOPICS: Set[TopicType] = Set(TopicTypes.Content, TopicTypes.TagContributor, TopicTypes.TagSeries)
+  val allowedTopicTypes: Set[TopicType] = Set(TopicTypes.Content, TopicTypes.TagContributor, TopicTypes.TagSeries)
+  val maxRegistrationCount: Int = 100
 
   override def sendNotification(push: Push): Future[SenderResult] = {
     def shouldSend(count: PlatformCount, topics: List[Topic]): Boolean = {
-      count.total <= 100 && topics.forall(t => ALLOWED_TOPICS.contains(t.`type`))
+      count.total < maxRegistrationCount && topics.forall(t => allowedTopicTypes.contains(t.`type`))
     }
 
     def sendOrFilter(count: PlatformCount, topics: List[Topic]): Future[SenderResult] = {
@@ -40,7 +41,7 @@ class FilteredNotificationSender(
         PlatformCount(1500000, 750000, 750000, 0)
       case NonFatal(e) =>
         logger.error(s"Unable to count registration for topics ${push.notification.topic}, falling back to default value", e)
-        PlatformCount(1, 1, 1, 0)
+        PlatformCount(maxRegistrationCount, 1, 1, 0)
     }
 
     for {

--- a/notification/app/notification/services/guardian/ReportTopicRegistrationCounter.scala
+++ b/notification/app/notification/services/guardian/ReportTopicRegistrationCounter.scala
@@ -17,7 +17,7 @@ class ReportTopicRegistrationCounter(
   override def count(topics: List[Topic]): Future[PlatformCount] = {
     lruCache(topics.toSet) {
       val topicParameters = topics.map(topic => "topics" -> topic.toString)
-      val allParams = topicParameters ++ List("api-key" -> apiKey)
+      val allParams = topicParameters :+ "api-key" -> apiKey
       ws.url(s"$reportUrl/registration-count")
         .withQueryStringParameters(allParams: _*)
         .get

--- a/notification/test/notification/services/guardian/GuardianNotificationSenderSpec.scala
+++ b/notification/test/notification/services/guardian/GuardianNotificationSenderSpec.scala
@@ -81,7 +81,7 @@ class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specific
           override def count(topics: List[Topic]): Future[PlatformCount] = Future.failed(new RuntimeException("exception"))
         },
         platform = iOS,
-        sqsArn = ""
+        sqsUrl = ""
       )
 
       val futureResult = notificationSender.sendNotification(Push(notification, Set()))
@@ -156,7 +156,7 @@ class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specific
         override def count(topics: List[Topic]): Future[PlatformCount] = Future.successful(topicStats(registrationCount))
       },
       platform = iOS,
-      sqsArn = ""
+      sqsUrl = ""
     )
   }
 }


### PR DESCRIPTION
**This should not be merged until** `create-workers-resources` **is merged**

This wires the code that writes to the SQS queues, and also implements a flip/flop filter that decides where to send the notification