### PR TITLE
Bump the threshold high enough to deliver the morning briefing

### DIFF
--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -52,7 +52,7 @@ final class Main(
   def pushTopic(topic: Topic): Action[Notification] = pushTopics
 
   def pushTopics: Action[Notification] = authAction.async(parse.json[Notification]) { request =>
-    val forcedProvider = request.headers.get("x-force-provider")
+    val avoidGuardianProvider = request.headers.get("x-avoid-guardian-provider").map(_.toBoolean)
 
     val topics = request.body.topic
     val MaxTopics = 3
@@ -61,7 +61,7 @@ final class Main(
       case a: Int if a > MaxTopics => Future.successful(BadRequest(s"Too many topics, maximum: $MaxTopics"))
       case _ if !topics.forall{request.isPermittedTopic} =>
         Future.successful(Unauthorized(s"This API key is not valid for ${topics.filterNot(request.isPermittedTopic)}."))
-      case _ => pushWithDuplicateProtection(Push(request.body.withTopics(topics), topics.toSet, forcedProvider))
+      case _ => pushWithDuplicateProtection(Push(request.body.withTopics(topics), topics.toSet, avoidGuardianProvider))
     }
   }
 

--- a/notification/app/notification/models/Push.scala
+++ b/notification/app/notification/models/Push.scala
@@ -2,4 +2,4 @@ package notification.models
 
 import models.{Notification, Topic}
 
-case class Push(notification: Notification, destination: Set[Topic])
+case class Push(notification: Notification, destination: Set[Topic], forcedProvider: Option[String] = None)

--- a/notification/app/notification/models/Push.scala
+++ b/notification/app/notification/models/Push.scala
@@ -2,4 +2,4 @@ package notification.models
 
 import models.{Notification, Topic}
 
-case class Push(notification: Notification, destination: Set[Topic], forcedProvider: Option[String] = None)
+case class Push(notification: Notification, destination: Set[Topic], avoidGuardianProvider: Option[Boolean] = None)

--- a/notification/app/notification/services/FilteredNotificationSender.scala
+++ b/notification/app/notification/services/FilteredNotificationSender.scala
@@ -26,7 +26,9 @@ class FilteredNotificationSender(
 
   override def sendNotification(push: Push): Future[SenderResult] = {
     def shouldSend(count: PlatformCount, topics: List[Topic]): Boolean = {
-      count.total < maxRegistrationCount && topics.forall(t => allowedTopicTypes.contains(t.`type`))
+      count.total < maxRegistrationCount &&
+        topics.forall(t => allowedTopicTypes.contains(t.`type`)) &&
+        (push.forcedProvider.isEmpty || push.forcedProvider.contains("guardian"))
     }
 
     def sendOrFilter(count: PlatformCount, topics: List[Topic]): Future[SenderResult] = {

--- a/notification/app/notification/services/FilteredNotificationSender.scala
+++ b/notification/app/notification/services/FilteredNotificationSender.scala
@@ -22,7 +22,7 @@ class FilteredNotificationSender(
     TopicTypes.TagSeries,
     TopicTypes.TagBlog
   )
-  val maxRegistrationCount: Int = 10000
+  val maxRegistrationCount: Int = 300000
 
   override def sendNotification(push: Push): Future[SenderResult] = {
     def shouldSend(count: PlatformCount, topics: List[Topic]): Boolean = {

--- a/notification/app/notification/services/FilteredNotificationSender.scala
+++ b/notification/app/notification/services/FilteredNotificationSender.scala
@@ -28,7 +28,7 @@ class FilteredNotificationSender(
     def shouldSend(count: PlatformCount, topics: List[Topic]): Boolean = {
       count.total < maxRegistrationCount &&
         topics.forall(t => allowedTopicTypes.contains(t.`type`)) &&
-        (push.forcedProvider.isEmpty || push.forcedProvider.contains("guardian"))
+        push.avoidGuardianProvider.forall(_ == false)
     }
 
     def sendOrFilter(count: PlatformCount, topics: List[Topic]): Future[SenderResult] = {


### PR DESCRIPTION
The last increase (10K) didn't bring that many runs (1 @ 6k) as notifications that big are less frequent.

I suggest we now increase it up to tomorrow's morning briefing. As a reminder the breaking news are still being filtered and won't be delivered through our system yet.