### PR TITLE
Parametrise the period of the "TooFewInvocations" alarms

### DIFF
--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -36,6 +36,9 @@ Parameters:
       - ios
       - android-edition
       - ios-edition
+  SenderTooFewInvocationsAlarmPeriod:
+    Type: String
+    Description: How long until no execution is suspicious, in seconds
 
 Conditions:
   IsProdStage: !Equals [!Ref Stage, PROD]
@@ -208,7 +211,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda
-      Period: 7200
+      Period: !Ref SenderTooFewInvocationsAlarmPeriod
       Statistic: Sum
       Threshold: 0
       TreatMissingData: breaching


### PR DESCRIPTION
An alarm was triggered because the new workers haven't got enough invocations.

The new workers are expected to be run once a day, so the period should be a day. I'm extracting the period into a parameter so that each worker can be customised depending on what it processes