### PR TITLE
Trying Scala futures

### DIFF
--- a/eventconsumer/src/main/scala/com/gu/notifications/events/AthenaLambda.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/AthenaLambda.scala
@@ -2,7 +2,7 @@ package com.gu.notifications.events
 
 import java.time.format.DateTimeFormatter
 import java.time.{Duration, ZoneOffset, ZonedDateTime}
-import java.util.concurrent.{CompletableFuture, CompletionStage, ConcurrentLinkedQueue}
+import java.util.concurrent.{ConcurrentLinkedQueue, Executors, TimeUnit}
 
 import com.gu.notifications.events.AthenaLambda.athenaAsyncClient
 import com.gu.notifications.events.dynamo.DynamoReportUpdater
@@ -11,16 +11,15 @@ import org.apache.logging.log4j.{LogManager, Logger}
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, DefaultCredentialsProvider, ProfileCredentialsProvider}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.athena.AthenaAsyncClient
-import software.amazon.awssdk.services.athena.model.{GetQueryExecutionRequest, GetQueryExecutionResponse, GetQueryResultsRequest, GetQueryResultsResponse, QueryExecutionContext, QueryExecutionState, ResultConfiguration, Row, StartQueryExecutionRequest, StartQueryExecutionResponse}
+import software.amazon.awssdk.services.athena.model.{GetQueryExecutionRequest, GetQueryExecutionResponse, GetQueryResultsResponse, QueryExecutionContext, QueryExecutionState, ResultConfiguration, Row, StartQueryExecutionRequest, StartQueryExecutionResponse}
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
-import scala.compat.java8.FutureConverters
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{Await, ExecutionContext, Future, Promise, duration}
 
 object AthenaLambda {
   val reportingWindow = Duration.ofHours(3)
-  val athenaAsyncClient = AthenaAsyncClient.builder()
+  val athenaAsyncClient = new ScalaAthenaAsyncClient(AthenaAsyncClient.builder()
     .region(Region.EU_WEST_1)
     .credentialsProvider(AwsCredentialsProviderChain.builder()
       .addCredentialsProvider(ProfileCredentialsProvider.builder()
@@ -28,25 +27,28 @@ object AthenaLambda {
         .build())
       .addCredentialsProvider(DefaultCredentialsProvider.builder().build())
       .build())
-    .build()
+    .build())
 }
 
 case class Query(database: String, queryString: String, outputLocation: String)
 
+
 class AthenaLambda {
+  val scheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
 
   import ExecutionContext.Implicits.global
+
   private val envDependencies = new EnvDependencies
   private val logger: Logger = LogManager.getLogger(classOf[AthenaLambda])
   private val stage: String = envDependencies.stage
   private val dynamoReportUpdater = new DynamoReportUpdater(stage)
 
 
-  def route(query: Query, startOfReportingWindow: ZonedDateTime): CompletableFuture[Void] = {
+  def route(query: Query, startOfReportingWindow: ZonedDateTime): Future[Unit] = {
     startQuery(query)
-      .thenComposeAsync(fetchQueryResponse(_, rows => rows.map(cells => (cells.head, PlatformCount(cells(1).toInt, cells(2).toInt, cells(3).toInt))).groupBy(_._1).mapValues(_.map(_._2).head)))
-      .thenComposeAsync(updateDynamoIfRecent(_, startOfReportingWindow))
-      .thenAcceptAsync((aggregationCounts: AggregationCounts) => {
+      .flatMap(fetchQueryResponse(_, rows => rows.map(cells => (cells.head, PlatformCount(cells(1).toInt, cells(2).toInt, cells(3).toInt))).groupBy(_._1).mapValues(_.map(_._2).head)))
+      .flatMap(updateDynamoIfRecent(_, startOfReportingWindow))
+      .map((aggregationCounts: AggregationCounts) => {
         logger.info(s"Aggregation counts $aggregationCounts")
         if (aggregationCounts.failure > 0) {
           throw new RuntimeException("Failures")
@@ -54,51 +56,49 @@ class AthenaLambda {
       })
   }
 
-  def startQuery(query: Query): CompletableFuture[String] = {
-    val startQueryAndGetId: CompletableFuture[String] = executeQuery(query).thenApplyAsync((startQueryExecutionResponse: StartQueryExecutionResponse) => startQueryExecutionResponse.queryExecutionId())
-    startQueryAndGetId.thenComposeAsync((executionId: String) =>
-      waitUntilQueryCompletes(executionId).thenApplyAsync((_: Void) => executionId)
+  def startQuery(query: Query): Future[String] = {
+    val startQueryAndGetId: Future[String] = executeQuery(query).map((startQueryExecutionResponse: StartQueryExecutionResponse) => startQueryExecutionResponse.queryExecutionId())
+    startQueryAndGetId.flatMap((executionId: String) =>
+      waitUntilQueryCompletes(executionId).map(_ => executionId)
     )
   }
 
 
-  private def waitUntilQueryCompletes(id: String): CompletableFuture[Void] = {
-    Thread.sleep(1000)
-    athenaAsyncClient.getQueryExecution(GetQueryExecutionRequest.builder()
+  private def waitUntilQueryCompletes(id: String): Future[Unit] = {
+    val promiseInASecond = Promise[Unit]
+    val runnable: Runnable = () => promiseInASecond.success(())
+    scheduledExecutorService.schedule(runnable, 1, TimeUnit.SECONDS)
+    promiseInASecond.future.flatMap(_ => athenaAsyncClient.getQueryExecution(GetQueryExecutionRequest.builder()
       .queryExecutionId(id)
-      .build()).thenComposeAsync((response: GetQueryExecutionResponse) => {
-      val state = response.queryExecution().status().state()
-      logger.info(s"Query $id state: $state")
-      state match {
-        case QueryExecutionState.QUEUED => waitUntilQueryCompletes(id)
-        case QueryExecutionState.RUNNING => waitUntilQueryCompletes(id)
-        case _ => CompletableFuture.completedFuture(null)
-      }
-    })
+      .build()))
+      .map((response: GetQueryExecutionResponse) => {
+        val state = response.queryExecution().status().state()
+        logger.info(s"Query $id state: $state")
+        state match {
+          case QueryExecutionState.QUEUED => waitUntilQueryCompletes(id)
+          case QueryExecutionState.RUNNING => waitUntilQueryCompletes(id)
+          case _ => Future.successful(())
+        }
+      }).flatten
   }
 
 
-  private def updateDynamoIfRecent(notificationIdCounts: Map[String, PlatformCount], startOfReportingWindow: ZonedDateTime): CompletionStage[AggregationCounts] = {
+  private def updateDynamoIfRecent(notificationIdCounts: Map[String, PlatformCount], startOfReportingWindow: ZonedDateTime): Future[AggregationCounts] = {
     val notificationReportEvents = notificationIdCounts.toList.map { case (id, count) => NotificationReportEvent(id, EventAggregation(count)) }
     val resultCounts = dynamoReportUpdater.updateSetEventsReceivedAfter(notificationReportEvents, startOfReportingWindow)
-    val aggregatedCounts = AggregationCounts.aggregateResultCounts(resultCounts)
-    FutureConverters.toJava(aggregatedCounts)
+    AggregationCounts.aggregateResultCounts(resultCounts)
   }
 
-  private def fetchQueryResponse[T](id: String, transform: List[List[String]] => T): CompletableFuture[T] = {
+  private def fetchQueryResponse[T](id: String, transform: List[List[String]] => T): Future[T] = {
     val queue = new ConcurrentLinkedQueue[List[List[String]]]()
-    athenaAsyncClient.getQueryResultsPaginator(GetQueryResultsRequest.builder()
-      .queryExecutionId(id)
-      .build()).subscribe((getQueryResultsResponse: GetQueryResultsResponse) => {
+    athenaAsyncClient.subscribeToPagination(id, (getQueryResultsResponse: GetQueryResultsResponse) => {
       val rows: List[Row] = getQueryResultsResponse.resultSet.rows().asScala.toList
       logger.info(s"Headers: ${rows.head.data().asScala.toList.map(_.varCharValue())}")
       queue.add(rows.tail.map { row => row.data().asScala.toList.map(_.varCharValue()) })
-    }).thenApplyAsync((_: Void) =>
-      transform(queue.asScala.flatten.toList)
-    )
+    }).map(_ => transform(queue.asScala.flatten.toList))
   }
 
-  private def executeQuery(query: Query): CompletableFuture[StartQueryExecutionResponse] =
+  private def executeQuery(query: Query): Future[StartQueryExecutionResponse] =
     athenaAsyncClient.startQueryExecution(StartQueryExecutionRequest.builder()
       .queryExecutionContext(QueryExecutionContext.builder()
         .database(query.database)
@@ -116,8 +116,8 @@ class AthenaLambda {
     val athenaDatabase = envDependencies.athenaDatabase
 
     @tailrec
-    def addPartitionFrom(fromTime: ZonedDateTime, started: List[CompletableFuture[String]] = List()):List[CompletableFuture[String]] = {
-      if(fromTime.isAfter(now)) {
+    def addPartitionFrom(fromTime: ZonedDateTime, started: List[Future[String]] = List()): List[Future[String]] = {
+      if (fromTime.isAfter(now)) {
         started
       }
       else {
@@ -133,7 +133,7 @@ LOCATION '${envDependencies.ingestLocation}/date=$date/hour=$hour/'""".stripMarg
       }
     }
 
-    val addPartitions = addPartitionFrom(startOfReportingWindow).reduce((a,b) => a.thenComposeAsync(_ => b))
+    val addPartitions = addPartitionFrom(startOfReportingWindow).reduce((a, b) => a.flatMap(_ => b))
     val fetchEventsQuery = Query(athenaDatabase,
       s"""SELECT notificationid,
          count(*) AS total,
@@ -143,7 +143,8 @@ FROM notification_received_${stage.toLowerCase()}
 WHERE partition_date = '${toQueryDate(startOfReportingWindow)}'
          AND partition_hour >= ${startOfReportingWindow.getHour}
 GROUP BY  notificationid""".stripMargin, athenaOutputLocation)
-    addPartitions.thenComposeAsync(_ => route(fetchEventsQuery, startOfReportingWindow)).join()
+    Await.result(
+      addPartitions.flatMap(_ => route(fetchEventsQuery, startOfReportingWindow)), duration.Duration(4, TimeUnit.MINUTES))
   }
 
   private def toQueryDate(zonedDateTime: ZonedDateTime) = {

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/ScalaAthenaAsyncClient.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/ScalaAthenaAsyncClient.scala
@@ -1,0 +1,19 @@
+package com.gu.notifications.events
+
+import software.amazon.awssdk.services.athena.AthenaAsyncClient
+import software.amazon.awssdk.services.athena.model.{GetQueryExecutionRequest, GetQueryExecutionResponse, GetQueryResultsRequest, GetQueryResultsResponse, StartQueryExecutionRequest, StartQueryExecutionResponse}
+
+import scala.compat.java8.FutureConverters
+import scala.concurrent.Future
+
+class ScalaAthenaAsyncClient(athenaAsyncClient: AthenaAsyncClient) {
+  def startQueryExecution(request: StartQueryExecutionRequest): Future[StartQueryExecutionResponse] = FutureConverters.toScala(athenaAsyncClient.startQueryExecution(request))
+
+  def getQueryExecution(request: GetQueryExecutionRequest): Future[GetQueryExecutionResponse] = FutureConverters.toScala(athenaAsyncClient.getQueryExecution(request))
+
+  def subscribeToPagination[T](id: String, consumer: GetQueryResultsResponse => T): Future[Void] = {
+    FutureConverters.toScala(athenaAsyncClient.getQueryResultsPaginator(GetQueryResultsRequest.builder()
+      .queryExecutionId(id)
+      .build()).subscribe(x => consumer(x)))
+  }
+}

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/ScalaAthenaAsyncClient.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/ScalaAthenaAsyncClient.scala
@@ -1,19 +1,27 @@
 package com.gu.notifications.events
 
-import software.amazon.awssdk.services.athena.AthenaAsyncClient
-import software.amazon.awssdk.services.athena.model.{GetQueryExecutionRequest, GetQueryExecutionResponse, GetQueryResultsRequest, GetQueryResultsResponse, StartQueryExecutionRequest, StartQueryExecutionResponse}
+import java.util.concurrent.ConcurrentLinkedQueue
 
+import software.amazon.awssdk.services.athena.AthenaAsyncClient
+import software.amazon.awssdk.services.athena.model.{GetQueryExecutionRequest, GetQueryExecutionResponse, GetQueryResultsRequest, GetQueryResultsResponse, Row, StartQueryExecutionRequest, StartQueryExecutionResponse}
+
+import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class ScalaAthenaAsyncClient(athenaAsyncClient: AthenaAsyncClient) {
   def startQueryExecution(request: StartQueryExecutionRequest): Future[StartQueryExecutionResponse] = FutureConverters.toScala(athenaAsyncClient.startQueryExecution(request))
 
   def getQueryExecution(request: GetQueryExecutionRequest): Future[GetQueryExecutionResponse] = FutureConverters.toScala(athenaAsyncClient.getQueryExecution(request))
 
-  def subscribeToPagination[T](id: String, consumer: GetQueryResultsResponse => T): Future[Void] = {
+
+  def fetchQueryResponse[T](id: String, transform: List[List[String]] => T)(implicit executionContext: ExecutionContext): Future[T] = {
+    val queue = new ConcurrentLinkedQueue[List[List[String]]]()
     FutureConverters.toScala(athenaAsyncClient.getQueryResultsPaginator(GetQueryResultsRequest.builder()
       .queryExecutionId(id)
-      .build()).subscribe(x => consumer(x)))
+      .build()).subscribe((getQueryResultsResponse: GetQueryResultsResponse) => {
+      val rows: List[Row] = getQueryResultsResponse.resultSet.rows().asScala.toList
+      queue.add(rows.tail.map { row => row.data().asScala.toList.map(_.varCharValue()) })
+    })).map(_ => transform(queue.asScala.flatten.toList))
   }
 }


### PR DESCRIPTION
Not sure where the deadlock is, but swapped most of the Futures to Scala (there's some comments online about deadlock and `thenComposeAsync` although they also suggest that should have been fixed by now). There's an added benefit this segregates the two future types so only one is used in the main logic.
Swapped Thread.sleep to using a scheduled executor service.