### PR TITLE
send one request for breaking news instead of four

### DIFF
--- a/api-client/src/main/scala/com/gu/mobile.notifications.client/NextGenApiClient.scala
+++ b/api-client/src/main/scala/com/gu/mobile.notifications.client/NextGenApiClient.scala
@@ -23,34 +23,13 @@ protected class NextGenApiClient(
   private val url = s"$host/push/topic"
 
   override def send(notificationPayload: NotificationPayload)(implicit ec: ExecutionContext): Future[Either[ApiClientError, Unit]] = {
-
-    def doSend(payload: NotificationPayload): Future[Either[ApiClientError, Unit]] = {
-      val json = Json.stringify(Json.toJson(payload))
-      postJson(url, json) map {
-        case error: HttpError => Left(ApiHttpError(error.status, Some(error.body)))
-        case HttpOk(201, body) => validateFormat[NextGenResponse](body)
-        case HttpOk(code, body) => Left(UnexpectedApiResponseError(s"Server returned status code $code and body:$body"))
-      } recover {
-        case e: Exception => Left(HttpProviderError(e))
-      }
-    }
-
-    def doSendOncePerTopic(payload: BreakingNewsPayload): Future[Either[ApiClientError, Unit]] = {
-      val results = payload.topic
-        .map(topic => payload.copy(topic = List(topic), id = UUID.randomUUID()))
-        .map(doSend)
-      Future.sequence(results).map { responses =>
-        responses.collect { case Left(error) => error } match {
-          case Nil => Right(())
-          case onlyOneError :: Nil => Left(onlyOneError)
-          case errors: List[ApiClientError] => Left(UnexpectedApiResponseError(errors.map(_.description).mkString(", ")))
-        }
-      }
-    }
-
-    notificationPayload match {
-      case breakingNews: BreakingNewsPayload if breakingNews.topic.size > 1 => doSendOncePerTopic(breakingNews)
-      case _ => doSend(notificationPayload)
+    val json = Json.stringify(Json.toJson(notificationPayload))
+    postJson(url, json) map {
+      case error: HttpError => Left(ApiHttpError(error.status, Some(error.body)))
+      case HttpOk(201, body) => validateFormat[NextGenResponse](body)
+      case HttpOk(code, body) => Left(UnexpectedApiResponseError(s"Server returned status code $code and body:$body"))
+    } recover {
+      case e: Exception => Left(HttpProviderError(e))
     }
   }
 


### PR DESCRIPTION
We want to ensure that breaking news alerts can be targeted to our largest arguments. This will done in the notification microservice, so we need to send the breaking news as one request here 