### PR TITLE
Support transactions while registering

### DIFF
--- a/common/src/main/scala/db/RegistrationRepository.scala
+++ b/common/src/main/scala/db/RegistrationRepository.scala
@@ -1,13 +1,14 @@
 package db
 
 import cats.data.NonEmptyList
+import doobie.free.connection.ConnectionIO
 import models.{Platform, TopicCount}
 
 trait RegistrationRepository[F[_], S[_[_], _]] {
   def findTokens(topics: NonEmptyList[String], shardRange: Option[Range]): S[F, (String, Platform)]
   def findByToken(token: String): S[F, Registration]
-  def save(sub: Registration): F[Int]
-  def remove(sub: Registration): F[Int]
-  def removeByToken(token: String): F[Int]
+  def insert(reg: Registration): ConnectionIO[Int]
+  def delete(sub: Registration): ConnectionIO[Int]
+  def deleteByToken(token: String): ConnectionIO[Int]
   def topicCounts(countsThreshold: Int): S[F, TopicCount]
 }

--- a/common/src/main/scala/db/RegistrationRepository.scala
+++ b/common/src/main/scala/db/RegistrationRepository.scala
@@ -4,7 +4,6 @@ import cats.data.NonEmptyList
 import models.{Platform, TopicCount}
 
 trait RegistrationRepository[F[_], S[_[_], _]] {
-  def findTokens(topics: NonEmptyList[String], platform: Option[String], shardRange: Option[Range]): S[F, String]
   def findTokens(topics: NonEmptyList[String], shardRange: Option[Range]): S[F, (String, Platform)]
   def findByToken(token: String): S[F, Registration]
   def save(sub: Registration): F[Int]

--- a/common/src/main/scala/db/RegistrationService.scala
+++ b/common/src/main/scala/db/RegistrationService.scala
@@ -13,8 +13,6 @@ import scala.concurrent.ExecutionContext
 
 class RegistrationService[F[_], S[_[_], _]](repository: RegistrationRepository[F, S]) {
   def findByToken(token: String): S[F, Registration] = repository.findByToken(token)
-  def findTokens(topics: NonEmptyList[Topic], platform: Option[Platform], shardRange: Option[ShardRange]): S[F, String] =
-    repository.findTokens(topics.map(_.name), platform.map(_.toString), shardRange.map(_.range))
   def findTokens(topics: NonEmptyList[Topic], shardRange: Option[ShardRange]): S[F, (String, Platform)] =
     repository.findTokens(topics.map(_.name), shardRange.map(_.range))
   def save(sub: Registration): F[Int] = repository.save(sub)

--- a/common/src/test/scala/db/RegistrationServiceSpec.scala
+++ b/common/src/test/scala/db/RegistrationServiceSpec.scala
@@ -40,7 +40,7 @@ class RegistrationServiceSpec(implicit ee: ExecutionEnv) extends Specification w
 
   override def before() = {
     initializeDatabase()
-    registrations.map(service.save).foreach(io => run(io))
+    registrations.map(service.insert).foreach(io => run(io))
   }
 
   def run[A](s: Stream[IO, A]): List[A] = s.compile.toList.unsafeRunSync()
@@ -62,21 +62,20 @@ class RegistrationServiceSpec(implicit ee: ExecutionEnv) extends Specification w
   val shardRange2 = ShardRange(2, 2)
 
   val topicsAll: NonEmptyList[Topic] =
-    NonEmptyList.of(registrations.head.topic, registrations.tail.map(_.topic):_*)
+    NonEmptyList.of(Topic("topic1"), Topic("topic2"), Topic("topic3"), Topic("topic4"))
   val topics1 = NonEmptyList.one(Topic("topic1"))
   val topics2 = NonEmptyList.one(Topic("topic2"))
 
   "RegistrationService" should {
     "allow adding registration" in {
       val reg = Registration(Device("something", Android), Topic("someTopic"), Shard(1))
-      run(service.save(reg)) should equalTo(1)
+      run(service.insert(reg)) should equalTo(1)
     }
-    "allow finding registrations by topics, platform and shard" in {
-      run(service.findTokens(topicsAll, None)).length should equalTo(6)
+    "allow finding registrations by topics and shard" in {
+      run(service.findTokens(topicsAll, None)).length should equalTo(7)
       run(service.findTokens(topics1, None)).length should equalTo(4)
-      run(service.findTokens(topics1, None)).length should equalTo(3)
-      run(service.findTokens(topics1, Some(allShards))).length should equalTo(3)
-      run(service.findTokens(topics1, Some(shardRange1))).length should equalTo(2)
+      run(service.findTokens(topics1, Some(allShards))).length should equalTo(4)
+      run(service.findTokens(topics1, Some(shardRange1))).length should equalTo(3)
       run(service.findTokens(topics2, Some(shardRange1))).length should equalTo(1)
       run(service.findTokens(topics2, Some(shardRange2))).length should equalTo(0)
     }
@@ -87,20 +86,14 @@ class RegistrationServiceSpec(implicit ee: ExecutionEnv) extends Specification w
     "allow removing registrations" in {
       val regB = registrations.filter(_.device.token == "b").head
       val regE = registrations.filter(_.device.token == "e").head
-      run(service.remove(regB)) should equalTo(1)
-      run(service.remove(regE)) should equalTo(1)
+      run(service.delete(regB)) should equalTo(1)
+      run(service.delete(regE)) should equalTo(1)
       run(service.findByToken(regB.device.token)).length should equalTo(0)
       run(service.findByToken(regE.device.token)).length should equalTo(0)
     }
     "allow removing registrations by token" in {
       run(service.removeAllByToken("f")) should equalTo(2)
       run(service.findByToken("f")).length should equalTo(0)
-    }
-    "update when saving the same registration twice" in {
-      val reg = registrations.filter(_.device.token == "a").head
-      val newShardId: Short = 99
-      run(service.save(reg.copy(shard = Shard(newShardId))))
-      run(service.findByToken(reg.device.token)).head.shard.id should equalTo(newShardId)
     }
   }
 }

--- a/common/src/test/scala/db/RegistrationServiceSpec.scala
+++ b/common/src/test/scala/db/RegistrationServiceSpec.scala
@@ -72,13 +72,13 @@ class RegistrationServiceSpec(implicit ee: ExecutionEnv) extends Specification w
       run(service.save(reg)) should equalTo(1)
     }
     "allow finding registrations by topics, platform and shard" in {
-      run(service.findTokens(topicsAll, None, None)).length should equalTo(6)
-      run(service.findTokens(topics1, None, None)).length should equalTo(4)
-      run(service.findTokens(topics1, Some(Ios), None)).length should equalTo(3)
-      run(service.findTokens(topics1, Some(Ios), Some(allShards))).length should equalTo(3)
-      run(service.findTokens(topics1, Some(Ios), Some(shardRange1))).length should equalTo(2)
-      run(service.findTokens(topics2, Some(Android), Some(shardRange1))).length should equalTo(1)
-      run(service.findTokens(topics2, Some(Android), Some(shardRange2))).length should equalTo(0)
+      run(service.findTokens(topicsAll, None)).length should equalTo(6)
+      run(service.findTokens(topics1, None)).length should equalTo(4)
+      run(service.findTokens(topics1, None)).length should equalTo(3)
+      run(service.findTokens(topics1, Some(allShards))).length should equalTo(3)
+      run(service.findTokens(topics1, Some(shardRange1))).length should equalTo(2)
+      run(service.findTokens(topics2, Some(shardRange1))).length should equalTo(1)
+      run(service.findTokens(topics2, Some(shardRange2))).length should equalTo(0)
     }
     "allow finding registrations by token" in {
       run(service.findByToken("f")).length should equalTo(2)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
@@ -24,12 +24,6 @@ object ChunkedTokens {
 trait TokenService[F[_]] {
   def tokens(
     notification: Notification,
-    shardRange: ShardRange,
-    platform: Platform
-  ): Stream[F, String]
-
-  def tokens(
-    notification: Notification,
     shardRange: ShardRange
   ): Stream[F, (String, Platform)]
 }
@@ -41,23 +35,6 @@ class TokenServiceImpl[F[_]](
   F: Async[F],
   T: Timer[F]
 ) extends TokenService[F] {
-  override def tokens(
-    notification: Notification,
-    shardRange: ShardRange,
-    platform: Platform
-  ): Stream[F, String] = {
-    val topicsF: F[NonEmptyList[Topic]] = notification
-      .topic
-      .map(t => Topic(t.fullName))
-      .toNel
-      .map(nel => F.delay(nel))
-      .getOrElse(F.raiseError(InvalidTopics(notification.id)))
-
-    for {
-      topics <- Stream.eval(topicsF)
-      res <- registrationService.findTokens(topics, Some(platform), Some(shardRange))
-    } yield res
-  }
 
   override def tokens(notification: Notification, shardRange: ShardRange): Stream[F, (String, Platform)] = {
     val topicsF: F[NonEmptyList[Topic]] = notification

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -95,11 +95,6 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
     val workerRequestHandler = new HarvesterRequestHandler {
 
       override val tokenService: TokenService[IO] = new TokenService[IO] {
-        override def tokens(notification: Notification, shardRange: ShardRange, platform: Platform): Stream[IO, String] = {
-          tokenStreamCount.incrementAndGet()
-          tokenStream
-        }
-
         override def tokens(notification: Notification, shardRange: ShardRange): Stream[IO, (String, Platform)] = {
           tokenPlatformStreamCount.incrementAndGet()
           tokenPlatformStream

--- a/registration/app/registration/services/NotificationRegistrar.scala
+++ b/registration/app/registration/services/NotificationRegistrar.scala
@@ -22,7 +22,6 @@ trait NotificationRegistrar {
   import NotificationRegistrar.RegistrarResponse
   val providerIdentifier: String
   def register(deviceToken: DeviceToken, registration: Registration): RegistrarResponse[RegistrationResponse]
-  def unregister(deviceToken: DeviceToken, platform: Platform): RegistrarResponse[Unit]
 }
 
 object NotificationRegistrar {

--- a/registration/test/registration/controllers/RegistrationsFixtures.scala
+++ b/registration/test/registration/controllers/RegistrationsFixtures.scala
@@ -37,10 +37,6 @@ trait DelayedRegistrationsBase extends RegistrationsBase {
         provider = Unknown
       ))
     }
-
-
-    override def unregister(deviceToken: DeviceToken, platform: Platform): RegistrarResponse[Unit] =
-      Future.successful(Right(()))
   }
 }
 
@@ -76,10 +72,6 @@ trait RegistrationsBase extends WithPlayApp with RegistrationsJson {
         provider = Unknown
       ))
     }
-
-
-    override def unregister(deviceToken: DeviceToken, platform: Platform): RegistrarResponse[Unit] =
-      Future.successful(Right(()))
 
   }
 


### PR DESCRIPTION
This is to cover the very unlikely case where a breaking news is sent while a device re-registers.

There is a short window (~60 ms) where a device is deleted from the database before being re-inserted. A selection during that window would be without the token of that device.

To solve that case I'm introducing transactions here, although I haven't been able to measure the impact on performance yet, and it's going to be hard to measure that impact without being in production.