### PR TITLE
Mss 610/connfigure csrf filter to accept auth header

### DIFF
--- a/notification/conf/application.conf
+++ b/notification/conf/application.conf
@@ -1,6 +1,8 @@
 play.application.loader="notification.NotificationApplicationLoader"
 pidfile.path=/tmp/notification.pid
-
+play.filters.csrf.header.bypassHeaders {
+  Authorization = "*"
+}
 fcm-io {
   fork-join-executor {
     parallelism-max = 10


### PR DESCRIPTION
My bad for not testing this change: https://github.com/guardian/mobile-n10n/pull/320 locally

The CSRFfilter consumes any 'Authorization' header, so allow this allows it to be passed on