### PR TITLE
Turn dry run off in preparation for production

### DIFF
--- a/notification/app/notification/NotificationApplicationLoader.scala
+++ b/notification/app/notification/NotificationApplicationLoader.scala
@@ -144,9 +144,6 @@ class NotificationApplicationComponents(context: Context) extends BuiltInCompone
     new FilteredNotificationSender(notificationSender, topicRegistrationCounter, invertCondition)
 
   lazy val notificationSenders = List(
-    guardianIosNotificationSender,
-    guardianAndroidNotificationSender,
-    guardianNewsstandNotificationSender,
     gcmNotificationSender,
     apnsNotificationSender,
     newsstandShardNotificationSender,


### PR DESCRIPTION
Step 1: merge this PR => no traffic on our system anymore
Step 2: flip the dry run mode to off in the config
Step 3: redeploy workers to reload the config => our system is ready to receive notification
Step 4: merge https://github.com/guardian/mobile-n10n/pull/248