### PR TITLE
Extract editions

### DIFF
--- a/reportextractor/src/main/scala/com/gu/notifications/extractor/Lambda.scala
+++ b/reportextractor/src/main/scala/com/gu/notifications/extractor/Lambda.scala
@@ -61,7 +61,8 @@ class Lambda extends RequestHandler[DateRange, Unit] {
   val notificationTypesToExtract: List[NotificationType] = List(
     NotificationType.BreakingNews,
     NotificationType.Content,
-    NotificationType.FootballMatchStatus
+    NotificationType.FootballMatchStatus,
+    NotificationType.Editions
   )
 
   override def handleRequest(dateRange: DateRange, context: Context): Unit = {


### PR DESCRIPTION
I couldn't find the editions notification in the data lake, that would be why.

Once merged, I'll backdate the last two weeks of data.