### PR TITLE
MSS-909: Remove content-available flag

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
@@ -64,7 +64,6 @@ class ApnsPayloadBuilder(config: ApnsConfig) {
         case _: Link.External => ""
         case _: Link.Internal => "ITEM_CATEGORY"
       }),
-      contentAvailable = true,
       mutableContent = true,
       sound = Some("default"),
       customProperties = Seq(
@@ -87,7 +86,6 @@ class ApnsPayloadBuilder(config: ApnsConfig) {
       alertTitle = None,
       alertBody = Some(n.title),
       categoryName = Some("ITEM_CATEGORY"),
-      contentAvailable = true,
       mutableContent = true,
       sound = Some("default"),
       customProperties = Seq(
@@ -109,7 +107,6 @@ class ApnsPayloadBuilder(config: ApnsConfig) {
       alertTitle = Some(n.title),
       alertBody = Some(n.message),
       categoryName = Some("football-match"),
-      contentAvailable = false,
       mutableContent = true,
       sound = if (n.importance == Importance.Major) Some("default") else None,
       customProperties = Seq(

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -88,7 +88,6 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
-        |      "content-available":1,
         |      "mutable-content":1
         |   },
         |   "provider":"Guardian",
@@ -127,7 +126,6 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
-        |      "content-available":1,
         |      "mutable-content":1
         |   },
         |   "provider":"Guardian",
@@ -166,7 +164,6 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
-        |      "content-available":1,
         |      "mutable-content":1
         |   },
         |   "provider":"Guardian",
@@ -204,7 +201,6 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
-        |      "content-available":1,
         |      "mutable-content":1
         |   },
         |   "provider":"Guardian",


### PR DESCRIPTION
Removes all instances of the content-available flag from the iOS push notification payload (except for daily edition)