### PR TITLE
Add "Breaking news" and send the mapi URL directly

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -69,6 +69,7 @@ object Configuration {
         newsstandBundleId = config.getString("apns.newsstandBundleId"),
         keyId = config.getString("apns.keyId"),
         certificate = config.getString("apns.certificate"),
+        mapiBaseUrl = config.getString("mapi.baseUrl"),
         sendingToProdServer = config.getBoolean("apns.sendingToProdServer"),
         dryRun = config.getBoolean("dryrun")
       ),

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
@@ -10,7 +10,7 @@ import com.gu.notifications.worker.delivery._
 import com.gu.notifications.worker.delivery.DeliveryException.{FailedDelivery, FailedRequest, InvalidToken}
 import models.ApnsConfig
 import _root_.models.{Newsstand, Notification, Platform, iOS}
-import com.gu.notifications.worker.delivery.apns.models.payload.ApnsPayload
+import com.gu.notifications.worker.delivery.apns.models.payload.ApnsPayloadBuilder
 import com.turo.pushy.apns.auth.ApnsSigningKey
 import com.turo.pushy.apns.util.concurrent.{PushNotificationFuture, PushNotificationResponseListener}
 import com.turo.pushy.apns.util.{SimpleApnsPushNotification, TokenUtil}
@@ -27,6 +27,8 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
   val dryRun = config.dryRun
   val platform: Platform = iOS
 
+  private val apnsPayloadBuilder = new ApnsPayloadBuilder(config)
+
   private val invalidTokenErrorCodes = Seq(
     "BadDeviceToken",
     "Unregistered"
@@ -34,7 +36,7 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
 
   def close(): Unit = underlying.close().get
 
-  def payloadBuilder: Notification => Option[ApnsPayload] = ApnsPayload.apply _
+  def payloadBuilder: Notification => Option[ApnsPayload] = apnsPayloadBuilder.apply _
 
   def sendNotification(notificationId: UUID, token: String, payload: Payload, platform: Platform, dryRun: Boolean)
     (onComplete: Either[Throwable, Success] => Unit)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/ApnsConfig.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/ApnsConfig.scala
@@ -6,6 +6,7 @@ case class ApnsConfig(
   newsstandBundleId: String,
   keyId: String,
   certificate: String,
+  mapiBaseUrl: String,
   sendingToProdServer: Boolean = false,
   dryRun: Boolean = true
 )

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
@@ -4,16 +4,17 @@ import java.net.URI
 
 import _root_.models.NotificationType._
 import _root_.models._
+import com.gu.notifications.worker.delivery.apns.models.ApnsConfig
 import com.gu.notifications.worker.delivery.{ApnsPayload => Payload}
 import com.gu.notifications.worker.delivery.utils.TimeToLive._
 import com.gu.notifications.worker.delivery.apns.models.payload.CustomProperty.Keys
 import com.gu.notifications.worker.delivery.apns.models.payload.PlatformUriTypes.{External, Item}
-import com.turo.pushy.apns.util.ApnsPayloadBuilder
+import com.turo.pushy.apns.util.{ApnsPayloadBuilder => Builder}
 
 case class PayLoadAndTimeToLive(payLoad: String, timeToLive: Option[Long] = None)
 
 
-object ApnsPayload {
+class ApnsPayloadBuilder(config: ApnsConfig) {
 
   def apply(notification: Notification): Option[Payload] = {
     val payload: Option[PayLoadAndTimeToLive] = notification match {
@@ -36,7 +37,7 @@ object ApnsPayload {
     customProperties: Seq[CustomProperty] = Seq()
   ) {
     def payload: String = {
-      val payloadBuilder = new ApnsPayloadBuilder()
+      val payloadBuilder = new Builder()
       alertTitle.foreach(payloadBuilder.setAlertTitle)
       alertBody.foreach(payloadBuilder.setAlertBody)
       categoryName.foreach(payloadBuilder.setCategoryName)
@@ -156,7 +157,7 @@ object ApnsPayload {
   }
 
   private def toIosLink(link: Link) = link match {
-    case Link.Internal(contentApiId, Some(shortUrl), _) => new URI(s"x-gu://${new URI(shortUrl).getPath}")
+    case Link.Internal(contentApiId, _, _) => new URI(s"${config.mapiBaseUrl}/items/$contentApiId")
     case _ => link.webUri("http://www.theguardian.com/")
   }
 }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
@@ -62,7 +62,7 @@ class ApnsPayloadBuilder(config: ApnsConfig) {
     val link = toPlatformLink(n.link)
     val imageUrl = n.thumbnailUrl.orElse(n.imageUrl)
     val payload = PushyPayload(
-      alertTitle = None,
+      alertTitle = Some("Breaking News"),
       alertBody = Some(n.message),
       categoryName = Option(n.link match {
         case _: Link.External => ""

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -74,7 +74,8 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |   "t":"m",
         |   "aps":{
         |      "alert":{
-        |         "body":"French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"
+        |         "body":"French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State",
+        |         "title" : "Breaking News"
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
@@ -85,7 +86,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |   "topics":"breaking/uk,breaking/us,breaking/au,breaking/international",
         |   "uriType":"item",
         |   "imageUrl":"https://media.guim.co.uk/633850064fba4941cdac17e8f6f8de97dd736029/24_0_1800_1080/500.jpg",
-        |   "link":"x-gu:///p/4p7xt",
+        |   "link":"https://mobile.guardianapis.com/items/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
         |   "notificationType":"news",
         |   "uri":"https://www.theguardian.com/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
         |   "uniqueIdentifier":"068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"
@@ -113,7 +114,8 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |   "t":"m",
         |   "aps":{
         |      "alert":{
-        |         "body":"French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"
+        |         "body":"French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State",
+        |         "title" : "Breaking News"
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
@@ -124,7 +126,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |   "topics":"breaking/uk,breaking/us,breaking/au,breaking/international",
         |   "uriType":"item",
         |   "imageUrl":"https://media.guim.co.uk/633850064fba4941cdac17e8f6f8de97dd736029/24_0_1800_1080/500-image-url.jpg",
-        |   "link":"x-gu:///p/4p7xt",
+        |   "link":"https://mobile.guardianapis.com/items/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
         |   "notificationType":"news",
         |   "uri":"https://www.theguardian.com/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
         |   "uniqueIdentifier":"068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"
@@ -152,7 +154,8 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |   "t":"m",
         |   "aps":{
         |      "alert":{
-        |         "body":"French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"
+        |         "body":"French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State",
+        |         "title" : "Breaking News"
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
@@ -161,7 +164,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |   "provider":"Guardian",
         |   "topics":"breaking/uk,breaking/us,breaking/au,breaking/international",
         |   "uriType":"item",
-        |   "link":"x-gu:///p/4p7xt",
+        |   "link":"https://mobile.guardianapis.com/items/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
         |   "notificationType":"news",
         |   "uri":"https://www.theguardian.com/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
         |   "uniqueIdentifier":"068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"
@@ -198,7 +201,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |   "provider":"Guardian",
         |   "topics":"tag-series/series-a,tag-series/series-b",
         |   "uriType":"item",
-        |   "link":"x-gu:///p/4p7xt",
+        |   "link":"https://mobile.guardianapis.com/items/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
         |   "notificationType":"content",
         |   "uri":"https://www.theguardian.com/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
         |   "uniqueIdentifier":"068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -4,6 +4,7 @@ import java.net.URI
 import java.util.UUID
 
 import com.google.gson.JsonParser
+import com.gu.notifications.worker.delivery.apns.models.ApnsConfig
 import models.Importance.Major
 import models.Link.Internal
 import models.TopicTypes.{Breaking, TagSeries}
@@ -12,7 +13,7 @@ import org.specs2.matcher.Matchers
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 
-class ApnsPayloadSpec extends Specification with Matchers {
+class ApnsPayloadBuilderSpec extends Specification with Matchers {
 
   "ApnsPayload" should {
     "generate correct payload for Breaking News notification" in new BreakingNewsScope {
@@ -40,7 +41,17 @@ class ApnsPayloadSpec extends Specification with Matchers {
     def expected: Option[String]
 
     private def expectedTrimmedJson = expected.map(s => new JsonParser().parse(s).toString)
-    def checkPayload() = ApnsPayload(notification).map(_.jsonString) should beEqualTo(expectedTrimmedJson)
+    def checkPayload() = {
+      val dummyConfig = new ApnsConfig(
+        teamId = "",
+        bundleId = "",
+        newsstandBundleId = "",
+        keyId = "",
+        certificate = "",
+        mapiBaseUrl = "https://mobile.guardianapis.com"
+      )
+      new ApnsPayloadBuilder(dummyConfig).apply(notification).map(_.jsonString) should beEqualTo(expectedTrimmedJson)
+    }
   }
 
   trait BreakingNewsScope extends NotificationScope {


### PR DESCRIPTION
Add "Breaking News" in the title for iOS notifications, and directly send the URL instead of the minified one.

Tested on CODE.