### PR TITLE
Concurrency and disable briefing

### DIFF
--- a/notification/app/notification/services/FilteredNotificationSender.scala
+++ b/notification/app/notification/services/FilteredNotificationSender.scala
@@ -22,7 +22,7 @@ class FilteredNotificationSender(
     TopicTypes.TagSeries,
     TopicTypes.TagBlog
   )
-  val maxRegistrationCount: Int = 300000
+  val maxRegistrationCount: Int = 100000
 
   override def sendNotification(push: Push): Future[SenderResult] = {
     def shouldSend(count: PlatformCount, topics: List[Topic]): Boolean = {

--- a/notificationworkerlambda/platform-worker-cfn.yaml
+++ b/notificationworkerlambda/platform-worker-cfn.yaml
@@ -19,10 +19,6 @@ Parameters:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
     Default: mobile-notifications-dist
-  Concurrency:
-    Description: How many lambda can run in parallel
-    Type: String
-    Default: 3
   VpcId:
     Description: ID of the Notification VPC
     Type: AWS::EC2::VPC::Id
@@ -143,7 +139,7 @@ Resources:
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 300
-      ReservedConcurrentExecutions: !Ref Concurrency
+      ReservedConcurrentExecutions: 100
       VpcConfig:
         SecurityGroupIds:
           - !GetAtt LambdaSecurityGroup.GroupId


### PR DESCRIPTION
- Raise the concurrency limit to what it should be (was like that before merging #253 which brought the bug we observe)
- lower the threshold of what the guardian system handles. This will force the morning briefing to go through Azure this weekend.