### PR TITLE
MSS-805: Allow harvester to support shards for all platforms

### DIFF
--- a/common/src/main/scala/db/RegistrationRepository.scala
+++ b/common/src/main/scala/db/RegistrationRepository.scala
@@ -1,10 +1,11 @@
 package db
 
 import cats.data.NonEmptyList
-import models.{PlatformCount, TopicCount}
+import models.{Platform, TopicCount}
 
 trait RegistrationRepository[F[_], S[_[_], _]] {
   def findTokens(topics: NonEmptyList[String], platform: Option[String], shardRange: Option[Range]): S[F, String]
+  def findTokens(topics: NonEmptyList[String], shardRange: Option[Range]): S[F, (String, Platform)]
   def findByToken(token: String): S[F, Registration]
   def save(sub: Registration): F[Int]
   def remove(sub: Registration): F[Int]

--- a/common/src/main/scala/db/RegistrationService.scala
+++ b/common/src/main/scala/db/RegistrationService.scala
@@ -5,7 +5,7 @@ import cats.effect.internals.IOContextShift
 import cats.effect.{Async, ContextShift, IO}
 import doobie.util.transactor.Transactor
 import fs2.Stream
-import models.{Platform, PlatformCount, ShardRange, TopicCount}
+import models.{ Platform, ShardRange, TopicCount }
 import play.api.Configuration
 import play.api.inject.ApplicationLifecycle
 
@@ -15,6 +15,8 @@ class RegistrationService[F[_], S[_[_], _]](repository: RegistrationRepository[F
   def findByToken(token: String): S[F, Registration] = repository.findByToken(token)
   def findTokens(topics: NonEmptyList[Topic], platform: Option[Platform], shardRange: Option[ShardRange]): S[F, String] =
     repository.findTokens(topics.map(_.name), platform.map(_.toString), shardRange.map(_.range))
+  def findTokens(topics: NonEmptyList[Topic], shardRange: Option[ShardRange]): S[F, (String, Platform)] =
+    repository.findTokens(topics.map(_.name), shardRange.map(_.range))
   def save(sub: Registration): F[Int] = repository.save(sub)
   def remove(sub: Registration): F[Int] = repository.remove(sub)
   def removeAllByToken(token: String): F[Int] = repository.removeByToken(token)

--- a/common/src/main/scala/db/SqlRegistrationRepository.scala
+++ b/common/src/main/scala/db/SqlRegistrationRepository.scala
@@ -12,10 +12,10 @@ import doobie.postgres.sqlstate
 import doobie.Fragments
 import models.{Platform, PlatformCount, TopicCount}
 import play.api.Logger
-import tracking.DynamoNotificationReportRepository
 
 class SqlRegistrationRepository[F[_]: Async](xa: Transactor[F])
   extends RegistrationRepository[F, Stream] {
+  val logger = Logger(classOf[SqlRegistrationRepository[F]])
   override def findTokens(
     topics: NonEmptyList[String],
     platform: Option[String],

--- a/common/src/main/scala/db/SqlRegistrationRepository.scala
+++ b/common/src/main/scala/db/SqlRegistrationRepository.scala
@@ -16,7 +16,6 @@ import tracking.DynamoNotificationReportRepository
 
 class SqlRegistrationRepository[F[_]: Async](xa: Transactor[F])
   extends RegistrationRepository[F, Stream] {
-  val logger = Logger(classOf[DynamoNotificationReportRepository])
   override def findTokens(
     topics: NonEmptyList[String],
     platform: Option[String],

--- a/common/src/main/scala/models/ShardedNotification.scala
+++ b/common/src/main/scala/models/ShardedNotification.scala
@@ -13,8 +13,7 @@ object ShardRange {
 case class ShardedNotification(
   notification: Notification,
   range: ShardRange,
-  platform: Platform
-)
+  platform: Option[Platform])
 
 object ShardedNotification {
   implicit val shardedNotificationJF: Format[ShardedNotification] = Json.format[ShardedNotification]

--- a/fakebreakingnewslambda/fakebreakingnewslambda-cfn.yaml
+++ b/fakebreakingnewslambda/fakebreakingnewslambda-cfn.yaml
@@ -22,9 +22,6 @@ Parameters:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
     Default: mobile-notifications-dist
-  AlarmTopic:
-    Type: String
-    Description: The ARN of the SNS topic to send all the cloudwatch alarms to
 
 Resources:
   ExecutionRole:
@@ -85,37 +82,3 @@ Resources:
           Value: !Ref Stack
         - Key: App
           Value: !Ref App
-
-  NotEnoughIosFakeBreakingNewsAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmActions: [!Ref AlarmTopic]
-      AlarmDescription: !Sub Triggers if not enough Ios dry run notifications are happening on ${Stage}
-      ComparisonOperator: LessThanThreshold
-      Dimensions:
-        - Name: platform
-          Value: ios
-      EvaluationPeriods: 1
-      MetricName: dryrun
-      Namespace: Notifications/${Stage}/workers
-      Period: 7200
-      Statistic: Sum
-      Threshold: 1
-      TreatMissingData: breaching
-
-  NotEnoughAndroidFakeBreakingNewsAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmActions: [!Ref AlarmTopic]
-      AlarmDescription: !Sub Triggers if not enough Android dry run notifications are happening on ${Stage}
-      ComparisonOperator: LessThanThreshold
-      Dimensions:
-        - Name: platform
-          Value: android
-      EvaluationPeriods: 1
-      MetricName: dryrun
-      Namespace: Notifications/${Stage}/workers
-      Period: 7200
-      Statistic: Sum
-      Threshold: 1
-      TreatMissingData: breaching

--- a/fakebreakingnewslambda/fakebreakingnewslambda-cfn.yaml
+++ b/fakebreakingnewslambda/fakebreakingnewslambda-cfn.yaml
@@ -22,6 +22,9 @@ Parameters:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
     Default: mobile-notifications-dist
+  AlarmTopic:
+    Type: String
+    Description: The ARN of the SNS topic to send all the cloudwatch alarms to
 
 Resources:
   ExecutionRole:
@@ -82,3 +85,37 @@ Resources:
           Value: !Ref Stack
         - Key: App
           Value: !Ref App
+
+  NotEnoughIosFakeBreakingNewsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: [!Ref AlarmTopic]
+      AlarmDescription: !Sub Triggers if not enough Ios dry run notifications are happening on ${Stage}
+      ComparisonOperator: LessThanThreshold
+      Dimensions:
+        - Name: platform
+          Value: ios
+      EvaluationPeriods: 1
+      MetricName: dryrun
+      Namespace: Notifications/${Stage}/workers
+      Period: 7200
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: breaching
+
+  NotEnoughAndroidFakeBreakingNewsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: [!Ref AlarmTopic]
+      AlarmDescription: !Sub Triggers if not enough Android dry run notifications are happening on ${Stage}
+      ComparisonOperator: LessThanThreshold
+      Dimensions:
+        - Name: platform
+          Value: android
+      EvaluationPeriods: 1
+      MetricName: dryrun
+      Namespace: Notifications/${Stage}/workers
+      Period: 7200
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: breaching

--- a/notification/app/notification/services/guardian/GuardianNotificationSender.scala
+++ b/notification/app/notification/services/guardian/GuardianNotificationSender.scala
@@ -117,7 +117,6 @@ class GuardianNotificationSender(
     }
 
     shard(countWithDefault).map { shard =>
-      ShardedNotification(notification, shard, Some(platform))
       val shardedNotification = ShardedNotification(notification, shard, Some(platform))
       val payloadJson = Json.stringify(Json.toJson(shardedNotification))
       val messageId = s"${notification.id}-$platform-${shard.start}-${shard.end}"

--- a/notification/app/notification/services/guardian/GuardianNotificationSender.scala
+++ b/notification/app/notification/services/guardian/GuardianNotificationSender.scala
@@ -117,8 +117,8 @@ class GuardianNotificationSender(
     }
 
     shard(countWithDefault).map { shard =>
-      ShardedNotification(notification, shard, platform)
-      val shardedNotification = ShardedNotification(notification, shard, platform)
+      ShardedNotification(notification, shard, Some(platform))
+      val shardedNotification = ShardedNotification(notification, shard, Some(platform))
       val payloadJson = Json.stringify(Json.toJson(shardedNotification))
       val messageId = s"${notification.id}-$platform-${shard.start}-${shard.end}"
       new SendMessageBatchRequestEntry(messageId, payloadJson)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -34,9 +34,14 @@ trait HarvesterRequestHandler extends Logging {
     throwables.broadcastTo(logErrors, cloudwatch.sendFailures(env.stage, platform))
   }
 
-  def firebaseSink(notification: Notification, range: ShardRange): Sink[IO, String] = {
+  def firebaseSinkBuilder(notification: Notification, range: ShardRange): Sink[IO, (String, Platform)] = {
     val androidSinkErrors = sinkErrors(Android)
-    tokens => tokens.chunkN(1000)
+    tokens =>
+      tokens
+        .collect {
+          case (token, Android) => token
+        }
+        .chunkN(1000)
         .map(chunk => ChunkedTokens(notification, chunk.toList, Android, range))
         .map(firebaseDeliveryService.sending)
         .parJoin(maxConcurrency)
@@ -46,11 +51,16 @@ trait HarvesterRequestHandler extends Logging {
         .to(androidSinkErrors)
   }
 
-  def apnsSink(notification: Notification, range: ShardRange, platform: Platform): Sink[IO, String] = {
+  def apnsSink(notification: Notification, range: ShardRange, platform: Platform): Sink[IO, (String, Platform)] = {
     val iosSinkErrors = sinkErrors(iOS)
-    tokens => tokens.chunkN(1000)
-      .map(chunk => ChunkedTokens(notification, chunk.toList, platform, range))
-      .map(apnsDeliveryService.sending)
+    tokens =>
+      tokens
+        .collect {
+          case (token, tokenPlatform) if tokenPlatform == platform => token
+        }
+        .chunkN(1000)
+        .map(chunk => ChunkedTokens(notification, chunk.toList, platform, range))
+        .map(apnsDeliveryService.sending)
         .parJoin(maxConcurrency)
         .collect {
           case Left(throwable) => throwable
@@ -62,17 +72,19 @@ trait HarvesterRequestHandler extends Logging {
   def queueShardedNotification(shardNotifications: Stream[IO, ShardedNotification]): Stream[IO, Unit] = {
     for {
       n <- shardNotifications
-      platform = n.platform
-      sink: Sink[IO, String] = platform match {
-        case Android => firebaseSink(n.notification, n.range)
-        case _root_.models.iOS => apnsSink(n.notification, n.range, platform)
-        case Newsstand => apnsSink(n.notification, n.range, platform)
-        case _ => throw new Exception("Unknown platform")
-      }
+      firebaseSink = firebaseSinkBuilder(n.notification, n.range)
+      newsstandSink = apnsSink(n.notification, n.range, Newsstand)
+      iosSink = apnsSink(n.notification, n.range, iOS)
       notificationLog = s"(notification: ${n.notification.id} ${n.range})"
       _ = logger.info(s"Queuing notification $notificationLog...")
-      tokens = tokenService.tokens(n.notification, n.range, platform)
-      resp <- tokens.to(sink)
+      tokens = {
+        n.platform
+          .map(p =>
+            tokenService.tokens(n.notification, n.range, p)
+              .map(token => (token, p)))
+          .getOrElse(tokenService.tokens(n.notification, n.range))
+      }
+      resp <- tokens.broadcastTo(firebaseSink, newsstandSink, iosSink)
     } yield resp
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -77,13 +77,10 @@ trait HarvesterRequestHandler extends Logging {
       iosSink = apnsSink(n.notification, n.range, iOS)
       notificationLog = s"(notification: ${n.notification.id} ${n.range})"
       _ = logger.info(s"Queuing notification $notificationLog...")
-      tokens = {
-        n.platform
-          .map(p =>
-            tokenService.tokens(n.notification, n.range, p)
-              .map(token => (token, p)))
-          .getOrElse(tokenService.tokens(n.notification, n.range))
-      }
+      tokens = n.platform match {
+          case Some(platform) => tokenService.tokens(n.notification, n.range, platform).map(token => (token, platform))
+          case None => tokenService.tokens(n.notification, n.range)
+        }
       resp <- tokens.broadcastTo(firebaseSink, newsstandSink, iosSink)
     } yield resp
   }

--- a/report/test/report/controllers/ReportIntegrationSpec.scala
+++ b/report/test/report/controllers/ReportIntegrationSpec.scala
@@ -159,6 +159,7 @@ class ReportIntegrationSpec(implicit ee: ExecutionEnv) extends PlaySpecification
         override lazy val registrationDbService: RegistrationService[IO, fs2.Stream] = new RegistrationService(
           new RegistrationRepository[IO, fs2.Stream] {
             override def findTokens(topics: NonEmptyList[String], platform: Option[String], shardRange: Option[Range]): fs2.Stream[IO, String] = ???
+            override def findTokens(topics: NonEmptyList[String], shardRange: Option[Range]): fs2.Stream[IO, (String, Platform)] = ???
             override def findByToken(token: String): fs2.Stream[IO, db.Registration] = ???
             override def save(sub: db.Registration): IO[Port] = ???
             override def remove(sub: db.Registration): IO[Port] = ???


### PR DESCRIPTION
Harvester will need to support both types of shard until notification migrates successfully to send for all platforms.