### PR TITLE
Mss 610/update api client with api key header

### DIFF
--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/ApiClient.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/ApiClient.scala
@@ -45,6 +45,7 @@ protected trait SimpleHttpApiClient extends ApiClient {
   protected def postJson(destUrl: String, json: String) = {
     httpProvider.post(
       url = destUrl,
+      apiKey = apiKey,
       contentType = ContentType("application/json", "UTF-8"),
       body = json.getBytes("UTF-8")
     )

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/HttpProvider.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/HttpProvider.scala
@@ -13,7 +13,7 @@ case class HttpError(status: Int, body: String) extends HttpResponse
 case class ContentType(mediaType: String, charset: String)
 
 trait HttpProvider {
-  def post(url: String, contentType: ContentType, body: Array[Byte]): Future[HttpResponse]
+  def post(url: String, apiKey: String, contentType: ContentType, body: Array[Byte]): Future[HttpResponse]
 
   def get(url: String): Future[HttpResponse]
 }

--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/NextGenApiClient.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/NextGenApiClient.scala
@@ -20,7 +20,7 @@ protected class NextGenApiClient(
   val clientId: String = "nextGen"
 ) extends SimpleHttpApiClient {
 
-  private val url = s"$host/push/topic?api-key=$apiKey"
+  private val url = s"$host/push/topic"
 
   override def send(notificationPayload: NotificationPayload)(implicit ec: ExecutionContext): Future[Either[ApiClientError, Unit]] = {
 

--- a/api-client/src/test/scala/com/gu/mobile/notifications/client/ApiClientSpec.scala
+++ b/api-client/src/test/scala/com/gu/mobile/notifications/client/ApiClientSpec.scala
@@ -19,17 +19,18 @@ trait ApiClientSpec[C <: ApiClient] extends Specification with Mockito {
 
   def apiTest(serverResponse: HttpResponse)(test: C => Unit): Result = {
     val fakeHttpProvider = mock[HttpProvider]
-    fakeHttpProvider.post(anyString, any[ContentType], any[Array[Byte]]) returns Future.successful(serverResponse)
+    fakeHttpProvider.post(anyString, anyString, any[ContentType], any[Array[Byte]]) returns Future.successful(serverResponse)
 
     val testApiClient = getTestApiClient(fakeHttpProvider)
    
     test(testApiClient)
 
     val bodyCapture = new ArgumentCapture[Array[Byte]]
+    val apiKeyCapture = new ArgumentCapture[String]
     val urlCapture = new ArgumentCapture[String]
     val contentTypeCapture = new ArgumentCapture[ContentType]
 
-    there was one(fakeHttpProvider).post(urlCapture, contentTypeCapture, bodyCapture)
+    there was one(fakeHttpProvider).post(urlCapture, apiKeyCapture, contentTypeCapture, bodyCapture)
     urlCapture.value mustEqual expectedPostUrl
     contentTypeCapture.value mustEqual ContentType("application/json", "UTF-8")
     Json.parse(bodyCapture.value) mustEqual Json.parse(expectedPostBody)

--- a/api-client/src/test/scala/com/gu/mobile/notifications/client/NextGenApiClientSpec.scala
+++ b/api-client/src/test/scala/com/gu/mobile/notifications/client/NextGenApiClientSpec.scala
@@ -24,8 +24,9 @@ class NextGenApiClientSpec(implicit ee: ExecutionEnv) extends ApiClientSpec[Next
     topic = List(Topic(Breaking, "n1")),
     debug = true
   )
+  //  val expectedPostUrl = s"$host/push/topic?api-key=$apiKey"
 
-  val expectedPostUrl = s"$host/push/topic?api-key=$apiKey"
+  val expectedPostUrl = s"$host/push/topic"
   val expectedPostBody = Json.stringify(Json.toJson(payload))
 
   override def getTestApiClient(httpProvider: HttpProvider) = new NextGenApiClient(
@@ -59,6 +60,8 @@ class NextGenApiClientSpec(implicit ee: ExecutionEnv) extends ApiClientSpec[Next
       there was two(fakeHttpProvider).post(urlCapture, apiKeyCapture, contentTypeCapture, bodyCapture)
       urlCapture.value mustEqual expectedPostUrl
       contentTypeCapture.value mustEqual ContentType("application/json", "UTF-8")
+      apiKeyCapture.value mustEqual apiKey
+
       val ids = bodyCapture.values
         .asScala.toList
         .map(Json.parse)

--- a/api-client/src/test/scala/com/gu/mobile/notifications/client/NextGenApiClientSpec.scala
+++ b/api-client/src/test/scala/com/gu/mobile/notifications/client/NextGenApiClientSpec.scala
@@ -46,16 +46,17 @@ class NextGenApiClientSpec(implicit ee: ExecutionEnv) extends ApiClientSpec[Next
       val payLoadMultipleTopics = payload.copy(topic = List(Topic(Breaking, "n1"), Topic(Breaking, "n2")))
 
       val fakeHttpProvider = mock[HttpProvider]
-      fakeHttpProvider.post(anyString, any[ContentType], any[Array[Byte]]) returns Future.successful(HttpOk(201, """{"id":"someId"}"""))
+      fakeHttpProvider.post(anyString, anyString, any[ContentType], any[Array[Byte]]) returns Future.successful(HttpOk(201, """{"id":"someId"}"""))
 
       val testApiClient = getTestApiClient(fakeHttpProvider)
       testApiClient.send(payLoadMultipleTopics)
 
       val bodyCapture = new ArgumentCapture[Array[Byte]]
+      val apiKeyCapture = new ArgumentCapture[String]
       val urlCapture = new ArgumentCapture[String]
       val contentTypeCapture = new ArgumentCapture[ContentType]
 
-      there was two(fakeHttpProvider).post(urlCapture, contentTypeCapture, bodyCapture)
+      there was two(fakeHttpProvider).post(urlCapture, apiKeyCapture, contentTypeCapture, bodyCapture)
       urlCapture.value mustEqual expectedPostUrl
       contentTypeCapture.value mustEqual ContentType("application/json", "UTF-8")
       val ids = bodyCapture.values
@@ -80,7 +81,7 @@ class NextGenApiClientSpec(implicit ee: ExecutionEnv) extends ApiClientSpec[Next
     "return HttpProviderError if http provider throws exception" in {
       val throwable = new RuntimeException("something went wrong!!")
       val fakeHttpProvider = mock[HttpProvider]
-      fakeHttpProvider.post(anyString, any[ContentType], any[Array[Byte]]) returns Future.failed(throwable)
+      fakeHttpProvider.post(anyString, anyString, any[ContentType], any[Array[Byte]]) returns Future.failed(throwable)
       val client = getTestApiClient(fakeHttpProvider)
       client.send(payload) must beEqualTo(Left(HttpProviderError(throwable))).await
     }

--- a/api-client/src/test/scala/com/gu/mobile/notifications/client/NextGenApiClientSpec.scala
+++ b/api-client/src/test/scala/com/gu/mobile/notifications/client/NextGenApiClientSpec.scala
@@ -24,7 +24,6 @@ class NextGenApiClientSpec(implicit ee: ExecutionEnv) extends ApiClientSpec[Next
     topic = List(Topic(Breaking, "n1")),
     debug = true
   )
-  //  val expectedPostUrl = s"$host/push/topic?api-key=$apiKey"
 
   val expectedPostUrl = s"$host/push/topic"
   val expectedPostBody = Json.stringify(Json.toJson(payload))

--- a/api-client/version.sbt
+++ b/api-client/version.sbt
@@ -1,1 +1,1 @@
-version := "1.3-SNAPSHOT"
+version := "1.4"

--- a/api-client/version.sbt
+++ b/api-client/version.sbt
@@ -1,1 +1,1 @@
-version := "1.4"
+version := "1.3-SNAPSHOT"

--- a/build.sbt
+++ b/build.sbt
@@ -229,6 +229,7 @@ lazy val apiClient = {
   import ReleaseStateTransformations._
   Project("api-client", file("api-client")).settings(Seq(
     name := "mobile-notifications-client",
+    organization := "com.gu",
     scalaVersion := "2.11.12",
     crossScalaVersions := Seq("2.11.12", "2.12.6"),
     releaseCrossBuild := true,


### PR DESCRIPTION
Alters the notifications-api-client to take the api-key as a http header rather than url parameter: See https://theguardian.atlassian.net/browse/MSS-610