### PR TITLE
Make scheduled notification replaceable

### DIFF
--- a/notification/app/notification/controllers/Schedule.scala
+++ b/notification/app/notification/controllers/Schedule.scala
@@ -18,7 +18,7 @@ class Schedule(authAction: AuthAction, controllerComponents: ControllerComponent
     val notification = request.body
     val sevenDaysInSeconds = Duration.ofDays(7).getSeconds
     notificationSchedulePersistence.writeAsync(NotificationsScheduleEntry(
-      UUID.randomUUID().toString,
+      notification.id.toString,
       Json.prettyPrint(Json.toJson(notification)),
       date.toEpochSecond,
       date.toEpochSecond + sevenDaysInSeconds


### PR DESCRIPTION
This allow the editions team to fire a request with the same notification ID twice.

The scheduled notification will automatically be replaced in the dynamoDB (dynamo DB's default is to upsert rows)

Now there's an interesting case I haven't covered here:

- A notification is scheduled for 00:00
- The notification is sent at 00:01
- at 00:02 The same notification ID is re-scheduled for 00:04
- The notification will fail to be sent at 00:04 as it's bearing the same ID and the notification service protects against duplicate push notifications. Is this acceptable @sihil ?

In that case we'd get a bunch of alarms on our end telling us the schedule service failed to send the notification and the notification service encountered a 500. (In other we'll know if this is relevant but users will have missed their edition)