### PR TITLE
Purge breaking news article before sending the breaking news

### DIFF
--- a/notification/app/notification/NotificationApplicationLoader.scala
+++ b/notification/app/notification/NotificationApplicationLoader.scala
@@ -92,6 +92,9 @@ class NotificationApplicationComponents(identity: AppIdentity, context: Context)
     harvesterSqsUrl = configuration.get[String]("notifications.queues.harvester")
   )
 
+  lazy val fastlyPurge: FastlyPurge = wire[FastlyPurgeImpl]
+  lazy val articlePurge: ArticlePurge = wire[ArticlePurge]
+
   lazy val mainController = wire[Main]
   lazy val router: Router = wire[Routes]
 

--- a/notification/app/notification/services/ArticlePurge.scala
+++ b/notification/app/notification/services/ArticlePurge.scala
@@ -1,0 +1,27 @@
+package notification.services
+
+import models.Link.Internal
+import models.{BreakingNewsNotification, GITContent, Link, Notification}
+
+import scala.concurrent.Future
+
+class ArticlePurge(fastlyPurge: FastlyPurge, configuration: Configuration) {
+  private def breakingNewsUrl(notification: Notification): Option[String] = {
+    def linkToUrl(link: Link): Option[String] = link match {
+      case Internal(contentApiId, _, GITContent) => Some(s"${configuration.mapiEndpointBase}/items/$contentApiId")
+      case _ => None
+    }
+
+    notification match {
+      case breaking: BreakingNewsNotification => linkToUrl(breaking.link)
+      case _ => None
+    }
+  }
+
+  def purgeFromNotification(notification: Notification): Future[Boolean] = {
+    breakingNewsUrl(notification) match {
+      case Some(url) => fastlyPurge.softPurge(url)
+      case _ => Future.successful(false)
+    }
+  }
+}

--- a/notification/app/notification/services/Configuration.scala
+++ b/notification/app/notification/services/Configuration.scala
@@ -14,6 +14,8 @@ class Configuration(conf: PlayConfig, identity: AppIdentity) {
   lazy val dynamoScheduleTableName: String = conf.get[String]("db.dynamo.schedule.table-name")
   lazy val newsstandRestrictedApiKeys: Set[String] = conf.get[Seq[String]]("notifications.api.newsstandRestrictedKeys").toSet
 
+  lazy val mapiEndpointBase: String = conf.get[String]("mapi.base")
+
   lazy val newsstandShards: Int = conf.get[Int]("newsstand.shards")
   lazy val stage = identity match {
     case AwsIdentity(_, _, stage, _) => stage

--- a/notification/app/notification/services/FastlyPurge.scala
+++ b/notification/app/notification/services/FastlyPurge.scala
@@ -1,0 +1,31 @@
+package notification.services
+
+import play.api.Logger
+import play.api.libs.ws.WSClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait FastlyPurge {
+  def softPurge(url: String): Future[Boolean]
+}
+
+class FastlyPurgeImpl(wsClient: WSClient)(implicit ec: ExecutionContext) extends FastlyPurge {
+
+  private val logger: Logger = Logger(this.getClass)
+
+  def softPurge(url: String): Future[Boolean] = {
+
+    wsClient.url(url)
+      .addHttpHeaders("Fastly-Soft-Purge" -> "1")
+      .execute("PURGE")
+      .map { resp =>
+        logger.info(s"Soft purged $url got HTTP ${resp.status} back")
+        if (resp.status == 200) {
+          true
+        } else {
+          throw new Exception(s"Unable to soft purge url, got HTTP ${resp.status} for $url")
+        }
+      }
+  }
+
+}

--- a/notification/test/notification/controllers/MainSpec.scala
+++ b/notification/test/notification/controllers/MainSpec.scala
@@ -127,6 +127,11 @@ class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito
       m
     }
 
+    val fastlyPurge = new FastlyPurge {
+      override def softPurge(url: String): Future[Boolean] = Future.successful(true)
+    }
+    val articlePurge = new ArticlePurge(fastlyPurge, conf)
+
     val controllerComponents = stubControllerComponents()
     val reportRepository = new InMemoryNotificationReportRepository
     val authAction = new NotificationAuthAction(conf, controllerComponents)
@@ -138,6 +143,7 @@ class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito
       newsstandSender = newsstandNotificationSender,
       metrics = metrics,
       notificationReportRepository = reportRepository,
+      articlePurge = articlePurge,
       controllerComponents = controllerComponents,
       authAction = authAction
     )

--- a/notification/test/notification/services/ArticlePurgeSpec.scala
+++ b/notification/test/notification/services/ArticlePurgeSpec.scala
@@ -1,0 +1,51 @@
+package notification.services
+
+import models.GITContent
+import models.Link.Internal
+import notification.NotificationsFixtures
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import scala.concurrent.Future
+
+class ArticlePurgeSpec(implicit ee: ExecutionEnv) extends Specification with Mockito with NotificationsFixtures {
+
+  "ArticlePurge" should {
+    "trigger a soft purge for a breaking news" in new ArticlePurgeScope {
+      val breakingNews = breakingNewsNotification(Nil).copy(link = new Internal("expected/article/id", None, GITContent))
+
+      articlePurge.purgeFromNotification(breakingNews) should beEqualTo(true).await
+      val urlCaptor = capture[String]
+      there was one(fastlyPurge).softPurge(urlCaptor)
+      println(urlCaptor.value)
+      urlCaptor.value shouldEqual "https://somemapihost.com/items/expected/article/id"
+    }
+
+    "do nothing for any other notification type" in new ArticlePurgeScope {
+      val newsstand = newsstandShardNotification()
+      articlePurge.purgeFromNotification(newsstand) should beEqualTo(false).await
+      there was no(fastlyPurge).softPurge(any[String])
+    }
+  }
+
+  trait ArticlePurgeScope extends Scope {
+
+    val conf: Configuration = {
+      val m = mock[Configuration]
+      m.mapiEndpointBase returns s"https://somemapihost.com"
+      m
+    }
+
+    val fastlyPurge: FastlyPurge = {
+      val m = mock[FastlyPurge]
+      m.softPurge(any[String]) returns Future.successful(true)
+      m
+    }
+
+    val articlePurge = new ArticlePurge(fastlyPurge, conf)
+
+  }
+
+}


### PR DESCRIPTION
This is to ensure the article that is about to be read is as fresh as possible.

Editorial noticed in some cases the articles had been edited shortly before the notification was sent, but the version visible on the device was an older cached version. This should fix the issue