### PR TITLE
Tolerate sqs error

### DIFF
--- a/notification/app/notification/services/guardian/GuardianNotificationSender.scala
+++ b/notification/app/notification/services/guardian/GuardianNotificationSender.scala
@@ -28,7 +28,7 @@ class GuardianNotificationSender(
 )(implicit ec: ExecutionContext) extends NotificationSender {
 
   val WORKER_BATCH_SIZE: Int = 10000
-  val SQS_BATCH_SIZE: Int = 200 // max 256kb per sqs call, 1 notification ~< 1kb
+  val SQS_BATCH_SIZE: Int = 10
 
   private val logger: Logger = Logger.apply(classOf[GuardianNotificationSender])
 


### PR DESCRIPTION
There was an error this morning when the morning briefing went out (the notification was received on devices just fine), but the exception wasn't caught.

This fixes both the root cause of the exception (sqs batch too big) and handles the case where we get an exception such that the service gracefully continues.