### PR TITLE
Implement an individual notification timeout

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/PushNotificationResponseListenerWithTimeout.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/PushNotificationResponseListenerWithTimeout.scala
@@ -1,0 +1,32 @@
+package com.gu.notifications.worker.delivery.apns
+
+import java.util.{Timer, TimerTask}
+
+import com.turo.pushy.apns.PushNotificationResponse
+import com.turo.pushy.apns.util.concurrent.{PushNotificationFuture, PushNotificationResponseListener}
+
+/**
+  * This is an attempt to confirm the hypothesis that sometimes notifications are sent to APNs but dropped on their side.
+  * It would mean pushy would never complete its future, leaving our code hanging forever.
+  * The primary goal of this class is to help us confirm if the hypothesis is correct.
+  */
+trait PushNotificationResponseListenerWithTimeout[A <: com.turo.pushy.apns.ApnsPushNotification] extends PushNotificationResponseListener[A] {
+
+  def timeout(): Unit
+  def operationCompleteWithoutTimeout(future: PushNotificationFuture[A, PushNotificationResponse[A]]): Unit
+
+  private val task = new TimerTask {
+    override def run(): Unit = {
+      timeout()
+    }
+  }
+
+  def startTimeout(timer: Timer, timeoutInMs: Long): Unit = {
+    timer.schedule(task, timeoutInMs)
+  }
+
+  override def operationComplete(future: PushNotificationFuture[A, PushNotificationResponse[A]]): Unit = {
+    task.cancel()
+    operationCompleteWithoutTimeout(future)
+  }
+}


### PR DESCRIPTION
While discussing with Frankie yesterday we put our finger onto something:

What if the timeouts we see at the lambda level were caused by APNs not responding for _some_ of the notifications? 
The cause could be a bug in Apple's service, or an unreliable network leading to one of the HTTP/2 channels to be hanging forever. This would mean the netty future would never complete, and therefore our lambda to timeout.

It seems pushy does not implement a per notification timeout: https://github.com/relayrides/pushy/issues/466 which means the hypothesis is at least valid. 

This PR is a fairly naive approach to implement one such timeout. I'm using Java's Timer api as when handling the netty Future we're closer to the imperative Java world than the pure plan of existence that Cats can reach.

We'll be able to confirm if the hypothesis is correct by checking the logs.