### PR TITLE
Add the unique id of the notification to the edition payload

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
@@ -148,6 +148,7 @@ class ApnsPayloadBuilder(config: ApnsConfig) {
   private def editionsPayload(notification: EditionsNotification): ApnsPayload =
     ApnsPayload(PushyPayload(
       customProperties = Seq(
+        CustomProperty(Keys.UniqueIdentifier -> notification.id.toString),
         CustomProperty(Keys.EditionsDate -> notification.date),
         CustomProperty(Keys.EditionsKey -> notification.key),
         CustomProperty(Keys.EditionsName -> notification.name)

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -296,7 +296,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
 
   trait EditionsNotificationScope extends NotificationScope {
     val notification = models.EditionsNotification(
-      id = UUID.randomUUID(),
+      id = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
       topic = Nil,
       key = "aKey",
       name = "aName",
@@ -312,7 +312,8 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |   },
         |   "name": "aName",
         |   "date": "aDate",
-        |   "key": "aKey"
+        |   "key": "aKey",
+        |   "uniqueIdentifier":"068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"
         |}""".stripMargin
     )
   }


### PR DESCRIPTION
So that the daily edition app can properly track which notification has been received.