### PR TITLE
MSS-805: Stop sending notifications to harvester by platform

### DIFF
--- a/common/src/main/scala/models/ExtendedNotificationReport.scala
+++ b/common/src/main/scala/models/ExtendedNotificationReport.scala
@@ -24,7 +24,7 @@ object ExtendedSenderReport {
     senderName = s.senderName,
     sentTime = s.sentTime,
     sendersId = s.sendersId,
-    platformStatistics = s.platformStatistics
+    platformStatistics = None
   )
 }
 

--- a/common/src/test/scala/models/NotificationReportTest.scala
+++ b/common/src/test/scala/models/NotificationReportTest.scala
@@ -44,11 +44,7 @@ class NotificationReportTest extends Specification {
           |  "reports": [
           |    {
           |     "senderName": "Firebase",
-          |     "sentTime": "2015-01-01T00:00:00.000Z",
-          |     "platformStatistics": {
-          |       "platform": "android",
-          |       "recipientsCount": 3
-          |     }
+          |     "sentTime": "2015-01-01T00:00:00.000Z"
           |    }
           |
           | ],
@@ -71,7 +67,7 @@ class NotificationReportTest extends Specification {
             dryRun = None
           ),
           reports = List(
-            SenderReport("Firebase", sentTime, None, Some(PlatformStatistics(Android, recipientsCount = 3)))
+            SenderReport("Firebase", sentTime, None)
           ),
           Some(UUID.fromString("524dd8a4-b12d-427b-a3e9-ddbc9c2380d2"))
         )

--- a/common/src/test/scala/tracking/DynamoNotificationReportRepositorySpec.scala
+++ b/common/src/test/scala/tracking/DynamoNotificationReportRepositorySpec.scala
@@ -83,7 +83,7 @@ class DynamoNotificationReportRepositorySpec(implicit ev: ExecutionEnv) extends 
         dryRun = None,
       ),
       reports = List(
-        SenderReport("Firebase", DateTime.parse(sentTime).withZone(DateTimeZone.UTC), Some(s"hub-$id"), Some(PlatformStatistics(Android, 5)))
+        SenderReport("Firebase", DateTime.parse(sentTime).withZone(DateTimeZone.UTC), Some(s"hub-$id"))
       ),
       version = version,
       events = None

--- a/notification/app/notification/NotificationApplicationLoader.scala
+++ b/notification/app/notification/NotificationApplicationLoader.scala
@@ -91,24 +91,21 @@ class NotificationApplicationComponents(identity: AppIdentity, context: Context)
     .withRegion(EU_WEST_1)
     .build()
 
-  lazy val guardianIosNotificationSender: GuardianNotificationSender = new GuardianNotificationSender(
+  lazy val guardianNotificationSender: GuardianNotificationSender = new GuardianNotificationSender(
     sqsClient = sqsClient,
     registrationCounter = topicRegistrationCounter,
-    platform = iOS,
     harvesterSqsUrl = configuration.get[String]("notifications.queues.harvester")
   )
 
   lazy val guardianAndroidNotificationSender: GuardianNotificationSender = new GuardianNotificationSender(
     sqsClient = sqsClient,
     registrationCounter = topicRegistrationCounter,
-    platform = Android,
     harvesterSqsUrl = configuration.get[String]("notifications.queues.harvester")
   )
 
   lazy val guardianNewsstandNotificationSender: GuardianNotificationSender = new GuardianNotificationSender(
     sqsClient = sqsClient,
     registrationCounter = topicRegistrationCounter,
-    platform = Newsstand,
     harvesterSqsUrl = configuration.get[String]("notifications.queues.harvester")
   )
 
@@ -116,9 +113,7 @@ class NotificationApplicationComponents(identity: AppIdentity, context: Context)
     new FilteredNotificationSender(notificationSender, topicRegistrationCounter, invertCondition)
 
   lazy val notificationSenders = List(
-    guardianIosNotificationSender,
-    guardianAndroidNotificationSender,
-    guardianNewsstandNotificationSender,
+    guardianNotificationSender,
   )
 
   lazy val mainController = wire[Main]

--- a/notification/test/notification/NotificationsFixtures.scala
+++ b/notification/test/notification/NotificationsFixtures.scala
@@ -69,7 +69,7 @@ trait NotificationsFixtures {
     sendersId: Option[String] = None,
     sentTimeOffsetSeconds: Int = 0
   ): SenderReport =
-    SenderReport(senderName, DateTime.now.plusSeconds(sentTimeOffsetSeconds), sendersId, platformStats)
+    SenderReport(senderName, DateTime.now.plusSeconds(sentTimeOffsetSeconds), sendersId, None)
 
   def reportWithSenderReports(reports: List[SenderReport]): DynamoNotificationReport = DynamoNotificationReport.create(
     breakingNewsNotification(validTopics),

--- a/notification/test/notification/services/guardian/GuardianNotificationSenderSpec.scala
+++ b/notification/test/notification/services/guardian/GuardianNotificationSenderSpec.scala
@@ -58,7 +58,7 @@ class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specific
       result should beRight.which { senderReport =>
         senderReport.senderName shouldEqual "Guardian"
         senderReport.sendersId should beNone
-        senderReport.platformStatistics should beSome(PlatformStatistics(iOS, 1))
+        senderReport.platformStatistics should beNone
       }
     }
 
@@ -71,7 +71,7 @@ class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specific
       result should beRight.which { senderReport =>
         senderReport.senderName shouldEqual "Guardian"
         senderReport.sendersId should beNone
-        senderReport.platformStatistics should beSome(PlatformStatistics(iOS, 3000000))
+        senderReport.platformStatistics should beNone
       }
     }
 
@@ -82,7 +82,6 @@ class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specific
         registrationCounter = new TopicRegistrationCounter {
           override def count(topics: List[Topic])(implicit format: Format[TopicCount]): Future[PlatformCount] = Future.failed(new RuntimeException("exception"))
         },
-        platform = iOS,
         harvesterSqsUrl = ""
       )
 
@@ -108,7 +107,7 @@ class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specific
       there was one(sqsClient).sendMessageBatchAsync(any[SendMessageBatchRequest], any[AsyncHandler[SendMessageBatchRequest, SendMessageBatchResult]])
 
       result should beLeft(GuardianFailedToQueueShard(
-        senderName = s"Guardian ios",
+        senderName = s"Guardian",
         reason = s"Unable to queue notification. Please check the logs for notification 4c261110-4672-4451-a5b8-3422c6839c42"
       ): SenderError)
     }
@@ -133,7 +132,7 @@ class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specific
     )
 
     def topicStats(registrationCount: Int): PlatformCount = PlatformCount(
-      total = registrationCount * 2,
+      total = registrationCount,
       ios = registrationCount,
       android = registrationCount,
       newsstand = 0
@@ -158,7 +157,6 @@ class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specific
       registrationCounter = new TopicRegistrationCounter {
         override def count(topics: List[Topic])(implicit format: Format[TopicCount] ): Future[PlatformCount] = Future.successful(topicStats(registrationCount))
       },
-      platform = iOS,
       harvesterSqsUrl = ""
     )
   }


### PR DESCRIPTION
Harvester can handle multiple platforms.

Beware: it appears the platform statistics needs revisiting; do you want to keep this or fix this?

I wonder if there's a way for the sender stats to be aggregated if you do wish to keep this and enhance with the three stage of counts: available, sent, received