### PR TITLE
Hash the article ID in a UUID.

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
@@ -1,6 +1,7 @@
 package com.gu.notifications.worker.delivery.apns.models.payload
 
 import java.net.URI
+import java.util.UUID
 
 import _root_.models.NotificationType._
 import _root_.models._
@@ -156,7 +157,7 @@ class ApnsPayloadBuilder(config: ApnsConfig) {
   }
 
   private def toCollapseId(link: Link): Option[String] = link match {
-    case Link.Internal(contentApiId, _, _) => Some(contentApiId)
+    case Link.Internal(contentApiId, _, _) => Some(UUID.nameUUIDFromBytes(contentApiId.getBytes).toString)
     case _ => None
   }
 }


### PR DESCRIPTION
It turns out the collapse ID is limited to 64 characters, so articles ID can be bigger.