### PR TITLE
Force socket timeout to 30 seconds. 

### DIFF
--- a/common/src/main/scala/db/DatabaseConfig.scala
+++ b/common/src/main/scala/db/DatabaseConfig.scala
@@ -1,5 +1,6 @@
 package db
 
+import java.util.Properties
 import java.util.concurrent.Executors
 
 import cats.effect.internals.IOContextShift
@@ -38,6 +39,11 @@ object DatabaseConfig {
     hikariConfig.setJdbcUrl(config.url)
     hikariConfig.setUsername(config.user)
     hikariConfig.setPassword(config.password)
+
+    val dsProperties: Properties = new Properties()
+    dsProperties.setProperty("socketTimeout", "30")
+
+    hikariConfig.setDataSourceProperties(dsProperties)
     val dataSource = new HikariDataSource(hikariConfig)
 
     (Transactor.fromDataSource.apply(dataSource, connectEC, transactEC), dataSource)


### PR DESCRIPTION
This should dramatically improve RDS incident recovery.