### PR TITLE
Adding a trace case for Firebase errors that aren't token errors

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryException.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryException.scala
@@ -36,8 +36,8 @@ object DeliveryException {
         tokenInvalidationTimestamp.map(ts => s", Token invalidation timestamp: $ts")
   }
 
-  case class FailedRequest(notificationId: UUID, token: String, cause: Throwable) extends DeliveryException {
-    override def getMessage = s"Request failed (Notification: $notificationId, Token: $token). Cause: ${cause.getMessage}"
+  case class FailedRequest(notificationId: UUID, token: String, cause: Throwable, errorCode: Option[String] = None) extends DeliveryException {
+    override def getMessage = s"Request failed (Notification: $notificationId, Token: $token). Cause: ${cause.getMessage}. ErrorCode: $errorCode}."
   }
 
   case class InvalidPayload(notificationId: UUID) extends DeliveryException {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -59,6 +59,8 @@ class FcmClient private (firebaseMessaging: FirebaseMessaging, firebaseApp: Fire
             onComplete(Right(FcmDeliverySuccess(token, messageId)))
           case Failure(UnwrappingExecutionException(e: FirebaseMessagingException)) if invalidTokenErrorCodes.contains(e.getErrorCode) =>
             onComplete(Left(InvalidToken(notificationId, token, e.getMessage)))
+          case Failure(UnwrappingExecutionException(e: FirebaseMessagingException)) =>
+            onComplete(Left(FailedRequest(notificationId, token, e, Option(e.getErrorCode))))
           case Failure(NonFatal(t)) =>
             onComplete(Left(FailedRequest(notificationId, token, t)))
         }


### PR DESCRIPTION
So we can get the error code in the logs