### PR TITLE
Optimise workers

### DIFF
--- a/common/src/main/scala/db/DatabaseConfig.scala
+++ b/common/src/main/scala/db/DatabaseConfig.scala
@@ -32,12 +32,12 @@ object DatabaseConfig {
   private def transactorAndDataSource[F[_] : Async](config: JdbcConfig)(implicit cs: ContextShift[F]): (Transactor[F], HikariDataSource) = {
     val connectEC = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(config.fixedThreadPool))
     val transactEC = ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
-    val ikariConfig = new HikariConfig()
-    ikariConfig.setMaximumPoolSize(config.fixedThreadPool)
-    ikariConfig.setJdbcUrl(config.url)
-    ikariConfig.setUsername(config.user)
-    ikariConfig.setPassword(config.password)
-    val dataSource = new HikariDataSource(ikariConfig)
+    val hikariConfig = new HikariConfig()
+    hikariConfig.setMaximumPoolSize(config.fixedThreadPool)
+    hikariConfig.setJdbcUrl(config.url)
+    hikariConfig.setUsername(config.user)
+    hikariConfig.setPassword(config.password)
+    val dataSource = new HikariDataSource(hikariConfig)
 
     (Transactor.fromDataSource.apply(dataSource, connectEC, transactEC), dataSource)
   }

--- a/common/src/main/scala/db/DatabaseConfig.scala
+++ b/common/src/main/scala/db/DatabaseConfig.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.Executors
 
 import cats.effect.internals.IOContextShift
 import cats.effect.{Async, ContextShift, IO}
-import com.zaxxer.hikari.HikariDataSource
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 import doobie.Transactor
 import play.api.inject.ApplicationLifecycle
 
@@ -32,10 +32,12 @@ object DatabaseConfig {
   private def transactorAndDataSource[F[_] : Async](config: JdbcConfig)(implicit cs: ContextShift[F]): (Transactor[F], HikariDataSource) = {
     val connectEC = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(config.fixedThreadPool))
     val transactEC = ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
-    val dataSource = new HikariDataSource()
-    dataSource.setJdbcUrl(config.url)
-    dataSource.setUsername(config.user)
-    dataSource.setPassword(config.password)
+    val ikariConfig = new HikariConfig()
+    ikariConfig.setMaximumPoolSize(config.fixedThreadPool)
+    ikariConfig.setJdbcUrl(config.url)
+    ikariConfig.setUsername(config.user)
+    ikariConfig.setPassword(config.password)
+    val dataSource = new HikariDataSource(ikariConfig)
 
     (Transactor.fromDataSource.apply(dataSource, connectEC, transactEC), dataSource)
   }

--- a/notificationworkerlambda/cfn.yaml
+++ b/notificationworkerlambda/cfn.yaml
@@ -130,6 +130,7 @@ Resources:
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 300
+      ReservedConcurrentExecutions: 100
       VpcConfig:
         SecurityGroupIds:
           - !GetAtt LambdaSecurityGroup.GroupId

--- a/notificationworkerlambda/cfn.yaml
+++ b/notificationworkerlambda/cfn.yaml
@@ -19,10 +19,6 @@ Parameters:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
     Default: mobile-notifications-dist
-  Concurrency:
-    Description: How many lambda can run in parallel
-    Type: String
-    Default: 3
   VpcId:
     Description: ID of the Notification VPC
     Type: AWS::EC2::VPC::Id
@@ -48,7 +44,7 @@ Resources:
       MessageRetentionPeriod: 3600 # 1 hour
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt Dlq.Arn
-        maxReceiveCount: 1 # ie: no retry
+        maxReceiveCount: 5
 
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -134,7 +130,6 @@ Resources:
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 300
-      ReservedConcurrentExecutions: !Ref Concurrency
       VpcConfig:
         SecurityGroupIds:
           - !GetAtt LambdaSecurityGroup.GroupId


### PR DESCRIPTION
- reduce the number of initial connections to 2 per workers, so that a big notification doesn't saturate the database
- bump the retry as the EventSourceMapping needs it to handle messages properly
- treat the delay of the retry as an initial delay applied no matter what