### PR TITLE
set ios title and message

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
@@ -84,8 +84,8 @@ class ApnsPayloadBuilder(config: ApnsConfig) {
   private def contentPayload(n: ContentNotification): ApnsPayload = {
     val link = toPlatformLink(n.link)
     val payLoad = PushyPayload(
-      alertTitle = None,
-      alertBody = n.title,
+      alertTitle = n.title,
+      alertBody = n.message,
       categoryName = Some("ITEM_CATEGORY"),
       mutableContent = true,
       sound = Some("default"),

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -181,7 +181,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
     val notification = models.ContentNotification(
       id = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
       `type` = NotificationType.Content,
-      title  = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"),
+      title  = Some("Following"),
       message = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"),
       iosUseMessage = None,
       thumbnailUrl = Some(new URI("https://media.guim.co.uk/633850064fba4941cdac17e8f6f8de97dd736029/24_0_1800_1080/500.jpg")),
@@ -197,6 +197,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |   "t":"m",
         |   "aps":{
         |      "alert":{
+        |         "title": "Following",
         |         "body":"French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"
         |      },
         |      "sound":"default",


### PR DESCRIPTION
Fixes the the kicker bug: Android seems to work fine.
Release at the same tiime as: https://github.com/guardian/mobile-notifications-content/pull/25