### PR TITLE
Support notification tracking

### DIFF
--- a/common/src/main/scala/tracking/NotificationReportRepository.scala
+++ b/common/src/main/scala/tracking/NotificationReportRepository.scala
@@ -63,13 +63,13 @@ class NotificationReportRepository(client: AsyncDynamo, tableName: String)
 
     def fetch(
       startKey: Option[util.Map[String, AttributeValue]] = None,
-      lastList: RepositoryResult[List[NotificationReport]] = Right(Nil)
+      lastListResult: RepositoryResult[List[NotificationReport]] = Right(Nil)
     ): Future[RepositoryResult[List[NotificationReport]]] = {
       client.query(buildDynamoQuery(startKey)) flatMap { result =>
         val reports = for {
-          list1 <- lastList
-          list2 <- reportsFromResult(result)
-        } yield list1 ++ list2
+          lastList <- lastListResult
+          fetched <- reportsFromResult(result)
+        } yield lastList ++ fetched
         maybeStartKey(result) match {
           case None => Future.successful(reports)
           case Some(newStartKey) => fetch(Some(newStartKey), reports)

--- a/commoneventconsumer/src/main/scala/com/gu/notifications/events/model/PlatformCount.scala
+++ b/commoneventconsumer/src/main/scala/com/gu/notifications/events/model/PlatformCount.scala
@@ -5,7 +5,9 @@ import play.api.libs.json.Json
 case class PlatformCount(
   total: Int,
   ios: Int,
-  android: Int
+  android: Int,
+  iosEdition: Option[Int],
+  androidEdition: Option[Int]
 )
 
 


### PR DESCRIPTION
- Modify the SQL request to also count android-edition and ios-edition
- Add attributes to the platform counts
- refactor the method that fetches the reports such that if a report can't be parsed the error is bubbled up to the client