### PR TITLE
Mss 593/improving lambda cloudwatch alarms

### DIFF
--- a/notificationworkerlambda/platform-worker-cfn.yaml
+++ b/notificationworkerlambda/platform-worker-cfn.yaml
@@ -38,6 +38,9 @@ Parameters:
     Type: String
     Description: The ARN of the SNS topic to send all the cloudwatch alarms to
 
+Conditions:
+  IsProdStage: !Equals [!Ref Stage, PROD]
+
 Resources:
 
   Dlq:
@@ -196,6 +199,7 @@ Resources:
   TooFewInvocationsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      ActionsEnabled: !If [IsProdStage, true, false]
       AlarmDescription: !Sub Triggers if the ${App} lambda is not frequently invoked in ${Stage}
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:

--- a/notificationworkerlambda/platform-worker-cfn.yaml
+++ b/notificationworkerlambda/platform-worker-cfn.yaml
@@ -191,6 +191,23 @@ Resources:
       Period: 60
       Statistic: Sum
       Threshold: 0
+      TreatMissingData: notBreaching
+
+  TooFewInvocationsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: !Sub Triggers if the ${App} lambda is not frequently invoked in ${Stage}
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Sub ${App}-${Stage}
+      EvaluationPeriods: 1
+      MetricName: Invocations
+      Namespace: AWS/Lambda
+      Period: 7200
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: breaching
 
 Outputs:
   SQSArn:

--- a/notificationworkerlambda/platform-worker-cfn.yaml
+++ b/notificationworkerlambda/platform-worker-cfn.yaml
@@ -199,6 +199,7 @@ Resources:
   TooFewInvocationsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmActions: [!Ref AlarmTopic]
       ActionsEnabled: !If [IsProdStage, true, false]
       AlarmDescription: !Sub Triggers if the ${App} lambda is not frequently invoked in ${Stage}
       ComparisonOperator: LessThanOrEqualToThreshold


### PR DESCRIPTION
Not having errors should not be treated as an alarm, so it seems appropriate to set `TreatMissingData` to `notBreaching`

However, not having data is a worry, so adding `TooFewInvocationsAlarm` which will also be set up on CODE, but because we expect this to alarm on CODE I've set ActionsEnabled to false if not prod.