### PR TITLE
Re organise the database thread pool config

### DIFF
--- a/common/src/main/scala/db/DatabaseConfig.scala
+++ b/common/src/main/scala/db/DatabaseConfig.scala
@@ -15,7 +15,7 @@ case class JdbcConfig(
   url: String,
   user: String,
   password: String,
-  fixedThreadPool: Int = 20
+  maxConnectionPoolSize: Int = 10
 )
 
 object DatabaseConfig {
@@ -30,10 +30,10 @@ object DatabaseConfig {
     )
   }
   private def transactorAndDataSource[F[_] : Async](config: JdbcConfig)(implicit cs: ContextShift[F]): (Transactor[F], HikariDataSource) = {
-    val connectEC = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(config.fixedThreadPool))
+    val connectEC = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(10))
     val transactEC = ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
     val hikariConfig = new HikariConfig()
-    hikariConfig.setMaximumPoolSize(config.fixedThreadPool)
+    hikariConfig.setMaximumPoolSize(config.maxConnectionPoolSize)
     hikariConfig.setJdbcUrl(config.url)
     hikariConfig.setUsername(config.user)
     hikariConfig.setPassword(config.password)

--- a/common/src/main/scala/db/RegistrationService.scala
+++ b/common/src/main/scala/db/RegistrationService.scala
@@ -36,7 +36,7 @@ object RegistrationService {
     val url = config.get[String]("registration.db.url")
     val user = config.get[String]("registration.db.user")
     val password = config.get[String]("registration.db.password")
-    val threads = config.get[Int]("registration.db.threads")
+    val threads = config.get[Int]("registration.db.maxConnectionPoolSize")
 
     val jdbcConfig = JdbcConfig("org.postgresql.Driver", url, user, password, threads)
     val transactor = DatabaseConfig.transactor[IO](jdbcConfig, applicationLifecycle)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -28,7 +28,7 @@ object Configuration {
     url = config.getString("registration.db.url"),
     user = config.getString("registration.db.user"),
     password = config.getString("registration.db.password"),
-    fixedThreadPool = config.getInt("registration.db.threads")
+    maxConnectionPoolSize = config.getInt("registration.db.maxConnectionPoolSize")
   )
 
   def fetchApns(): ApnsWorkerConfiguration = {


### PR DESCRIPTION
I leave the fixed size thread pool to 10, but use a parameter for the maximum amount of database connection.

It is currently set to 10 for services, and 1 for lambdas in the config.