### PR TITLE
MSS-735: Segregate key responsibilities for Newsstand

### DIFF
--- a/notification/app/notification/services/Configuration.scala
+++ b/notification/app/notification/services/Configuration.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration._
 
 class Configuration(conf: PlayConfig) {
 
-  lazy val apiKeys: Seq[String] = conf.get[Seq[String]]("notifications.api.secretKeys")
+  lazy val apiKeys: Set[String] = conf.get[Seq[String]]("notifications.api.secretKeys").toSet
   lazy val frontendNewsAlertEndpoint: String = conf.get[String]("notifications.frontendNewsAlert.endpoint")
   lazy val frontendNewsAlertApiKey: String = conf.get[String]("notifications.frontendNewsAlert.apiKey")
   lazy val dynamoReportsTableName: String = conf.get[String]("db.dynamo.reports.table-name")

--- a/notification/test/notification/controllers/MainSpec.scala
+++ b/notification/test/notification/controllers/MainSpec.scala
@@ -167,7 +167,7 @@ class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito
     with NotificationsFixtures {
     val conf: Configuration = {
       val m = mock[Configuration]
-      m.apiKeys returns List(apiKey)
+      m.apiKeys returns Set(apiKey)
       m.newsstandRestrictedApiKeys returns Set(apiKey)
       m
     }


### PR DESCRIPTION
Newsstand keys only for Newsstand. Other keys, not for Newsstand