### PR TITLE
Remove Firebase and Azure

### DIFF
--- a/notification/app/notification/NotificationApplicationLoader.scala
+++ b/notification/app/notification/NotificationApplicationLoader.scala
@@ -144,14 +144,9 @@ class NotificationApplicationComponents(context: Context) extends BuiltInCompone
     new FilteredNotificationSender(notificationSender, topicRegistrationCounter, invertCondition)
 
   lazy val notificationSenders = List(
-    withFilter(guardianIosNotificationSender, invertCondition = false),
-    withFilter(guardianAndroidNotificationSender, invertCondition = false),
-    withFilter(guardianNewsstandNotificationSender, invertCondition = false),
-    withFilter(gcmNotificationSender, invertCondition = true),
-    withFilter(apnsNotificationSender, invertCondition = true),
-    withFilter(newsstandShardNotificationSender, invertCondition = true),
-    //frontendAlerts, //disabled until frontend decides whether to fix this feature or not.
-    withFilter(fcmNotificationSender, invertCondition = true)
+    guardianIosNotificationSender,
+    guardianAndroidNotificationSender,
+    guardianNewsstandNotificationSender,
   )
 
   lazy val mainController = wire[Main]

--- a/registration/app/registration/RegistrationApplicationLoader.scala
+++ b/registration/app/registration/RegistrationApplicationLoader.scala
@@ -116,7 +116,7 @@ class RegistrationApplicationComponents(identity: AppIdentity, context: Context)
     metrics = metrics
   )
 
-  lazy val mainController = new Main(copyingRegistrarProvider, topicValidator, legacyRegistrationConverter, legacyNewsstandRegistrationConverter, appConfig, controllerComponents)
+  lazy val mainController = new Main(databaseRegistrar, topicValidator, legacyRegistrationConverter, legacyNewsstandRegistrationConverter, appConfig, controllerComponents)
 
   override lazy val router: Router = wire[Routes]
   lazy val prefix: String = "/"

--- a/registration/test/registration/controllers/MainControllerSpec.scala
+++ b/registration/test/registration/controllers/MainControllerSpec.scala
@@ -56,7 +56,7 @@ class MainControllerSpec extends PlaySpecification with JsonMatchers with Mockit
       contentAsString(result) must /("results") /#(0) /("platform" -> "ios")
       contentAsString(result) must /("results") /#(0) /("deviceId" -> "4027049721A496EA56A4C789B62F2C10B0380427C2A6B0CFC1DE692BDA2CC5D4")
       contentAsString(result) must (/("results") andHave size(1))
-    }
+    }.pendingUntilFixed("Endpoint to be dropped")
 
     "return 204 when unregistering" in new RegistrationsContext {
       val Some(register) = route(app, FakeRequest(DELETE, "/registrations?platform=ios&azureToken=4027049721A496EA56A4C789B62F2C10B0380427C2A6B0CFC1DE692BDA2CC5D4"))


### PR DESCRIPTION
This is the minimum required change to remove any logic regarding Firebase and Azure registrations.

This doesn't focus on any dead code (yet) but rather focuses on the minimum code change to completely avoid the migration logic and never call any logic from our Azure and Firebase clients.