### PR TITLE
Force socket timeout to 30 seconds. 

### DIFF
--- a/common/src/main/scala/db/DatabaseConfig.scala
+++ b/common/src/main/scala/db/DatabaseConfig.scala
@@ -39,11 +39,7 @@ object DatabaseConfig {
     hikariConfig.setJdbcUrl(config.url)
     hikariConfig.setUsername(config.user)
     hikariConfig.setPassword(config.password)
-
-    val dsProperties: Properties = new Properties()
-    dsProperties.setProperty("socketTimeout", "30")
-
-    hikariConfig.setDataSourceProperties(dsProperties)
+    hikariConfig.addDataSourceProperty("socketTimeout", "30")
     val dataSource = new HikariDataSource(hikariConfig)
 
     (Transactor.fromDataSource.apply(dataSource, connectEC, transactEC), dataSource)


### PR DESCRIPTION
This should help incident recovery.

This is a shorter version of the [previous change](https://github.com/guardian/mobile-n10n/pull/466) to make it nicer for the blog post.