### PR TITLE
send apiKey as a header

### DIFF
--- a/schedulelambda/src/main/scala/com/gu/notificationschedule/notifications/RequestNotification.scala
+++ b/schedulelambda/src/main/scala/com/gu/notificationschedule/notifications/RequestNotification.scala
@@ -21,8 +21,9 @@ class RequestNotificationImpl(
                                cloudWatchMetrics: CloudWatchMetrics
                              ) extends RequestNotification {
   private val logger: Logger = LogManager.getLogger(classOf[RequestNotificationImpl])
-  private val url = new URIBuilder(config.pushTopicsUrl).addParameter("api-key", config.apiKey).build().toURL
+  private val url = new URIBuilder(config.pushTopicsUrl).build().toURL
   private val jsonMediaType = MediaType.parse("application/json; charset=utf-8")
+  private val authHeaderValue = s"Bearer ${config.apiKey}"
 
   def apply(nowEpoch: Long, notificationsScheduleEntry: NotificationsScheduleEntry): Try[Unit] = {
     cloudWatchMetrics.timeTry("notification-request", () =>
@@ -60,6 +61,7 @@ class RequestNotificationImpl(
   private def tryRequestNotification(notificationsScheduleEntry: NotificationsScheduleEntry): Try[Option[Response]] = Try {
     Option(okHttpClient.newCall(new Request.Builder()
       .url(url)
+      .header("Authorization", authHeaderValue)
       .post(RequestBody.create(
         jsonMediaType,
         notificationsScheduleEntry.notification

--- a/schedulelambda/src/test/scala/com/gu/notificationschedule/notifications/RequestNotificationImplSpec.scala
+++ b/schedulelambda/src/test/scala/com/gu/notificationschedule/notifications/RequestNotificationImplSpec.scala
@@ -39,7 +39,8 @@ class RequestNotificationImplSpec extends Specification with Mockito {
       okHttpClient.newCall(any[Request]()) answers {
         (_: Any) match {
           case (request: Request) => {
-            request.url() must beEqualTo(HttpUrl.parse("http://push.topic.invalid/?api-key=secretkey"))
+            request.url() must beEqualTo(HttpUrl.parse("http://push.topic.invalid"))
+            request.header("Authorization") must beEqualTo(s"Bearer secretkey")
             request.method().toLowerCase must beEqualTo("post")
             val buffer = new Buffer()
             request.body().writeTo(buffer)


### PR DESCRIPTION
Send the apiKey as a header from schedule tools