### PR TITLE
Add 'election' breaking news topic type to mobile notifications client

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/Topic.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/Topic.scala
@@ -35,6 +35,7 @@ object Topic {
   val BreakingNewsAu = Topic(Breaking, AU.toString)
   val BreakingNewsInternational = Topic(Breaking, International.toString)
   val BreakingNewsSport = Topic(Breaking, "sport")
+  val BreakingNewsElection = Topic(Breaking, "election")
   val BreakingNewsInternalTest = Topic(Breaking, "internal-test")
   val NewsstandIos = Topic(Newsstand, "newsstandIos")
 }

--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/Topic.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/Topic.scala
@@ -35,7 +35,7 @@ object Topic {
   val BreakingNewsAu = Topic(Breaking, AU.toString)
   val BreakingNewsInternational = Topic(Breaking, International.toString)
   val BreakingNewsSport = Topic(Breaking, "sport")
-  val BreakingNewsElection = Topic(Breaking, "election")
+  val BreakingNewsElection = Topic(Breaking, "uk-general-election")
   val BreakingNewsInternalTest = Topic(Breaking, "internal-test")
   val NewsstandIos = Topic(Newsstand, "newsstandIos")
 }


### PR DESCRIPTION
Adds a new election topic type to the mobile notifications client, for the benefit of notification emitters (e.g. https://github.com/guardian/facia-tool).