### PR TITLE
Revert "Mss 610/remove api key parameter parsing"

### DIFF
--- a/common/src/main/scala/authentication/AuthAction.scala
+++ b/common/src/main/scala/authentication/AuthAction.scala
@@ -28,8 +28,9 @@ abstract class AuthAction(controllerComponents: ControllerComponents) extends Ac
 
   private def getApiKey[A](request: Request[A]) =
     request.headers.get("Authorization")
-      .collect {
-        case BearerAuthHeaderRegexp(apiKey) => apiKey
-      }
+        .collect {
+          case BearerAuthHeaderRegexp(apiKey) => apiKey
+        }
+        .orElse(request.getQueryString("api-key"))
 }
 

--- a/notification/test/notification/NotificationsFixtures.scala
+++ b/notification/test/notification/NotificationsFixtures.scala
@@ -88,9 +88,9 @@ trait NotificationsFixtures {
 
   val apiKey = "test"
   val electionsApiKey = "elections-test"
-  val authenticatedRequest = FakeRequest(method = "POST", path = "").withHeaders("Authorization" -> s"Bearer $apiKey")
-  val electionsAuthenticatedRequest = FakeRequest(method = "POST", path = "").withHeaders( "Authorization" -> s"Bearer $electionsApiKey")
-  val invalidAuthenticatedRequest = FakeRequest(method = "POST", path = "").withHeaders( "Authorization" -> s"Bearer wrong-key")
+  val authenticatedRequest = FakeRequest(method = "POST", path = s"?api-key=$apiKey")
+  val electionsAuthenticatedRequest = FakeRequest(method = "POST", path = s"?api-key=$electionsApiKey")
+  val invalidAuthenticatedRequest = FakeRequest(method = "POST", path = s"?api-key=wrong-key")
   val validTopics = List(Topic(Breaking, "uk"), Topic(Breaking, "us"))
   val validElectionTopics = List(Topic(ElectionResults, "uk"), Topic(ElectionResults, "us"))
   val validNewsstandNotificationsTopic = List(Topic(TopicTypes.NewsstandShard, "newsstand-shard-1"))

--- a/report/test/report/controllers/RegistrationCountSpec.scala
+++ b/report/test/report/controllers/RegistrationCountSpec.scala
@@ -16,13 +16,13 @@ class RegistrationCountSpec extends PlaySpecification with Mockito {
   "RegistrationCount controller" should {
     "return a 400 if there's not topic passed as parameters" in new RegistrationCountScope {
       registrationService.countPerPlatformForTopics(any[NonEmptyList[db.Topic]]) returns IO.pure(PlatformCount(0,0,0,0))
-      val result = registrationCount.forTopics(Nil).apply(FakeRequest(GET, "/registration-count").withHeaders("Authorization" -> "Bearer test"))
+      val result = registrationCount.forTopics(Nil).apply(FakeRequest(GET, "/registration-count?api-key=test"))
       status(result) shouldEqual 400
       there was no(registrationService).countPerPlatformForTopics(any[NonEmptyList[db.Topic]])
     }
     "return 200 if there's a topic passed" in new RegistrationCountScope {
       registrationService.countPerPlatformForTopics(any[NonEmptyList[db.Topic]]) returns IO.pure(PlatformCount(1,1,0,0))
-      val request = FakeRequest(GET, "/registration-count?topic=breaking/uk").withHeaders("Authorization" -> "Bearer test")
+      val request = FakeRequest(GET, "/registration-count?api-key=test&topic=breaking/uk")
       val result = registrationCount.forTopics(List(Topic(TopicTypes.Breaking, "uk"))).apply(request)
       status(result) shouldEqual 200
       val json = contentAsJson(result)

--- a/report/test/report/controllers/ReportIntegrationSpec.scala
+++ b/report/test/report/controllers/ReportIntegrationSpec.scala
@@ -30,7 +30,7 @@ class ReportIntegrationSpec(implicit ee: ExecutionEnv) extends PlaySpecification
   "Report service" should {
 
     "Return last 7 days notification reports if no date supplied" in new ReportTestScope {
-      val result = route(app, FakeRequest(GET, s"/notifications?type=news").withHeaders("Authorization" -> s"Bearer $apiKey")).get
+      val result = route(app, FakeRequest(GET, s"/notifications?type=news&api-key=$apiKey")).get
 
       status(result) must equalTo(OK)
       contentType(result) must beSome("application/json")
@@ -41,7 +41,7 @@ class ReportIntegrationSpec(implicit ee: ExecutionEnv) extends PlaySpecification
     }
 
     "Return a list of notification reports filtered by date" in new ReportTestScope {
-      val result = route(app, FakeRequest(GET, s"/notifications?type=news&from=2015-01-01T00:00:00Z&until=2015-01-02T00:00:00Z").withHeaders("Authorization" -> s"Bearer $apiKey")).get
+      val result = route(app, FakeRequest(GET, s"/notifications?type=news&from=2015-01-01T00:00:00Z&until=2015-01-02T00:00:00Z&api-key=$apiKey")).get
 
       status(result) must equalTo(OK)
       contentType(result) must beSome("application/json")
@@ -50,7 +50,7 @@ class ReportIntegrationSpec(implicit ee: ExecutionEnv) extends PlaySpecification
 
 
     "Return content notification reports" in new ReportTestScope {
-      val result = route(app, FakeRequest(GET, s"/notifications?type=content").withHeaders("Authorization" -> s"Bearer $apiKey")).get
+      val result = route(app, FakeRequest(GET, s"/notifications?type=content&api-key=$apiKey")).get
 
       status(result) must equalTo(OK)
       contentType(result) must beSome("application/json")
@@ -61,7 +61,7 @@ class ReportIntegrationSpec(implicit ee: ExecutionEnv) extends PlaySpecification
 
     "Return an individual notification report complete with platform specific data" in new ReportTestScope {
       val id = reportsInRange.head.id
-      val result = route(app, FakeRequest(GET, s"/notifications/$id").withHeaders("Authorization" -> s"Bearer $apiKey")).get
+      val result = route(app, FakeRequest(GET, s"/notifications/$id?api-key=$apiKey")).get
 
       status(result) must equalTo(OK)
       contentType(result) must beSome("application/json")


### PR DESCRIPTION
Reverts guardian/mobile-n10n#330
(We need to fix daily edition and newsstand before we do this)