### PR TITLE
Instantiate two new lambdas with the same code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -318,6 +318,8 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
     riffRaffArtifactResources += (baseDirectory.value / "harvester-cfn.yaml", s"harvester-cfn/harvester-cfn.yaml"),
     riffRaffArtifactResources += (baseDirectory.value / "sender-worker-cfn.yaml", s"ios-notification-worker-cfn/sender-worker-cfn.yaml"),
     riffRaffArtifactResources += (baseDirectory.value / "sender-worker-cfn.yaml", s"android-notification-worker-cfn/sender-worker-cfn.yaml"),
+    riffRaffArtifactResources += (baseDirectory.value / "sender-worker-cfn.yaml", s"ios-edition-notification-worker-cfn/sender-worker-cfn.yaml"),
+    riffRaffArtifactResources += (baseDirectory.value / "sender-worker-cfn.yaml", s"android-edition-notification-worker-cfn/sender-worker-cfn.yaml"),
     riffRaffArtifactResources += (baseDirectory.value / "registration-cleaning-worker-cfn.yaml", s"registration-cleaning-worker-cfn/registration-cleaning-worker-cfn.yaml"),
     riffRaffArtifactResources += (baseDirectory.value / "topic-counter-cfn.yaml", s"topic-counter-cfn/topic-counter-cfn.yaml")
   )

--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -31,12 +31,9 @@ Parameters:
   VPCSecurityGroup:
     Type: AWS::EC2::SecurityGroup::Id
     Description: The default security group of the VPC
-  IosSqsArn:
-    Type: String
-    Description: IOS Sqs queue
-  AndroidSqsArn:
-    Type: String
-    Description: Android Sqs queue
+  WorkerSqsArns:
+    Type: List<String>
+    Description: The ARNs of all the worker's queues
   AlarmTopic:
     Type: String
     Description: The ARN of the SNS topic to send all the cloudwatch alarms to
@@ -103,9 +100,13 @@ Resources:
             Effect: Allow
             Action: sqs:*
             Resource:
-            - !GetAtt Sqs.Arn
-            - !Ref IosSqsArn
-            - !Ref AndroidSqsArn
+              - !GetAtt Sqs.Arn
+      - PolicyName: SQSOutput
+        PolicyDocument:
+          Statement:
+            Effect: Allow
+            Action: sqs:*
+            Resource: !Ref WorkerSqsArns
       - PolicyName: VPC
         PolicyDocument:
           Statement:

--- a/notificationworkerlambda/riff-raff.yaml
+++ b/notificationworkerlambda/riff-raff.yaml
@@ -7,10 +7,24 @@ deployments:
     app: notificationworkerlambda
     parameters:
       bucket: mobile-notifications-dist
-      functionNames: [ios-notification-worker-sender-, android-notification-worker-sender-, registration-cleaning-worker-, topic-counter-, mobile-notifications-harvester-]
+      functionNames:
+        - ios-notification-worker-sender-
+        - android-notification-worker-sender-
+        - ios-edition-notification-worker-sender-
+        - android-edition-notification-worker-sender-
+        - registration-cleaning-worker-
+        - topic-counter-
+        - mobile-notifications-harvester-
       fileName: notificationworkerlambda.jar
       prefixStack: false
-    dependencies: [ios-notification-worker-cfn, android-notification-worker-cfn, registration-cleaning-worker-cfn, topic-counter-cfn, harvester-cfn]
+    dependencies:
+      - ios-notification-worker-cfn
+      - android-notification-worker-cfn
+      - ios-edition-notification-worker-cfn
+      - android-edition-notification-worker-cfn
+      - registration-cleaning-worker-cfn
+      - topic-counter-cfn
+      - harvester-cfn
   harvester-cfn:
     type: cloud-formation
     app: harvester
@@ -29,6 +43,20 @@ deployments:
     parameters:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: android-notification-worker-cfn
+      templatePath: sender-worker-cfn.yaml
+  ios-edition-notification-worker-cfn:
+    type: cloud-formation
+    app: ios-edition-notification-worker
+    parameters:
+      prependStackToCloudFormationStackName: false
+      cloudFormationStackName: ios-edition-notification-worker-cfn
+      templatePath: sender-worker-cfn.yaml
+  android-edition-notification-worker-cfn:
+    type: cloud-formation
+    app: android-edition-notification-worker
+    parameters:
+      prependStackToCloudFormationStackName: false
+      cloudFormationStackName: android-edition-notification-worker-cfn
       templatePath: sender-worker-cfn.yaml
   registration-cleaning-worker-cfn:
     type: cloud-formation

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -28,6 +28,14 @@ Parameters:
   AlarmTopic:
     Type: String
     Description: The ARN of the SNS topic to send all the cloudwatch alarms to
+  Platform:
+    Type: String
+    Description: The platform handled by this worker
+    AllowedValues:
+      - android
+      - ios
+      - android-edition
+      - ios-edition
 
 Conditions:
   IsProdStage: !Equals [!Ref Stage, PROD]
@@ -127,6 +135,7 @@ Resources:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
+          Platform: !Ref Platform
       Description: Sends notifications
       Handler: !Ref SenderFullyQualifiedHandler
       MemorySize: 3008

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -1,13 +1,11 @@
 package com.gu.notifications.worker
 
-import _root_.models.Android
 import cats.effect.IO
 import com.gu.notifications.worker.cleaning.CleaningClientImpl
 import com.gu.notifications.worker.delivery.fcm.{Fcm, FcmClient}
 import com.gu.notifications.worker.utils.{Cloudwatch, CloudwatchImpl}
 
 class AndroidSender extends SenderRequestHandler[FcmClient] {
-  val platform = Android
   val config: FcmWorkerConfiguration = Configuration.fetchFirebase()
   val cleaningClient = new CleaningClientImpl(config.sqsUrl)
   val cloudwatch: Cloudwatch = new CloudwatchImpl

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -22,8 +22,10 @@ case class ApnsWorkerConfiguration(
 
 case class HarvesterConfiguration(
   jdbcConfig: JdbcConfig,
-  apnsSqsUrl: String,
-  firebaseSqsUrl: String
+  iosLiveSqsUrl: String,
+  iosEditionSqsUrl: String,
+  androidLiveSqsUrl: String,
+  androidEditionSqsUrl: String
 )
 
 case class FcmWorkerConfiguration(
@@ -81,9 +83,11 @@ object Configuration {
   def fetchHarvester(): HarvesterConfiguration = {
     val config = fetchConfiguration()
     HarvesterConfiguration(
-      jdbcConfig(config),
-      config.getString("delivery.apnsSqsUrl"),
-      config.getString("delivery.firebaseSqsUrl")
+      jdbcConfig = jdbcConfig(config),
+      iosLiveSqsUrl = config.getString("delivery.apnsSqsUrl"),
+      iosEditionSqsUrl = config.getString("delivery.iosEditionSqsUrl"),
+      androidLiveSqsUrl = config.getString("delivery.firebaseSqsUrl"),
+      androidEditionSqsUrl = config.getString("delivery.androidEditionSqsUrl")
     )
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -51,9 +51,7 @@ object Configuration {
     }
   }
 
-  private def platform: Platform = Option(System.getenv("Platform"))
-    .flatMap(Platform.fromString)
-    .get // exception if this isn't set correctly, the lambda shouldn't run
+  def platform: Option[Platform] = Option(System.getenv("Platform")).flatMap(Platform.fromString)
 
   private def jdbcConfig(config: Config) = JdbcConfig(
     driverClassName = "org.postgresql.Driver",
@@ -70,7 +68,7 @@ object Configuration {
       config.getString("cleaner.sqsUrl"),
       ApnsConfig(
         teamId = config.getString("apns.teamId"),
-        bundleId = if (platform == Ios) config.getString("apns.bundleId") else config.getString("apns.newsstandBundleId"),
+        bundleId = if (platform.contains(Ios)) config.getString("apns.bundleId") else config.getString("apns.newsstandBundleId"),
         keyId = config.getString("apns.keyId"),
         certificate = config.getString("apns.certificate"),
         mapiBaseUrl = config.getString("mapi.baseUrl"),

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -44,7 +44,7 @@ trait HarvesterRequestHandler extends Logging {
           case (token, tokenPlatform) if tokenPlatform == platform => token
         }
         .chunkN(1000)
-        .map(chunk => ChunkedTokens(shardedNotification.notification, chunk.toList, platform, shardedNotification.range))
+        .map(chunk => ChunkedTokens(shardedNotification.notification, chunk.toList, shardedNotification.range))
         .map(deliveryService.sending)
         .parJoin(maxConcurrency)
         .collect {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/IOSSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/IOSSender.scala
@@ -1,13 +1,11 @@
 package com.gu.notifications.worker
 
-import _root_.models.Ios
 import cats.effect.IO
 import com.gu.notifications.worker.cleaning.CleaningClientImpl
 import com.gu.notifications.worker.delivery.apns.{Apns, ApnsClient}
 import com.gu.notifications.worker.utils.{Cloudwatch, CloudwatchImpl}
 
 class IOSSender extends SenderRequestHandler[ApnsClient] {
-  val platform = Ios
   val config: ApnsWorkerConfiguration = Configuration.fetchApns()
   val cleaningClient = new CleaningClientImpl(config.sqsUrl)
   val cloudwatch: Cloudwatch = new CloudwatchImpl

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryClient.scala
@@ -2,7 +2,7 @@ package com.gu.notifications.worker.delivery
 
 import java.util.UUID
 
-import models.{Notification, Platform}
+import models.Notification
 
 import scala.concurrent.ExecutionContextExecutor
 
@@ -12,7 +12,7 @@ trait DeliveryClient {
   type Payload <: DeliveryPayload
 
   def close(): Unit
-  def sendNotification(notificationId: UUID, token: String, payload: Payload, platform: Platform, dryRun: Boolean)
+  def sendNotification(notificationId: UUID, token: String, payload: Payload, dryRun: Boolean)
     (onComplete: Either[Throwable, Success] => Unit)
     (implicit ece: ExecutionContextExecutor): Unit
   def payloadBuilder: Notification => Option[Payload]

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryService.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryService.scala
@@ -16,8 +16,7 @@ import scala.util.control.NonFatal
 trait DeliveryService[F[_], C <: DeliveryClient] {
   def send(
     notification: Notification,
-    token: String,
-    platform: Platform
+    token: String
   ): Stream[F, Either[DeliveryException, C#Success]]
 }
 
@@ -31,8 +30,7 @@ class DeliveryServiceImpl[F[_], C <: DeliveryClient] (
 
   def send(
     notification: Notification,
-    token: String,
-    platform: Platform
+    token: String
   ): Stream[F, Either[DeliveryException, C#Success]] = {
 
     def sendAsync(client: C)(token: String, payload: client.Payload): F[C#Success] =
@@ -41,7 +39,6 @@ class DeliveryServiceImpl[F[_], C <: DeliveryClient] (
           notification.id,
           token,
           payload,
-          platform,
           notification.dryRun.contains(true) || client.dryRun
         )(cb)
       }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
@@ -25,7 +25,6 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
   type Success = ApnsDeliverySuccess
   type Payload = ApnsPayload
   val dryRun = config.dryRun
-  val platform: Platform = Ios
 
   private val apnsPayloadBuilder = new ApnsPayloadBuilder(config)
 
@@ -38,7 +37,7 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
 
   def payloadBuilder: Notification => Option[ApnsPayload] = apnsPayloadBuilder.apply _
 
-  def sendNotification(notificationId: UUID, token: String, payload: Payload, platform: Platform, dryRun: Boolean)
+  def sendNotification(notificationId: UUID, token: String, payload: Payload, dryRun: Boolean)
     (onComplete: Either[Throwable, Success] => Unit)
     (implicit ece: ExecutionContextExecutor): Unit = {
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
@@ -42,14 +42,9 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
     (onComplete: Either[Throwable, Success] => Unit)
     (implicit ece: ExecutionContextExecutor): Unit = {
 
-    val bundleId = platform match {
-      case Newsstand => config.newsstandBundleId
-      case _ => config.bundleId
-    }
-
     val pushNotification = new SimpleApnsPushNotification(
       TokenUtil.sanitizeTokenString(token),
-      bundleId,
+      config.bundleId,
       payload.jsonString,
       //Default to no invalidation time but an hour for breaking news and 10 mins for football
       //See https://stackoverflow.com/questions/12317037/apns-notifications-ttl

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/ApnsConfig.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/ApnsConfig.scala
@@ -3,7 +3,6 @@ package com.gu.notifications.worker.delivery.apns.models
 case class ApnsConfig(
   teamId: String,
   bundleId: String,
-  newsstandBundleId: String,
   keyId: String,
   certificate: String,
   mapiBaseUrl: String,

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -26,7 +26,6 @@ class FcmClient private (firebaseMessaging: FirebaseMessaging, firebaseApp: Fire
   type Success = FcmDeliverySuccess
   type Payload = FcmPayload
   val dryRun = config.dryRun
-  val platform: Platform = Android
 
   private val invalidTokenErrorCodes = Seq(
     "invalid-registration-token",
@@ -37,7 +36,7 @@ class FcmClient private (firebaseMessaging: FirebaseMessaging, firebaseApp: Fire
 
   def payloadBuilder: Notification => Option[FcmPayload] = n => FcmPayloadBuilder(n, config.debug)
 
-  def sendNotification(notificationId: UUID, token: String, payload: Payload, platform: Platform, dryRun: Boolean)
+  def sendNotification(notificationId: UUID, token: String, payload: Payload, dryRun: Boolean)
     (onComplete: Either[Throwable, Success] => Unit)
     (implicit executionContext: ExecutionContextExecutor): Unit = {
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
@@ -11,10 +11,10 @@ import play.api.libs.json.{Format, Json}
 
 import scala.concurrent.ExecutionContextExecutor
 
-case class IndividualNotification(notification: Notification, token: String, platform: Platform)
+case class IndividualNotification(notification: Notification, token: String)
 
-case class ChunkedTokens(notification: Notification, tokens: List[String], platform: Platform, range: ShardRange) {
-  def toNotificationToSends: List[IndividualNotification] = tokens.map(IndividualNotification(notification, _, platform))
+case class ChunkedTokens(notification: Notification, tokens: List[String], range: ShardRange) {
+  def toNotificationToSends: List[IndividualNotification] = tokens.map(IndividualNotification(notification, _))
 }
 
 object ChunkedTokens {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Cloudwatch.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Cloudwatch.scala
@@ -10,7 +10,7 @@ import models.Platform
 import scala.collection.JavaConverters._
 
 trait Cloudwatch {
-  def sendMetrics(stage: String, platform: Platform): Sink[IO, SendingResults]
+  def sendMetrics(stage: String, platform: Option[Platform]): Sink[IO, SendingResults]
   def sendFailures(stage: String, platform: Platform): Sink[IO, Throwable]
 }
 
@@ -29,9 +29,9 @@ class CloudwatchImpl extends Cloudwatch {
       .withValue(value.toDouble)
       .withDimensions(dimension)
 
-  def sendMetrics(stage: String, platform: Platform): Sink[IO, SendingResults] = _.evalMap { results =>
+  def sendMetrics(stage: String, platform: Option[Platform]): Sink[IO, SendingResults] = _.evalMap { results =>
     IO.delay {
-      val dimension = new Dimension().withName("platform").withValue(platform.toString)
+      val dimension = new Dimension().withName("platform").withValue(platform.map(_.toString).getOrElse("unknown"))
       val metrics: Seq[MetricDatum] = Seq(
         countDatum("success", results.successCount, dimension),
         countDatum("failure", results.failureCount, dimension),

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -117,7 +117,7 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
         sqsDeliveries
       }
       override val cloudwatch: Cloudwatch = new Cloudwatch {
-        override def sendMetrics(stage: String, platform: Platform): Sink[IO, SendingResults] = ???
+        override def sendMetrics(stage: String, platform: Option[Platform]): Sink[IO, SendingResults] = ???
 
         override def sendFailures(stage: String, platform: Platform): Sink[IO, Throwable] = {
           cloudwatchFailures.incrementAndGet()

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -105,17 +105,22 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
           tokenPlatformStream
         }
       }
-      override val apnsDeliveryService: SqsDeliveryService[IO] = (chunkedTokens: ChunkedTokens) => {
+      override val iosLiveDeliveryService: SqsDeliveryService[IO] = (chunkedTokens: ChunkedTokens) => {
         apnsSqsDeliveriesCount.incrementAndGet()
         apnsSqsDeliveriesTotal.addAndGet(chunkedTokens.tokens.size)
         sqsDeliveries
       }
 
-      override val firebaseDeliveryService: SqsDeliveryService[IO] = (chunkedTokens: ChunkedTokens) => {
+      override val androidLiveDeliveryService: SqsDeliveryService[IO] = (chunkedTokens: ChunkedTokens) => {
         firebaseSqsDeliveriesCount.incrementAndGet()
         firebaseSqsDeliveriesTotal.addAndGet(chunkedTokens.tokens.size)
         sqsDeliveries
       }
+
+      override val iosEditionDeliveryService: SqsDeliveryService[IO] = (chunkedTokens: ChunkedTokens) => sqsDeliveries
+
+      override val androidEditionDeliveryService: SqsDeliveryService[IO] = (chunkedTokens: ChunkedTokens) => sqsDeliveries
+
       override val cloudwatch: Cloudwatch = new Cloudwatch {
         override def sendMetrics(stage: String, platform: Option[Platform]): Sink[IO, SendingResults] = ???
 

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -88,7 +88,6 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
     val chunkedTokens = ChunkedTokens(
       notification = notification,
       range = ShardRange(0, 1),
-      platform = Android,
       tokens = List("token")
     )
 

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -112,12 +112,11 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
     var sendingResults: Option[SendingResults] = None
 
     val workerRequestHandler = new SenderRequestHandler[ApnsClient] {
-      override def platform: Platform = Ios
 
       override val maxConcurrency = 100
 
       override def deliveryService: IO[DeliveryService[IO, ApnsClient]] = IO.pure(new DeliveryService[IO, ApnsClient] {
-        override def send(notification: Notification, token: String, platform: Platform): Stream[IO, Either[DeliveryException, ApnsDeliverySuccess]] = {
+        override def send(notification: Notification, token: String): Stream[IO, Either[DeliveryException, ApnsDeliverySuccess]] = {
           deliveryCallsCount += 1
           deliveries
         }
@@ -134,7 +133,7 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
       }
 
       override val cloudwatch: Cloudwatch = new Cloudwatch {
-        override def sendMetrics(stage: String, platform: Platform): Sink[IO, SendingResults] = { stream =>
+        override def sendMetrics(stage: String, platform: Option[Platform]): Sink[IO, SendingResults] = { stream =>
           cloudwatchCallsCount += 1
           stream.map { results =>
             sendingResults = Some(results)

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -45,7 +45,6 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
       val dummyConfig = new ApnsConfig(
         teamId = "",
         bundleId = "",
-        newsstandBundleId = "",
         keyId = "",
         certificate = "",
         mapiBaseUrl = "https://mobile.guardianapis.com"


### PR DESCRIPTION
- Add an environment variable to the lambda, telling it which platform it's handling
- Use this platform to decide which configuration to load. This will need to be refactored later such that each lambda has its own SSM prefix based on the platform. This will keep the number of loaded properties to the minimum
- Remove `platform` from the model that gets serialised on the SQS queue

TODO

- [x] Wire the harvester such that newsstand notifications are sent to the new SQS queue. In its current form this PR would break the daily edition