### PR TITLE
Re-enable lifecycle policy

### DIFF
--- a/eventconsumer/cfn.yaml
+++ b/eventconsumer/cfn.yaml
@@ -142,7 +142,7 @@ Resources:
       LifecycleConfiguration:
         Rules:
           - ExpirationInDays: 21
-            Status: Disabled
+            Status: Enabled
       NotificationConfiguration:
         QueueConfigurations:
         - Event: s3:ObjectCreated:*


### PR DESCRIPTION
I've segregated the historical from Nov 14th - 28th to `s3://aws-mobile-event-logs-historical/` and create a historical table in athena.