### PR TITLE
Mutable content is always true to trigger the right background process

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
@@ -64,7 +64,7 @@ class ApnsPayloadBuilder(config: ApnsConfig) {
         case _: Link.Internal => "ITEM_CATEGORY"
       }),
       contentAvailable = true,
-      mutableContent = imageUrl.isDefined,
+      mutableContent = true,
       sound = Some("default"),
       customProperties = Seq(
         CustomProperty(Keys.UniqueIdentifier -> n.id.toString),
@@ -87,7 +87,7 @@ class ApnsPayloadBuilder(config: ApnsConfig) {
       alertBody = Some(n.title),
       categoryName = Some("ITEM_CATEGORY"),
       contentAvailable = true,
-      mutableContent = false,
+      mutableContent = true,
       sound = Some("default"),
       customProperties = Seq(
         CustomProperty(Keys.UniqueIdentifier -> n.id.toString),

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -156,7 +156,8 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
-        |      "content-available":1
+        |      "content-available":1,
+        |      "mutable-content":1
         |   },
         |   "provider":"Guardian",
         |   "topics":"breaking/uk,breaking/us,breaking/au,breaking/international",
@@ -193,7 +194,8 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
-        |      "content-available":1
+        |      "content-available":1,
+        |      "mutable-content":1
         |   },
         |   "provider":"Guardian",
         |   "topics":"tag-series/series-a,tag-series/series-b",


### PR DESCRIPTION
This is in preparation of the new ios version of the app.

It won't rely on having `content-available: 1` anymore, but will rely on `mutable-content: 1` as a more reliable way to trigger the pre-caching and tracking of push notifications. 🤞 