### PR TITLE
MSS-595: Log athena polling states

### DIFF
--- a/eventconsumer/src/main/scala/com/gu/notifications/events/AthenaLambda.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/AthenaLambda.scala
@@ -66,7 +66,9 @@ class AthenaLambda {
     athenaAsyncClient.getQueryExecution(GetQueryExecutionRequest.builder()
       .queryExecutionId(id)
       .build()).thenComposeAsync((response: GetQueryExecutionResponse) => {
-      response.queryExecution().status().state() match {
+      val state = response.queryExecution().status().state()
+      logger.info(state.toString)
+      state match {
         case QueryExecutionState.QUEUED => waitUntilQueryCompletes(id)
         case QueryExecutionState.RUNNING => waitUntilQueryCompletes(id)
         case _ => CompletableFuture.completedFuture(null)

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/AthenaLambda.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/AthenaLambda.scala
@@ -67,7 +67,7 @@ class AthenaLambda {
       .queryExecutionId(id)
       .build()).thenComposeAsync((response: GetQueryExecutionResponse) => {
       val state = response.queryExecution().status().state()
-      logger.info(state.toString)
+      logger.info(s"Query $id state: $state")
       state match {
         case QueryExecutionState.QUEUED => waitUntilQueryCompletes(id)
         case QueryExecutionState.RUNNING => waitUntilQueryCompletes(id)


### PR DESCRIPTION
When the lambda errors there might be a bad state indicated here so worth logging.
Also, there's a risk the query is in remaining in QUEUED or RUNNING state. This should make that clear.