### PR TITLE
Add marginally more load

### DIFF
--- a/notification/app/notification/services/FilteredNotificationSender.scala
+++ b/notification/app/notification/services/FilteredNotificationSender.scala
@@ -22,7 +22,7 @@ class FilteredNotificationSender(
     TopicTypes.TagSeries,
     TopicTypes.TagBlog
   )
-  val maxRegistrationCount: Int = 10
+  val maxRegistrationCount: Int = 100
 
   override def sendNotification(push: Push): Future[SenderResult] = {
     def shouldSend(count: PlatformCount, topics: List[Topic]): Boolean = {


### PR DESCRIPTION
First two notifications were sent (iOS only so far). It's taking a while so I'm bumping the threshold ever so slightly in order to see more notifications, and see if we get them back in our event log.