### PR TITLE
Only mark invalid tokens as warning

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Reporting.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Reporting.scala
@@ -1,6 +1,7 @@
 package com.gu.notifications.worker.utils
 
 import cats.effect.IO
+import com.gu.notifications.worker.delivery.DeliveryException.InvalidToken
 import com.gu.notifications.worker.delivery.{DeliveryClient, DeliveryException, DeliverySuccess}
 import org.slf4j.Logger
 
@@ -9,6 +10,7 @@ object Reporting {
   def log[C <: DeliveryClient](prefix: String)(implicit logger: Logger): Either[DeliveryException, DeliverySuccess] => IO[Unit] = { resp =>
     IO.delay {
       resp match {
+        case Left(e: InvalidToken) => logger.warn(s"$prefix $e")
         case Left(e) => logger.error(s"$prefix $e")
         case Right(_) => () // doing nothing when success
       }


### PR DESCRIPTION
We get quite a lot of these, marking them as error leaves a lot of noise in the logs.
We'll eventually disable them completely as this is just normal behaviour, but in the meantime I'm downgrading these "Errors" to warnings so that searching for an Error in the logs is more meaningful