### PR TITLE
MSS-735: Prepare for restricted newsstand api keys

### DIFF
--- a/common/src/main/scala/authentication/AuthAction.scala
+++ b/common/src/main/scala/authentication/AuthAction.scala
@@ -1,11 +1,11 @@
 package authentication
 
-import models.Topic
+import models.TopicType
 import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class RequestWithAuthentication[A](isPermittedTopic: Topic => Boolean, request: Request[A]) extends WrappedRequest[A](request)
+case class RequestWithAuthentication[A](isPermittedTopicType: TopicType => Boolean, request: Request[A]) extends WrappedRequest[A](request)
 
 abstract class AuthAction(controllerComponents: ControllerComponents) extends ActionBuilder[RequestWithAuthentication, AnyContent] with Results {
 
@@ -13,7 +13,7 @@ abstract class AuthAction(controllerComponents: ControllerComponents) extends Ac
 
   def validApiKey(key: String) : Boolean
 
-  def isPermittedTopic(apiKey: String) : Topic => Boolean
+  def isPermittedTopicType(apiKey: String) : TopicType => Boolean
 
   override def parser: BodyParser[AnyContent] = controllerComponents.parsers.defaultBodyParser
 
@@ -21,7 +21,7 @@ abstract class AuthAction(controllerComponents: ControllerComponents) extends Ac
 
   override def invokeBlock[A](request: Request[A], block: RequestWithAuthentication[A] => Future[Result]): Future[Result] = {
     getApiKey(request) match {
-      case Some(apiKey) if validApiKey(apiKey) => block(RequestWithAuthentication(isPermittedTopic(apiKey), request))
+      case Some(apiKey) if validApiKey(apiKey) => block(RequestWithAuthentication(isPermittedTopicType(apiKey), request))
       case _ => Future.successful(Unauthorized("A valid api key is required"))
     }
   }

--- a/notification/app/notification/authentication/NotificationAuthAction.scala
+++ b/notification/app/notification/authentication/NotificationAuthAction.scala
@@ -1,37 +1,28 @@
 package notification.authentication
 
 import authentication.AuthAction
-import models.Topic
+import models.TopicType
 import models.TopicTypes.Newsstand
 import notification.services.Configuration
 import play.api.Logger
 import play.api.mvc.ControllerComponents
 
-class NotificationAuthAction(configuration: Configuration,  controllerComponents: ControllerComponents) extends AuthAction(controllerComponents) {
+class NotificationAuthAction(configuration: Configuration, controllerComponents: ControllerComponents) extends AuthAction(controllerComponents) {
 
   override def validApiKey(apiKey: String): Boolean = configuration.apiKeys.contains(apiKey) || configuration.newsstandRestrictedApiKeys.contains(apiKey)
 
-  override def isPermittedTopic(apiKey: String): Topic => Boolean = {
-    if(configuration.newsstandRestrictedApiKeys.contains(apiKey)) {
-      topic => {
-        topic.`type` match {
-          case Newsstand => true
-          case other =>
-            Logger.warn(s"Received notification of type $other that isn't Newsstand, with the Newsstand api key")
-            true
-        }
-      }
+  override def isPermittedTopicType(apiKey: String): TopicType => Boolean = {
+    if (configuration.newsstandRestrictedApiKeys.contains(apiKey)) {
+      case Newsstand => true
+      case other =>
+        Logger.warn(s"Received notification of type $other that isn't Newsstand, with the Newsstand api key")
+        true
     } else {
-
-      topic => {
-        topic.`type` match {
-          case Newsstand => {
-            Logger.warn(s"Received a Newsstand notification with a non Newsstand api key")
-            true
-          }
-          case _ => true
-        }
+      case Newsstand => {
+        Logger.warn(s"Received a Newsstand notification with a non Newsstand api key")
+        true
       }
+      case _ => true
     }
   }
 }

--- a/notification/app/notification/authentication/NotificationAuthAction.scala
+++ b/notification/app/notification/authentication/NotificationAuthAction.scala
@@ -9,7 +9,7 @@ import play.api.mvc.ControllerComponents
 
 class NotificationAuthAction(configuration: Configuration,  controllerComponents: ControllerComponents) extends AuthAction(controllerComponents) {
 
-  override def validApiKey(apiKey: String): Boolean = configuration.apiKeys.contains(apiKey) || configuration.electionRestrictedApiKeys.contains(apiKey)
+  override def validApiKey(apiKey: String): Boolean = configuration.apiKeys.contains(apiKey) || configuration.newsstandRestrictedApiKeys.contains(apiKey)
 
   override def isPermittedTopic(apiKey: String): Topic => Boolean = {
     if(configuration.newsstandRestrictedApiKeys.contains(apiKey)) {

--- a/notification/app/notification/authentication/NotificationAuthAction.scala
+++ b/notification/app/notification/authentication/NotificationAuthAction.scala
@@ -2,12 +2,36 @@ package notification.authentication
 
 import authentication.AuthAction
 import models.Topic
+import models.TopicTypes.Newsstand
 import notification.services.Configuration
+import play.api.Logger
 import play.api.mvc.ControllerComponents
 
 class NotificationAuthAction(configuration: Configuration,  controllerComponents: ControllerComponents) extends AuthAction(controllerComponents) {
 
-  override def validApiKey(apiKey: String): Boolean = configuration.apiKeys.contains(apiKey)
+  override def validApiKey(apiKey: String): Boolean = configuration.apiKeys.contains(apiKey) || configuration.electionRestrictedApiKeys.contains(apiKey)
 
-  override def isPermittedTopic(apiKey: String): Topic => Boolean = _ => true
+  override def isPermittedTopic(apiKey: String): Topic => Boolean = {
+    if(configuration.newsstandRestrictedApiKeys.contains(apiKey)) {
+      topic => {
+        topic.`type` match {
+          case Newsstand => true
+          case other =>
+            Logger.warn(s"Received notification of type $other that isn't Newsstand, with the Newsstand api key")
+            true
+        }
+      }
+    } else {
+
+      topic => {
+        topic.`type` match {
+          case Newsstand => {
+            Logger.warn(s"Received a Newsstand notification with a non Newsstand api key")
+            true
+          }
+          case _ => true
+        }
+      }
+    }
+  }
 }

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -40,7 +40,7 @@ final class Main(
   }
 
   def pushNewsstand: Action[AnyContent] = authAction.async { request =>
-    if(request.isPermittedTopic(TopicTypes.Newsstand)){
+    if(request.isPermittedTopic(Topic(TopicTypes.Newsstand, "newsstand"))){
       val id = UUID.randomUUID()
       newsstandSender.sendNotification(id) map { _ =>
         logger.info("Newsstand notification sent")

--- a/notification/app/notification/services/Configuration.scala
+++ b/notification/app/notification/services/Configuration.scala
@@ -11,6 +11,7 @@ class Configuration(conf: PlayConfig) {
   lazy val frontendNewsAlertApiKey: String = conf.get[String]("notifications.frontendNewsAlert.apiKey")
   lazy val dynamoReportsTableName: String = conf.get[String]("db.dynamo.reports.table-name")
   lazy val dynamoScheduleTableName: String = conf.get[String]("db.dynamo.schedule.table-name")
+  lazy val newsstandRestrictedApiKeys: Set[String] = conf.get[Seq[String]]("notifications.api.newsstandRestrictedKeys").toSet
 
   lazy val newsstandShards: Int = conf.get[Int]("newsstand.shards")
 }

--- a/notification/test/notification/controllers/MainSpec.scala
+++ b/notification/test/notification/controllers/MainSpec.scala
@@ -168,6 +168,7 @@ class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito
     val conf: Configuration = {
       val m = mock[Configuration]
       m.apiKeys returns List(apiKey)
+      m.newsstandRestrictedApiKeys returns Set(apiKey)
       m
     }
 

--- a/report/app/report/authentication/ReportAuthAction.scala
+++ b/report/app/report/authentication/ReportAuthAction.scala
@@ -1,7 +1,7 @@
 package report.authentication
 
 import authentication.AuthAction
-import models.Topic
+import models.TopicType
 import play.api.mvc.ControllerComponents
 import report.services.Configuration
 
@@ -11,6 +11,6 @@ class ReportAuthAction(configuration: Configuration, controllerComponents: Contr
 
   override def validApiKey(apiKey: String): Boolean = allApiKeys.contains(apiKey)
 
-  override def isPermittedTopic(apiKey: String): Topic => Boolean =
+  override def isPermittedTopicType(apiKey: String): TopicType => Boolean =
     _ => false
 }


### PR DESCRIPTION
Need to add Newsstand keys in config before deployment.
After that, logs should indicate if there is a misconfiguration, corrected if necessary and then the next step of applying the restriction can be applied.