### PR TITLE
Set a default title for Android payload and pass a title to iOS payload

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilder.scala
@@ -59,7 +59,7 @@ class ApnsPayloadBuilder(config: ApnsConfig) {
     val link = toPlatformLink(n.link)
     val imageUrl = n.thumbnailUrl.orElse(n.imageUrl)
     val payload = PushyPayload(
-      alertTitle = None,
+      alertTitle = n.title,
       alertBody = n.message,
       categoryName = Option(n.link match {
         case _: Link.External => ""

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/models/payload/FcmPayloadBuilder.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/models/payload/FcmPayloadBuilder.scala
@@ -55,10 +55,10 @@ object FcmPayloadBuilder {
       .map(_.name)
       .collect(Edition.fromString)
 
-    val androidLink = toAndroidLink(breakingNews.link)
     val platformLink = toPlatformLink(breakingNews.link)
     val edition = if (editions.size == 1) Some(editions.head) else None
     val keyword = tagLink.map(new URI(_))
+    val title = breakingNews.title.getOrElse("The Guardian")
 
     FirebaseAndroidNotification(
       notificationId = breakingNews.id,
@@ -69,15 +69,15 @@ object FcmPayloadBuilder {
         Keys.Editions -> editions.mkString(","),
         Keys.Link -> toAndroidLink(breakingNews.link).toString,
         Keys.UriType -> platformLink.`type`,
-        Keys.Uri -> platformLink.uri
+        Keys.Uri -> platformLink.uri,
+        Keys.Title -> title,
       ) ++ sectionLink.map(new URI(_)).map(Keys.Section -> _.toString).toMap
         ++ edition.map(Keys.Edition -> _.toString).toMap
         ++ keyword.map(Keys.Keyword -> _.toString).toMap
         ++ breakingNews.imageUrl.map(Keys.ImageUrl -> _.toString).toMap
         ++ breakingNews.thumbnailUrl.map(Keys.ThumbnailUrl -> _.toString).toMap
         ++ breakingNews.message.map(Keys.Message -> _).toMap
-        ++ breakingNews.message.map(Keys.Ticker -> _).toMap
-        ++ breakingNews.title.map(Keys.Title -> _).toMap,
+        ++ breakingNews.message.map(Keys.Ticker -> _).toMap,
       ttl = BreakingNewsTtl
     )
   }

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -26,6 +26,9 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
     "generate correct payload for Breaking News notification with no image" in new BreakingNewsScopeNoImage {
       checkPayload()
     }
+    "generate correct payload for Breaking News notification with no title" in new BreakingNewsScopeNoTitle {
+      checkPayload()
+    }
     "generate correct payload for Content notification" in new ContentNotificationScope {
       checkPayload()
     }
@@ -68,7 +71,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
     val notification = models.BreakingNewsNotification(
       id = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
       `type` = NotificationType.BreakingNews,
-      title  = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"),
+      title  = Some("The Guardian"),
       message = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"),
       thumbnailUrl = Some(new URI("https://media.guim.co.uk/633850064fba4941cdac17e8f6f8de97dd736029/24_0_1800_1080/500.jpg")),
       sender = "matt.wells@guardian.co.uk",
@@ -84,7 +87,8 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |   "t":"m",
         |   "aps":{
         |      "alert":{
-        |         "body":"French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"
+        |         "body":"French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State",
+        |         "title":"The Guardian"
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
@@ -106,7 +110,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
     val notification = models.BreakingNewsNotification(
       id = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
       `type` = NotificationType.BreakingNews,
-      title  = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"),
+      title  = Some("The Guardian"),
       message = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"),
       thumbnailUrl = None,
       sender = "matt.wells@guardian.co.uk",
@@ -122,7 +126,8 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         |   "t":"m",
         |   "aps":{
         |      "alert":{
-        |         "body":"French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"
+        |         "body":"French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State",
+        |         "title":"The Guardian"
         |      },
         |      "sound":"default",
         |      "category":"ITEM_CATEGORY",
@@ -144,7 +149,45 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
     val notification = models.BreakingNewsNotification(
       id = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
       `type` = NotificationType.BreakingNews,
-      title  = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"),
+      title  = Some("The Guardian"),
+      message = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"),
+      thumbnailUrl = None,
+      sender = "matt.wells@guardian.co.uk",
+      link = Internal("world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray", Some("https://gu.com/p/4p7xt"), GITContent),
+      imageUrl = None,
+      importance = Major,
+      topic = List(Topic(Breaking, "uk"), Topic(Breaking, "us"), Topic(Breaking, "au"), Topic(Breaking, "international")),
+      dryRun = None
+    )
+
+    val expected = Some(
+      """{
+        |   "t":"m",
+        |   "aps":{
+        |      "alert":{
+        |         "body":"French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State",
+        |         "title":"The Guardian"
+        |      },
+        |      "sound":"default",
+        |      "category":"ITEM_CATEGORY",
+        |      "mutable-content":1
+        |   },
+        |   "provider":"Guardian",
+        |   "topics":"breaking/uk,breaking/us,breaking/au,breaking/international",
+        |   "uriType":"item",
+        |   "link":"https://mobile.guardianapis.com/items/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
+        |   "notificationType":"news",
+        |   "uri":"https://www.theguardian.com/world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
+        |   "uniqueIdentifier":"068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"
+        |}""".stripMargin
+    )
+  }
+
+  trait BreakingNewsScopeNoTitle extends NotificationScope {
+    val notification = models.BreakingNewsNotification(
+      id = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
+      `type` = NotificationType.BreakingNews,
+      title  = None,
       message = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"),
       thumbnailUrl = None,
       sender = "matt.wells@guardian.co.uk",

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/fcm/models/payload/FcmPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/fcm/models/payload/FcmPayloadBuilderSpec.scala
@@ -19,6 +19,9 @@ class FcmPayloadBuilderSpec extends Specification with Matchers {
     "generate correct data for Breaking News notification" in new BreakingNewsScope {
       check()
     }
+    "generate correct data for Breaking News notification with no title" in new BreakingNewsScopeNoTitle {
+      check()
+    }
     "generate correct data for Content notification" in new ContentNotificationScope {
       check()
     }
@@ -58,6 +61,42 @@ class FcmPayloadBuilderSpec extends Specification with Matchers {
           Keys.NotificationType -> "news",
           Keys.Type -> "custom",
           Keys.Title -> "Test notification",
+          Keys.Ticker -> "The message",
+          Keys.Message -> "The message",
+          Keys.Debug -> "true",
+          Keys.Editions -> "uk",
+          Keys.Link -> "x-gu://www.guardian.co.uk/some/capi/id",
+          Keys.UriType -> "item",
+          Keys.Uri -> "x-gu:///items/some/capi/id",
+          Keys.Edition -> "uk",
+          Keys.ImageUrl -> "https://invalid.url/img.png",
+          Keys.ThumbnailUrl -> "https://invalid.url/img.png"
+        ),
+        ttl = TimeToLive.BreakingNewsTtl      )
+    )
+  }
+
+  trait BreakingNewsScopeNoTitle extends NotificationScope {
+    val notification = models.BreakingNewsNotification(
+      id = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
+      title = None,
+      message = Some("The message"),
+      thumbnailUrl = Some(new URI("https://invalid.url/img.png")),
+      sender = "UnitTests",
+      link = Internal("some/capi/id", None, GITContent),
+      imageUrl = Some(new URI("https://invalid.url/img.png")),
+      importance = Major,
+      topic = List(Topic(`type` = Breaking, name = "uk")),
+      dryRun = None
+    )
+
+    val expected = Some(
+      FirebaseAndroidNotification(
+        notificationId = UUID.fromString("4c261110-4672-4451-a5b8-3422c6839c42"),
+        data = Map(
+          Keys.NotificationType -> "news",
+          Keys.Type -> "custom",
+          Keys.Title -> "The Guardian",
           Keys.Ticker -> "The message",
           Keys.Message -> "The message",
           Keys.Debug -> "true",


### PR DESCRIPTION
iOS notification should never have "The Guardian" as a default title. We now pass whatever title is received, but set a default for Android.