### PR TITLE
Add more log if the future was rejected

### DIFF
--- a/notificationworkerlambda/src/main/resources/log4j2.xml
+++ b/notificationworkerlambda/src/main/resources/log4j2.xml
@@ -8,7 +8,10 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Logger name="com.turo.pushy.apns.ApnsClientHandler" level="TRACE">
+            <RegexFilter regex=".*Failed to write push notification on stream.*" onMatch="ACCEPT" onMismatch="DENY"/>
+        </Logger>
+        <Root level="INFO">
             <AppenderRef ref="Lambda"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
We're getting closer to understand the reason why Apple rejects some pushes.

I've narrowed it down to these [two lines](https://github.com/relayrides/pushy/blob/master/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java#L215-L216), but Pushy (or netty) later swallows the exception.

So I've added more debug, and a special logger to only trace that case and avoided polluting our logs too much