### PR TITLE
Add collapse ID based on article ID or match ID

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryPayload.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryPayload.scala
@@ -3,5 +3,5 @@ package com.gu.notifications.worker.delivery
 import com.google.firebase.messaging.AndroidConfig
 
 sealed trait DeliveryPayload
-class ApnsPayload(val jsonString: String, val ttl: Option[Long] = None) extends DeliveryPayload
-class FcmPayload(val androidConfig: AndroidConfig) extends DeliveryPayload
+case class ApnsPayload(jsonString: String, ttl: Option[Long] = None, collapseId: Option[String]) extends DeliveryPayload
+case class FcmPayload(androidConfig: AndroidConfig) extends DeliveryPayload

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
@@ -47,16 +47,15 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
       case _ => config.bundleId
     }
 
-    val collapseId = notificationId.toString
     val pushNotification = new SimpleApnsPushNotification(
       TokenUtil.sanitizeTokenString(token),
       bundleId,
       payload.jsonString,
       //Default to no invalidation time but an hour for breaking news and 10 mins for football
       //See https://stackoverflow.com/questions/12317037/apns-notifications-ttl
-      payload.ttl.map(invalidationTime(_).toDate).getOrElse(null),
+      payload.ttl.map(invalidationTime(_).toDate).orNull,
       DeliveryPriority.IMMEDIATE,
-      collapseId
+      payload.collapseId.orNull
     )
 
     type Feedback = PushNotificationFuture[SimpleApnsPushNotification, PushNotificationResponse[SimpleApnsPushNotification]]

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -9,7 +9,7 @@ import com.google.auth.oauth2.GoogleCredentials
 import com.google.firebase.messaging.{FirebaseMessaging, FirebaseMessagingException, Message}
 import com.google.firebase.{FirebaseApp, FirebaseOptions}
 import com.gu.notifications.worker.delivery.DeliveryException.{FailedRequest, InvalidToken}
-import com.gu.notifications.worker.delivery.fcm.models.payload.FcmPayload
+import com.gu.notifications.worker.delivery.fcm.models.payload.FcmPayloadBuilder
 import com.gu.notifications.worker.delivery.{DeliveryClient, FcmDeliverySuccess, FcmPayload}
 import models.FcmConfig
 import _root_.models.{Android, Notification, Platform}
@@ -35,7 +35,7 @@ class FcmClient private (firebaseMessaging: FirebaseMessaging, firebaseApp: Fire
 
   def close(): Unit = firebaseApp.delete()
 
-  def payloadBuilder: Notification => Option[FcmPayload] = n => FcmPayload(n, config.debug)
+  def payloadBuilder: Notification => Option[FcmPayload] = n => FcmPayloadBuilder(n, config.debug)
 
   def sendNotification(notificationId: UUID, token: String, payload: Payload, platform: Platform, dryRun: Boolean)
     (onComplete: Either[Throwable, Success] => Unit)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/models/payload/FcmPayloadBuilder.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/models/payload/FcmPayloadBuilder.scala
@@ -11,7 +11,7 @@ import com.gu.notifications.worker.delivery.fcm.models.payload.Editions.Edition
 import com.gu.notifications.worker.delivery.utils.TimeToLive._
 import models._
 
-object FcmPayload {
+object FcmPayloadBuilder {
 
   def apply(notification: Notification, debug: Boolean): Option[FcmPayload] =
     FirebaseAndroidNotification(notification, debug).map(n => new FcmPayload(n.androidConfig))

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/fcm/models/payload/FcmPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/fcm/models/payload/FcmPayloadBuilderSpec.scala
@@ -3,7 +3,7 @@ package com.gu.notifications.worker.delivery.fcm.models.payload
 import java.net.URI
 import java.util.UUID
 
-import com.gu.notifications.worker.delivery.fcm.models.payload.FcmPayload.FirebaseAndroidNotification
+import com.gu.notifications.worker.delivery.fcm.models.payload.FcmPayloadBuilder.FirebaseAndroidNotification
 import models.Importance.Major
 import models.Link.Internal
 import models.TopicTypes.Breaking
@@ -13,7 +13,7 @@ import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import com.gu.notifications.worker.delivery.utils.TimeToLive
 
-class FcmPayloadSpec extends Specification with Matchers {
+class FcmPayloadBuilderSpec extends Specification with Matchers {
 
   "FcmPayload" should {
     "generate correct data for Breaking News notification" in new BreakingNewsScope {


### PR DESCRIPTION
This theoretically allows Editorial to re-send a notification that would fix a typo or a headline