### PR TITLE
Raise the concurrency such that throttling is unlikely

### DIFF
--- a/notificationworkerlambda/platform-worker-cfn.yaml
+++ b/notificationworkerlambda/platform-worker-cfn.yaml
@@ -19,10 +19,6 @@ Parameters:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
     Default: mobile-notifications-dist
-  Concurrency:
-    Description: How many lambda can run in parallel
-    Type: String
-    Default: 3
   VpcId:
     Description: ID of the Notification VPC
     Type: AWS::EC2::VPC::Id
@@ -51,7 +47,7 @@ Resources:
       MessageRetentionPeriod: 3600 # 1 hour
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt Dlq.Arn
-        maxReceiveCount: 1 # ie: no retry
+        maxReceiveCount: 5
 
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -143,7 +139,7 @@ Resources:
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 300
-      ReservedConcurrentExecutions: !Ref Concurrency
+      ReservedConcurrentExecutions: 100
       VpcConfig:
         SecurityGroupIds:
           - !GetAtt LambdaSecurityGroup.GroupId


### PR DESCRIPTION
And bump the retry such that in case of a throttling event, batches are retried.