### PR TITLE
Direct correlation between delivery speed and memory (CPU)

### DIFF
--- a/notificationworkerlambda/platform-worker-cfn.yaml
+++ b/notificationworkerlambda/platform-worker-cfn.yaml
@@ -138,7 +138,7 @@ Resources:
           App: !Ref App
       Description: Consumes queue events and sends notifications
       Handler: !Ref FullyQualifiedHandler
-      MemorySize: 2048
+      MemorySize: 3008
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 300


### PR DESCRIPTION
By doubling the memory last week, we've almost divided the processing time by 2, leading me to believe CPU is actually the current bottleneck.

So I'm increasing the memory size (and by extension the CPU) to the current maximum aws lambdas can take, and I'm looking at the code to see if there's anything that can be done performance wise.