### PR TITLE
Run event consumer more often

### DIFF
--- a/eventconsumer/cfn.yaml
+++ b/eventconsumer/cfn.yaml
@@ -155,7 +155,7 @@ Resources:
   AthenaLambdaScheduleEventRule:
     Type: AWS::Events::Rule
     Properties:
-      ScheduleExpression: "cron(5,35 * * * ? *)"
+      ScheduleExpression: "cron(2/5 0 ? * * *)"
       Targets:
         - Id: AthenaLambdaScheduleEventRuleTarget
           Arn: !GetAtt AthenaLambda.Arn


### PR DESCRIPTION
Run every 5 minutes, starting at 2 minutes past the hour. (2, 7, 12, 17...).

2 minutes past the hour to leave fastly 2 minutes to ship the logs