### PR TITLE
Refactor the configuration of the workers

### DIFF
--- a/db-cleaner/cfn.yaml
+++ b/db-cleaner/cfn.yaml
@@ -60,7 +60,7 @@ Resources:
                 - ssm:GetParametersByPath
               Effect: Allow
               Resource:
-                !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/notifications/${Stage}/workers
+                !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/notifications/${Stage}/workers/cleaner
         - PolicyName: VPC
           PolicyDocument:
             Statement:
@@ -87,7 +87,7 @@ Resources:
       Handler: Provided
       MemorySize: 128
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
+      Runtime: provided
       Timeout: 60
       VpcConfig:
         SecurityGroupIds:

--- a/db-cleaner/src/cleaner.rs
+++ b/db-cleaner/src/cleaner.rs
@@ -82,7 +82,7 @@ fn fetch_config(credentials: ChainProvider) -> Result<HashMap<String, String>, S
         Region::EuWest1
     );
 
-    let path: String = "/notifications/".to_owned() + &stage + "/workers";
+    let path: String = "/notifications/".to_owned() + &stage + "/workers/cleaner";
 
     let config = HashMap::new();
 
@@ -96,11 +96,11 @@ fn fetch_config(credentials: ChainProvider) -> Result<HashMap<String, String>, S
 }
 
 fn config_to_connection_parameter(config: HashMap<String, String>) -> Result<ConnectionParameters, String> {
-    config.get("cleaner.registration.db.url").and_then(|jdbc_url| {
+    config.get("registration.db.url").and_then(|jdbc_url| {
         Some(ConnectionParameters {
             jdbc_url: jdbc_url.to_owned(),
-            user: config.get("cleaner.registration.db.user")?.to_owned(),
-            password: config.get("cleaner.registration.db.password")?.to_owned(),
+            user: config.get("registration.db.user")?.to_owned(),
+            password: config.get("registration.db.password")?.to_owned(),
         })
     }).ok_or("Unable to read the url, user or password from the configuration".to_string())
 }
@@ -189,9 +189,9 @@ mod test_config_to_connection_parameter {
     #[test]
     fn test_config_to_connection_parameter() {
         let mut config = HashMap::new();
-        config.insert("cleaner.registration.db.url".to_owned(), "someUrl".to_owned());
-        config.insert("cleaner.registration.db.user".to_owned(), "user".to_owned());
-        config.insert("cleaner.registration.db.password".to_owned(), "password".to_owned());
+        config.insert("registration.db.url".to_owned(), "someUrl".to_owned());
+        config.insert("registration.db.user".to_owned(), "user".to_owned());
+        config.insert("registration.db.password".to_owned(), "password".to_owned());
 
         let params = config_to_connection_parameter(config);
         let expected = ConnectionParameters {

--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -122,7 +122,7 @@ Resources:
           - Action: ssm:GetParametersByPath
             Effect: Allow
             Resource:
-              !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/notifications/${Stage}/workers
+              !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/notifications/${Stage}/workers/harvester
       - PolicyName: Cloudwatch
         PolicyDocument:
           Statement:

--- a/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
+++ b/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
@@ -100,7 +100,7 @@ Resources:
           - Action: ssm:GetParametersByPath
             Effect: Allow
             Resource:
-              !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/notifications/${Stage}/workers
+              !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/notifications/${Stage}/workers/cleaner
       - PolicyName: Cloudwatch
         PolicyDocument:
           Statement:

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -116,7 +116,7 @@ Resources:
           - Action: ssm:GetParametersByPath
             Effect: Allow
             Resource:
-              !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/notifications/${Stage}/workers
+              !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/notifications/${Stage}/workers/${Platform}
       - PolicyName: Cloudwatch
         PolicyDocument:
           Statement:

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -7,7 +7,7 @@ import com.gu.notifications.worker.utils.{Cloudwatch, CloudwatchImpl}
 
 class AndroidSender extends SenderRequestHandler[FcmClient] {
   val config: FcmWorkerConfiguration = Configuration.fetchFirebase()
-  val cleaningClient = new CleaningClientImpl(config.sqsUrl)
+  val cleaningClient = new CleaningClientImpl(config.cleaningSqsUrl)
   val cloudwatch: Cloudwatch = new CloudwatchImpl
 
   override val deliveryService: IO[Fcm[IO]] =

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/IOSSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/IOSSender.scala
@@ -7,7 +7,7 @@ import com.gu.notifications.worker.utils.{Cloudwatch, CloudwatchImpl}
 
 class IOSSender extends SenderRequestHandler[ApnsClient] {
   val config: ApnsWorkerConfiguration = Configuration.fetchApns()
-  val cleaningClient = new CleaningClientImpl(config.sqsUrl)
+  val cleaningClient = new CleaningClientImpl(config.cleaningSqsUrl)
   val cloudwatch: Cloudwatch = new CloudwatchImpl
 
   override val deliveryService: IO[Apns[IO]] =

--- a/notificationworkerlambda/topic-counter-cfn.yaml
+++ b/notificationworkerlambda/topic-counter-cfn.yaml
@@ -70,7 +70,7 @@ Resources:
           - Action: ssm:GetParametersByPath
             Effect: Allow
             Resource:
-              !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/notifications/${Stage}/workers
+              !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/notifications/${Stage}/workers/topicCounter
       - PolicyName: Cloudwatch
         PolicyDocument:
           Statement:


### PR DESCRIPTION
This refactoring:

- isolate the configuration of each worker. Before it was quite the noodle plate
- this should slightly speed up cold starts as we won't be loading the whole config namespace at boot time anymore
- this also give us the possibility to configure the sender workers independently, such that the ios live and the ios edition workers are executing the same code but two different configs.

Now obvisously that means all the config property are being moved, because of the high chance of manual error I wrote a script to automate the migration. This has been successfully ran on CODE. I'll also keep the older properties for a little while, just in case we need to revert.

Here's the migration script (it's not meant to be pretty)
```bash
#!/usr/bin/env bash
[ -z "$STAGE" ] && echo "set STAGE and re-launch" && exit 1;

LOG=$0.log

date | tee -a $LOG

cat conf-migration-mapping.tsv | while read FROM TO ; do
	FROM_WITH_PREFIX="/notifications/${STAGE}/workers/${FROM}"
	TO_WITH_PREFIX="/notifications/${STAGE}/workers/${TO}"
	JSON=$(aws ssm get-parameter --name "${FROM_WITH_PREFIX}" --with-decryption --profile mobile --region eu-west-1 | 
	jq "{Name: \"${TO_WITH_PREFIX}\", Value: .Parameter.Value, Type: .Parameter.Type}")
	echo "${JSON}" >> $LOG
	echo -n Copying $FROM_WITH_PREFIX to $TO_WITH_PREFIX | tee -a $LOG
	VERSION=$(aws ssm put-parameter --overwrite --region eu-west-1 --profile mobile --cli-input-json "$JSON" | jq .Version)
	echo " ✔ (Version: $VERSION)" | tee -a $LOG
done
```

Here's the input file conf-migration-mapping.tsv
```tsv
apns.bundleId	ios/apns.bundleId
apns.certificate	ios/apns.certificate
apns.keyId	ios/apns.keyId
apns.sendingToProdServer	ios/apns.sendingToProdServer
apns.teamId	ios/apns.teamId
mapi.baseUrl	ios/mapi.baseUrl
dryrun	ios/dryrun
cleaner.sqsUrl	ios/cleaningSqsUrl
dryrun	android/dryrun
fcm.debug	android/fcm.debug
fcm.serviceAccountKey	android/fcm.serviceAccountKey
cleaner.sqsUrl	android/cleaningSqsUrl
apns.newsstandBundleId	ios-edition/apns.bundleId
apns.certificate	ios-edition/apns.certificate
apns.keyId	ios-edition/apns.keyId
apns.sendingToProdServer	ios-edition/apns.sendingToProdServer
apns.teamId	ios-edition/apns.teamId
mapi.baseUrl	ios-edition/mapi.baseUrl
dryrun	ios-edition/dryrun
cleaner.sqsUrl	ios-edition/cleaningSqsUrl
dryrun	android-edition/dryrun
fcm.debug	android-edition/fcm.debug
fcm.serviceAccountKey	android-edition/fcm.serviceAccountKey
cleaner.sqsUrl	android-edition/cleaningSqsUrl
cleaner.registration.db.password	cleaner/registration.db.password
cleaner.registration.db.url	cleaner/registration.db.url
cleaner.registration.db.user	cleaner/registration.db.user
cleaner.sqsUrl	cleaner/cleaningSqsUrl
delivery.androidEditionSqsUrl	harvester/androidEditionSqsUrl
delivery.apnsSqsUrl	harvester/iosLiveSqsUrl
delivery.firebaseSqsUrl	harvester/androidLiveSqsUrl
delivery.iosEditionSqsUrl	harvester/iosEditionSqsUrl
registration.db.password	harvester/registration.db.password
registration.db.url	harvester/registration.db.url
registration.db.user	harvester/registration.db.user
registration.db.password	topicCounter/registration.db.password
registration.db.url	topicCounter/registration.db.url
registration.db.user	topicCounter/registration.db.user
topicCounts.bucket	topicCounter/bucket
topicCounts.countThreshold	topicCounter/countThreshold
topicCounts.fileName	topicCounter/fileName
```
Here's a sample output of the script

```
Copying /notifications/CODE/workers/apns.bundleId to /notifications/CODE/workers/ios/apns.bundleId ✔ (Version: 1)
Copying /notifications/CODE/workers/apns.certificate to /notifications/CODE/workers/ios/apns.certificate ✔ (Version: 1)
Copying /notifications/CODE/workers/apns.keyId to /notifications/CODE/workers/ios/apns.keyId ✔ (Version: 1)
Copying /notifications/CODE/workers/apns.sendingToProdServer to /notifications/CODE/workers/ios/apns.sendingToProdServer ✔ (Version: 1)
```

Deployment TODO list
 - [x] apply the migration script to prod
 - [x] manually edit configuration with the new firebase projects for the android-edition
 - [x] merge
 - [ ] check metrics and logs