### PR TITLE
Remove the content-available flag

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
@@ -63,7 +63,7 @@ class ApnsPayloadBuilder(config: ApnsConfig) {
         case _: Link.External => ""
         case _: Link.Internal => "ITEM_CATEGORY"
       }),
-      contentAvailable = true,
+      contentAvailable = false,
       mutableContent = true,
       sound = Some("default"),
       customProperties = Seq(
@@ -86,7 +86,7 @@ class ApnsPayloadBuilder(config: ApnsConfig) {
       alertTitle = None,
       alertBody = Some(n.title),
       categoryName = Some("ITEM_CATEGORY"),
-      contentAvailable = true,
+      contentAvailable = false,
       mutableContent = true,
       sound = Some("default"),
       customProperties = Seq(

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -77,7 +77,6 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
-        |      "content-available":1,
         |      "mutable-content":1
         |   },
         |   "provider":"Guardian",
@@ -116,7 +115,6 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
-        |      "content-available":1,
         |      "mutable-content":1
         |   },
         |   "provider":"Guardian",
@@ -155,7 +153,6 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
-        |      "content-available":1,
         |      "mutable-content":1
         |   },
         |   "provider":"Guardian",
@@ -193,7 +190,6 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
-        |      "content-available":1,
         |      "mutable-content":1
         |   },
         |   "provider":"Guardian",


### PR DESCRIPTION
From breaking news and content notifications. This should hopefully increase our delivery rate.

we need to wait long enough for the right version of the iOS app to be deployed in the wild.

@ddramowicz : with what version is this going live?