### PR TITLE
MSS-595: Recreate clients on each invocation

### DIFF
--- a/eventconsumer/src/main/scala/com/gu/notifications/events/AthenaMetrics.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/AthenaMetrics.scala
@@ -1,0 +1,163 @@
+package com.gu.notifications.events
+
+import java.time.format.DateTimeFormatter
+import java.time.{Duration, ZoneOffset, ZonedDateTime}
+import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
+
+import com.amazonaws.AmazonWebServiceRequest
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.services.athena.AmazonAthenaAsync
+import com.amazonaws.services.athena.model.{GetQueryExecutionRequest, GetQueryExecutionResult, GetQueryResultsRequest, GetQueryResultsResult, QueryExecutionContext, QueryExecutionState, ResultConfiguration, StartQueryExecutionRequest, StartQueryExecutionResult}
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
+import com.gu.notifications.events.dynamo.DynamoReportUpdater
+import com.gu.notifications.events.model.{AggregationCounts, EventAggregation, NotificationReportEvent, PlatformCount}
+import org.apache.logging.log4j.{LogManager, Logger}
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.concurrent.{Await, ExecutionContext, Future, Promise, duration}
+
+object AthenaMetrics {
+  val queuedString: String = QueryExecutionState.QUEUED.toString
+  val runningString: String = QueryExecutionState.RUNNING.toString
+  val reportingWindow: Duration = Duration.ofHours(3)
+}
+
+case class Query(database: String, queryString: String, outputLocation: String)
+
+
+class AthenaMetrics {
+
+  import ExecutionContext.Implicits.global
+
+  private val envDependencies = new EnvDependencies
+  private val logger: Logger = LogManager.getLogger(classOf[AthenaMetrics])
+  private val stage: String = envDependencies.stage
+
+  val dynamoReportUpdater = new DynamoReportUpdater(stage)
+
+  private def asyncHandle[REQ <: AmazonWebServiceRequest, RES](asyncHandlerConsumer: AsyncHandler[REQ, RES] => Any): Future[RES] = {
+    val promise = Promise[RES]
+    asyncHandlerConsumer(new AsyncHandler[REQ, RES] {
+      override def onError(exception: Exception): Unit = promise.failure(exception)
+
+      override def onSuccess(request: REQ, result: RES): Unit = promise.success(result)
+    })
+    promise.future
+  }
+
+  private def toQueryDate(zonedDateTime: ZonedDateTime): String = {
+    zonedDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE)
+  }
+
+  private def startQuery(query: Query)(implicit athenaAsyncClient: AmazonAthenaAsync, scheduledExecutorService: ScheduledExecutorService): Future[String] = {
+    def executeQuery(query: Query): Future[StartQueryExecutionResult] = asyncHandle[StartQueryExecutionRequest, StartQueryExecutionResult](asyncHandler =>
+      athenaAsyncClient.startQueryExecutionAsync(new StartQueryExecutionRequest()
+        .withQueryString(query.queryString)
+        .withQueryExecutionContext(new QueryExecutionContext().withDatabase(query.database))
+        .withResultConfiguration(new ResultConfiguration().withOutputLocation(query.outputLocation)), asyncHandler))
+
+    def waitUntilQueryCompletes(id: String): Future[Unit] = {
+      val promiseInASecond = Promise[Unit]
+      val runnable: Runnable = () => promiseInASecond.success(())
+      scheduledExecutorService.schedule(runnable, 1, TimeUnit.SECONDS)
+      promiseInASecond.future.flatMap { _ =>
+        asyncHandle[GetQueryExecutionRequest, GetQueryExecutionResult](asyncHandler =>
+          athenaAsyncClient.getQueryExecutionAsync(new GetQueryExecutionRequest().withQueryExecutionId(id), asyncHandler))
+      }.map((response: GetQueryExecutionResult) => {
+        val state = response.getQueryExecution.getStatus.getState
+        logger.info(s"Query $id state: $state")
+        state match {
+          case AthenaMetrics.queuedString => waitUntilQueryCompletes(id)
+          case AthenaMetrics.runningString => waitUntilQueryCompletes(id)
+          case _ => Future.successful(())
+        }
+      }).flatten
+    }
+
+    val startQueryAndGetId: Future[String] = executeQuery(query).map((startQueryExecutionResponse: StartQueryExecutionResult) => startQueryExecutionResponse.getQueryExecutionId)
+    startQueryAndGetId.flatMap((executionId: String) => waitUntilQueryCompletes(executionId).map(_ => executionId))
+  }
+
+  private def updateDynamoIfRecent(notificationIdCounts: Map[String, PlatformCount], startOfReportingWindow: ZonedDateTime)(implicit dynamoDBAsyncClient: AmazonDynamoDBAsync): Future[AggregationCounts] = {
+    val notificationReportEvents = notificationIdCounts.toList.map { case (id, count) => NotificationReportEvent(id, EventAggregation(count)) }
+    val resultCounts = dynamoReportUpdater.updateSetEventsReceivedAfter(notificationReportEvents, startOfReportingWindow)
+    AggregationCounts.aggregateResultCounts(resultCounts)
+  }
+
+  private def fetchQueryResponse[T](id: String, transform: List[List[String]] => T)(implicit athenaAsync: AmazonAthenaAsync): Future[T] = {
+    def readAndProcessNext(getQueryResultsResult: GetQueryResultsResult, last: List[List[String]] = Nil): Future[List[List[String]]] = {
+      val next = last ++ getQueryResultsResult.getResultSet.getRows.asScala.toList.map(row => row.getData.asScala.map(_.getVarCharValue).toList)
+      Option(getQueryResultsResult.getNextToken) match {
+        case Some(token) => asyncHandle[GetQueryResultsRequest, GetQueryResultsResult](asyncHandler =>
+          athenaAsync.getQueryResultsAsync(new GetQueryResultsRequest().withQueryExecutionId(id).withNextToken(token), asyncHandler)).flatMap(readAndProcessNext(_, next))
+        case None => Future.successful(next)
+      }
+    }
+
+    asyncHandle[GetQueryResultsRequest, GetQueryResultsResult](asyncHandler => athenaAsync.getQueryResultsAsync(new GetQueryResultsRequest().withQueryExecutionId(id), asyncHandler))
+      .flatMap(readAndProcessNext(_)).map {
+      case _ :: tail => tail
+      case _ => Nil
+    }.map(transform(_))
+  }
+
+  private def addS3PartitionsToAthenaIndex(
+    now: ZonedDateTime,
+    startOfReportingWindow: ZonedDateTime,
+    athenaDatabase: String,
+    athenaOutputLocation: String
+  )(implicit amazonAthenaAsync: AmazonAthenaAsync, scheduledExecutorService: ScheduledExecutorService
+  ): Future[String] = {
+    @tailrec
+    def addPartitionFrom(fromTime: ZonedDateTime, started: List[Future[String]] = List()): List[Future[String]] = {
+      if (fromTime.isAfter(now)) {
+        started
+      }
+      else {
+        val integerHour = fromTime.getHour
+        val hour = if (integerHour < 10) s"0$integerHour" else integerHour.toString
+        val date = toQueryDate(fromTime)
+        val list = startQuery(Query(
+          athenaDatabase,
+          s"""ALTER TABLE raw_events_$stage
+ADD IF NOT EXISTS PARTITION (date='$date', hour=$hour)
+LOCATION '${envDependencies.ingestLocation}/date=$date/hour=$hour/'""".stripMargin, athenaOutputLocation)) :: started
+        addPartitionFrom(fromTime.plusHours(1), list)
+      }
+    }
+
+    addPartitionFrom(startOfReportingWindow).reduce((a, b) => a.flatMap(_ => b))
+  }
+
+  private def routeFromQueryToUpdateDynamoDb(query: Query, startOfReportingWindow: ZonedDateTime)(implicit athenaAsync: AmazonAthenaAsync, dynamoDBAsync: AmazonDynamoDBAsync, scheduledExecutorService: ScheduledExecutorService): Future[Unit] = {
+    startQuery(query)
+      .flatMap(fetchQueryResponse(_, rows => rows.map(cells => (cells.head, PlatformCount(cells(1).toInt, cells(2).toInt, cells(3).toInt))).groupBy(_._1).mapValues(_.map(_._2).head)))
+      .flatMap(updateDynamoIfRecent(_, startOfReportingWindow))
+      .map((aggregationCounts: AggregationCounts) => {
+        logger.info(s"Aggregation counts $aggregationCounts")
+        if (aggregationCounts.failure > 0) {
+          throw new RuntimeException("Failures")
+        }
+      })
+  }
+
+  def handleRequest()(implicit athenaAsyncClient: AmazonAthenaAsync, scheduledExecutorService: ScheduledExecutorService, dynamoDBAsyncClient: AmazonDynamoDBAsync): Unit = {
+    val now = ZonedDateTime.now(ZoneOffset.UTC)
+    val startOfReportingWindow: ZonedDateTime = now.minus(AthenaMetrics.reportingWindow)
+    val athenaOutputLocation = s"${envDependencies.athenaOutputLocation}/${now.toLocalDate.toString}/${now.getHour}"
+    val athenaDatabase = envDependencies.athenaDatabase
+
+    val fetchEventsQuery = Query(athenaDatabase,
+      s"""SELECT notificationid,
+         count(*) AS total,
+         count_if(platform = 'ios') AS ios,
+         count_if(platform = 'android') AS android
+FROM notification_received_${stage.toLowerCase()}
+WHERE partition_date = '${toQueryDate(startOfReportingWindow)}'
+         AND partition_hour >= ${startOfReportingWindow.getHour}
+GROUP BY  notificationid""".stripMargin, athenaOutputLocation)
+    Await.result(addS3PartitionsToAthenaIndex(now, startOfReportingWindow, athenaDatabase, athenaOutputLocation).flatMap(_ => routeFromQueryToUpdateDynamoDb(fetchEventsQuery, startOfReportingWindow)), duration.Duration(4, TimeUnit.MINUTES))
+  }
+
+}

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/LocalRun.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/LocalRun.scala
@@ -13,7 +13,6 @@ object LocalRun extends App {
     args(0) match {
       case "athena" => {
         new AthenaLambda().handleRequest()
-        AwsClient.dynamoDbClient.shutdown()
       }
       case "sqs" => {
         val is = new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8))

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/Router.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/Router.scala
@@ -2,6 +2,7 @@ package com.gu.notifications.events
 
 import java.util.concurrent.TimeUnit
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.gu.notifications.events.dynamo.DynamoReportUpdater
 import com.gu.notifications.events.model.{AggregationCounts, NotificationReportEvent, S3ResultCounts}
 import com.gu.notifications.events.s3.{S3Event, S3EventProcessor}
@@ -12,7 +13,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Try
 
-class Router(eventConsumer: S3EventProcessor, reportUpdater: DynamoReportUpdater)(implicit executionContext: ExecutionContext) {
+class Router(eventConsumer: S3EventProcessor, reportUpdater: DynamoReportUpdater)(implicit executionContext: ExecutionContext, dynamoDBAsync: AmazonDynamoDBAsync) {
   private val logger: Logger = LogManager.getLogger(classOf[Router])
 
   def sqsEventRoute(inputString: String): Unit = {

--- a/eventconsumer/src/main/scala/com/gu/notifications/events/SqsLambda.scala
+++ b/eventconsumer/src/main/scala/com/gu/notifications/events/SqsLambda.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.ForkJoinPool
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
 import com.amazonaws.util.IOUtils
+import com.gu.notifications.events.aws.AwsClient
 import com.gu.notifications.events.dynamo.DynamoReportUpdater
 import com.gu.notifications.events.s3.S3EventProcessorImpl
 import org.apache.logging.log4j.{LogManager, Logger}
@@ -29,6 +30,7 @@ class SqsLambda(stage: String) extends RequestStreamHandler {
   private val logger: Logger = LogManager.getLogger(classOf[SqsLambda])
   private val reportUpdater = new DynamoReportUpdater(stage)
   implicit private val executionContext: ExecutionContext = ExecutionContext.fromExecutor(new ForkJoinPool(5))
+  implicit private val dynamoDbClient = AwsClient.dynamoDbClient
   private val s3EventProcessor = new S3EventProcessorImpl
   private val router = new Router(s3EventProcessor, reportUpdater)
 


### PR DESCRIPTION
After the lamdba runs, it won't be invokved for half an hour.
So we might as well clean up the clients and free up the network connections, etc that the client would otherwise hold. 