### PR TITLE
Disable retention policy

### DIFF
--- a/eventconsumer/cfn.yaml
+++ b/eventconsumer/cfn.yaml
@@ -165,7 +165,7 @@ Resources:
       LifecycleConfiguration:
         Rules:
           - ExpirationInDays: 21
-            Status: Enabled
+            Status: Disabled
       NotificationConfiguration:
         QueueConfigurations:
         - Event: s3:ObjectCreated:*


### PR DESCRIPTION
Is this how you cloud form?

The retention policy is making us lose historical performance data for notifications sent via azure. This data is really useful right now to benchmark the new system against. My suggestion is to
- Disable the lifecycle policy just to stop deleting it (this PR)
- Segregate the historical data into a separate bucket/table and resume lifecycle policy (probably next week)