### PR TITLE
One sink per platform

### DIFF
--- a/common/src/main/scala/models/ShardedNotification.scala
+++ b/common/src/main/scala/models/ShardedNotification.scala
@@ -13,7 +13,7 @@ object ShardRange {
 case class ShardedNotification(
   notification: Notification,
   range: ShardRange,
-  platform: Option[Platform])
+)
 
 object ShardedNotification {
   implicit val shardedNotificationJF: Format[ShardedNotification] = Json.format[ShardedNotification]

--- a/notification/app/notification/services/guardian/GuardianNotificationSender.scala
+++ b/notification/app/notification/services/guardian/GuardianNotificationSender.scala
@@ -113,7 +113,7 @@ class GuardianNotificationSender(
     }
 
     shard(countWithDefault).map { shard =>
-      val shardedNotification = ShardedNotification(notification, shard, platform = None)
+      val shardedNotification = ShardedNotification(notification, shard)
       val payloadJson = Json.stringify(Json.toJson(shardedNotification))
       val messageId = s"${notification.id}-${shard.start}-${shard.end}"
       new SendMessageBatchRequestEntry(messageId, payloadJson)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -37,7 +37,7 @@ trait HarvesterRequestHandler extends Logging {
   }
 
   def platformSink(shardedNotification: ShardedNotification, platform: Platform, deliveryService: SqsDeliveryService[IO]): Sink[IO, (String, Platform)] = {
-    val iosSinkErrors = sinkErrors(Ios)
+    val iosSinkErrors = sinkErrors(platform)
     tokens =>
       tokens
         .collect {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -77,10 +77,7 @@ trait HarvesterRequestHandler extends Logging {
       iosSink = apnsSink(n.notification, n.range, Ios)
       notificationLog = s"(notification: ${n.notification.id} ${n.range})"
       _ = logger.info(s"Queuing notification $notificationLog...")
-      tokens = n.platform match {
-          case Some(platform) => tokenService.tokens(n.notification, n.range, platform).map(token => (token, platform))
-          case None => tokenService.tokens(n.notification, n.range)
-        }
+      tokens = tokenService.tokens(n.notification, n.range)
       resp <- tokens.broadcastTo(firebaseSink, newsstandSink, iosSink)
     } yield resp
   }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -1,6 +1,6 @@
 package com.gu.notifications.worker
 
-import _root_.models.{Android, Newsstand, Notification, Platform, ShardRange, ShardedNotification, Ios}
+import _root_.models.{Android, Ios, Newsstand, AndroidEdition, IosEdition, Platform, ShardedNotification}
 import cats.effect.{ContextShift, IO, Timer}
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
@@ -26,6 +26,8 @@ trait HarvesterRequestHandler extends Logging {
   val tokenService: TokenService[IO]
   val cloudwatch: Cloudwatch
   val maxConcurrency: Int = 100
+  val supportedPlatforms = List(Ios, Android, IosEdition, AndroidEdition)
+
   val logErrors: Sink[IO, Throwable] = throwables => {
     throwables.map(throwable => logger.warn("Error queueing", throwable))
   }
@@ -34,24 +36,7 @@ trait HarvesterRequestHandler extends Logging {
     throwables.broadcastTo(logErrors, cloudwatch.sendFailures(env.stage, platform))
   }
 
-  def firebaseSinkBuilder(notification: Notification, range: ShardRange): Sink[IO, (String, Platform)] = {
-    val androidSinkErrors = sinkErrors(Android)
-    tokens =>
-      tokens
-        .collect {
-          case (token, Android) => token
-        }
-        .chunkN(1000)
-        .map(chunk => ChunkedTokens(notification, chunk.toList, Android, range))
-        .map(firebaseDeliveryService.sending)
-        .parJoin(maxConcurrency)
-        .collect {
-          case Left(throwable) => throwable
-        }
-        .to(androidSinkErrors)
-  }
-
-  def apnsSink(notification: Notification, range: ShardRange, platform: Platform): Sink[IO, (String, Platform)] = {
+  def platformSink(shardedNotification: ShardedNotification, platform: Platform, deliveryService: SqsDeliveryService[IO]): Sink[IO, (String, Platform)] = {
     val iosSinkErrors = sinkErrors(Ios)
     tokens =>
       tokens
@@ -59,8 +44,8 @@ trait HarvesterRequestHandler extends Logging {
           case (token, tokenPlatform) if tokenPlatform == platform => token
         }
         .chunkN(1000)
-        .map(chunk => ChunkedTokens(notification, chunk.toList, platform, range))
-        .map(apnsDeliveryService.sending)
+        .map(chunk => ChunkedTokens(shardedNotification.notification, chunk.toList, platform, shardedNotification.range))
+        .map(deliveryService.sending)
         .parJoin(maxConcurrency)
         .collect {
           case Left(throwable) => throwable
@@ -69,16 +54,18 @@ trait HarvesterRequestHandler extends Logging {
 
   }
 
-  def queueShardedNotification(shardNotifications: Stream[IO, ShardedNotification]): Stream[IO, Unit] = {
+  def queueShardedNotification(shardedNotifications: Stream[IO, ShardedNotification]): Stream[IO, Unit] = {
     for {
-      n <- shardNotifications
-      firebaseSink = firebaseSinkBuilder(n.notification, n.range)
-      newsstandSink = apnsSink(n.notification, n.range, Newsstand)
-      iosSink = apnsSink(n.notification, n.range, Ios)
-      notificationLog = s"(notification: ${n.notification.id} ${n.range})"
+      shardedNotification <- shardedNotifications
+      androidSink = platformSink(shardedNotification, Android, firebaseDeliveryService)
+      iosSink = platformSink(shardedNotification, Ios, apnsDeliveryService)
+      newsstandSink = platformSink(shardedNotification, Newsstand, apnsDeliveryService)
+      androidEditionSink = platformSink(shardedNotification, AndroidEdition, firebaseDeliveryService)
+      iosEditionSink = platformSink(shardedNotification, IosEdition, apnsDeliveryService)
+      notificationLog = s"(notification: ${shardedNotification.notification.id} ${shardedNotification.range})"
       _ = logger.info(s"Queuing notification $notificationLog...")
-      tokens = tokenService.tokens(n.notification, n.range)
-      resp <- tokens.broadcastTo(firebaseSink, newsstandSink, iosSink)
+      tokens = tokenService.tokens(shardedNotification.notification, shardedNotification.range)
+      resp <- tokens.broadcastTo(androidSink, iosSink, newsstandSink, androidEditionSink, iosEditionSink)
     } yield resp
   }
 

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -24,24 +24,8 @@ import scala.collection.JavaConverters._
 class HarvesterRequestHandlerSpec extends Specification with Matchers {
 
   "the WorkerRequestHandler" should {
-    "Send one Android breaking news notification" in new WRHSScope {
-      workerRequestHandler.handleHarvesting(sqsEventShardNotification(breakingNewsNotification, Some(Android)), null)
-      tokenStreamCount.get() shouldEqual 1
-      firebaseSqsDeliveriesCount.get() shouldEqual 3
-      apnsSqsDeliveriesCount.get() shouldEqual 0
-      firebaseSqsDeliveriesTotal.get() shouldEqual 2002
-      apnsSqsDeliveriesTotal.get() shouldEqual 0
-    }
-    "Queue one Android content notification" in new WRHSScope {
-      workerRequestHandler.handleHarvesting(sqsEventShardNotification(contentNotification, Some(Android)), null)
-      tokenStreamCount.get() shouldEqual 1
-      firebaseSqsDeliveriesCount.get() shouldEqual 3
-      apnsSqsDeliveriesCount.get() shouldEqual 0
-      firebaseSqsDeliveriesTotal.get() shouldEqual 2002
-      apnsSqsDeliveriesTotal.get() shouldEqual 0
-    }
     "Queue one multi platform breaking news notification" in new WRHSScope {
-      workerRequestHandler.handleHarvesting(sqsEventShardNotification(breakingNewsNotification, None), null)
+      workerRequestHandler.handleHarvesting(sqsEventShardNotification(breakingNewsNotification), null)
       tokenStreamCount.get() shouldEqual 0
       tokenPlatformStreamCount.get() shouldEqual 1
       firebaseSqsDeliveriesCount.get() shouldEqual 3
@@ -49,23 +33,6 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
       firebaseSqsDeliveriesTotal.get() shouldEqual 2002
       apnsSqsDeliveriesTotal.get() shouldEqual 2002
     }
-    "Send one iOS breaking news notification" in new WRHSScope {
-      workerRequestHandler.handleHarvesting(sqsEventShardNotification(breakingNewsNotification, Some(Ios)), null)
-      tokenStreamCount.get() shouldEqual 1
-      firebaseSqsDeliveriesCount.get() shouldEqual 0
-      apnsSqsDeliveriesCount.get() shouldEqual 3
-      firebaseSqsDeliveriesTotal.get() shouldEqual 0
-      apnsSqsDeliveriesTotal.get() shouldEqual 2002
-    }
-    "Queue one iOS content notification" in new WRHSScope {
-      workerRequestHandler.handleHarvesting(sqsEventShardNotification(contentNotification, Some(Ios)), null)
-      tokenStreamCount.get() shouldEqual 1
-      firebaseSqsDeliveriesCount.get() shouldEqual 0
-      apnsSqsDeliveriesCount.get() shouldEqual 3
-      firebaseSqsDeliveriesTotal.get() shouldEqual 0
-      apnsSqsDeliveriesTotal.get() shouldEqual 2002
-    }
-
   }
 
 
@@ -98,11 +65,11 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
       dryRun = None
     )
 
-    def sqsEventShardNotification(notification: Notification, platform: Option[Platform]): SQSEvent = {
+    def sqsEventShardNotification(notification: Notification): SQSEvent = {
       val shardedNotification = ShardedNotification(
         notification = notification,
-        range = ShardRange(0, 1),
-        platform = platform)
+        range = ShardRange(0, 1)
+      )
       val event = new SQSEvent()
       val sqsMessage = new SQSMessage()
       sqsMessage.setBody(Json.stringify(Json.toJson(shardedNotification)))


### PR DESCRIPTION
This
 - remove "platform" from the model passed between the notification service and the harvester. The platform is now fetched from the database for each token
 - create a sink for each platform

We currently have only two workers:
 - ios (live and daily edition)
 - android (live only)

I'm mapping the platforms like that for now:

android => android
android-edition => android
newsstand => ios
ios => ios
ios-edition => ios

We don't have any android-edition or ios-edition in the wild yet so it doesn't matter much, but the next step is deploying specialised workers for each platform.