### PR TITLE
MSS-1344: Fix jackson vulnerabilites and bump dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,10 +27,9 @@ val minJacksonLibs = Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % minJacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % minJacksonVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % minJacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind" % minJacksonVersion,
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % minJacksonVersion
 )
-
-val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.1"
-val jacksonDatatype = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.10.1"
 
 val playJsonVersion = "2.6.14"
 val specsVersion: String = "4.0.3"
@@ -65,9 +64,8 @@ lazy val commoneventconsumer = project
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "org.specs2" %% "specs2-core" % specsVersion % "test",
-      jacksonDatabind,
-      jacksonDatatype
-    )
+    ),
+    libraryDependencies ++= minJacksonLibs,
   ))
 
 lazy val commontest = project
@@ -75,9 +73,8 @@ lazy val commontest = project
     libraryDependencies ++= Seq(
       specs2,
       playCore,
-      jacksonDatabind,
-      jacksonDatatype
-    )
+    ),
+    libraryDependencies ++= minJacksonLibs,
   ))
 
 
@@ -107,8 +104,6 @@ lazy val common = project
       "com.gu" %% "mobile-logstash-encoder" % "1.0.2"
     ),
     libraryDependencies ++= minJacksonLibs,
-    libraryDependencies += jacksonDatabind,
-    libraryDependencies += jacksonDatatype,
     fork := true,
     startDynamoDBLocal := startDynamoDBLocal.dependsOn(compile in Test).value,
     test in Test := (test in Test).dependsOn(startDynamoDBLocal).value,
@@ -128,7 +123,6 @@ lazy val commonscheduledynamodb = project
 
     ),
     libraryDependencies ++= minJacksonLibs,
-    libraryDependencies += jacksonDatabind,
     test in Test := (test in Test).dependsOn(startDynamoDBLocal).value,
     testOnly in Test := (testOnly in Test).dependsOn(startDynamoDBLocal).evaluated,
     testQuick in Test := (testQuick in Test).dependsOn(startDynamoDBLocal).evaluated,
@@ -213,9 +207,8 @@ lazy val apiModels = {
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "org.specs2" %% "specs2-core" % specsVersion % "test",
       "org.specs2" %% "specs2-mock" % specsVersion % "test",
-      jacksonDatabind,
-      jacksonDatatype
     ),
+    libraryDependencies ++= minJacksonLibs,
     organization := "com.gu",
     bintrayOrganization := Some("guardian"),
     bintrayRepository := "mobile",
@@ -310,8 +303,8 @@ lazy val eventconsumer = lambda("eventconsumer", "eventconsumer", Some("com.gu.n
         "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
         "com.amazonaws" % "aws-java-sdk-athena" % awsSdkVersion,
         "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
-        jacksonDatabind
       ),
+      libraryDependencies ++= minJacksonLibs,
       riffRaffArtifactResources += ((baseDirectory.value / "cfn.yaml"), s"${name.value}-cfn/cfn.yaml")
     )
   })

--- a/build.sbt
+++ b/build.sbt
@@ -25,14 +25,16 @@ scalacOptions in ThisBuild ++= compilerOptions
 val minJacksonVersion: String = "2.8.9"
 val minJacksonLibs = Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % minJacksonVersion,
-  "com.fasterxml.jackson.core" % "jackson-databind" % minJacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % minJacksonVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % minJacksonVersion
 )
 
-val playJsonVersion = "2.6.9"
+val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.1"
+val jacksonDatatype = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8"
+
+val playJsonVersion = "2.6.14"
 val specsVersion: String = "4.0.3"
-val awsSdkVersion: String = "1.11.433"
+val awsSdkVersion: String = "1.11.692"
 val doobieVersion: String = "0.6.0"
 val catsVersion: String = "1.4.0"
 val simpleConfigurationVersion: String = "1.5.0"
@@ -62,7 +64,9 @@ lazy val commoneventconsumer = project
   .settings(Seq(
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-json" % playJsonVersion,
-      "org.specs2" %% "specs2-core" % specsVersion % "test"
+      "org.specs2" %% "specs2-core" % specsVersion % "test",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.1",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8"
     )
   ))
 
@@ -70,7 +74,9 @@ lazy val commontest = project
   .settings(Seq(
     libraryDependencies ++= Seq(
       specs2,
-      playCore
+      playCore,
+      jacksonDatabind,
+      jacksonDatatype
     )
   ))
 
@@ -101,6 +107,8 @@ lazy val common = project
       "com.gu" %% "mobile-logstash-encoder" % "1.0.2"
     ),
     libraryDependencies ++= minJacksonLibs,
+    libraryDependencies += jacksonDatabind,
+    libraryDependencies += jacksonDatatype,
     fork := true,
     startDynamoDBLocal := startDynamoDBLocal.dependsOn(compile in Test).value,
     test in Test := (test in Test).dependsOn(startDynamoDBLocal).value,
@@ -120,6 +128,7 @@ lazy val commonscheduledynamodb = project
 
     ),
     libraryDependencies ++= minJacksonLibs,
+    libraryDependencies += jacksonDatabind,
     test in Test := (test in Test).dependsOn(startDynamoDBLocal).value,
     testOnly in Test := (testOnly in Test).dependsOn(startDynamoDBLocal).evaluated,
     testQuick in Test := (testQuick in Test).dependsOn(startDynamoDBLocal).evaluated,
@@ -203,7 +212,9 @@ lazy val apiModels = {
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "org.specs2" %% "specs2-core" % specsVersion % "test",
-      "org.specs2" %% "specs2-mock" % specsVersion % "test"
+      "org.specs2" %% "specs2-mock" % specsVersion % "test",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.1",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8"
     ),
     organization := "com.gu",
     bintrayOrganization := Some("guardian"),
@@ -298,7 +309,8 @@ lazy val eventconsumer = lambda("eventconsumer", "eventconsumer", Some("com.gu.n
         "com.typesafe.play" %% "play-json" % playJsonVersion,
         "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
         "com.amazonaws" % "aws-java-sdk-athena" % awsSdkVersion,
-        "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0"
+        "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
+        "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.1"
       ),
       riffRaffArtifactResources += ((baseDirectory.value / "cfn.yaml"), s"${name.value}-cfn/cfn.yaml")
     )

--- a/build.sbt
+++ b/build.sbt
@@ -22,15 +22,15 @@ val compilerOptions = Seq(
 
 scalacOptions in ThisBuild ++= compilerOptions
 
-val minJacksonVersion: String = "2.8.9"
+val minJacksonVersion: String = "2.10.1"
 val minJacksonLibs = Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % minJacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % minJacksonVersion,
-  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % minJacksonVersion
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % minJacksonVersion,
 )
 
-val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.1"
-val jacksonDatatype = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8"
+val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.1"
+val jacksonDatatype = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.10.1"
 
 val playJsonVersion = "2.6.14"
 val specsVersion: String = "4.0.3"
@@ -65,8 +65,8 @@ lazy val commoneventconsumer = project
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "org.specs2" %% "specs2-core" % specsVersion % "test",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.1",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8"
+      jacksonDatabind,
+      jacksonDatatype
     )
   ))
 
@@ -213,8 +213,8 @@ lazy val apiModels = {
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "org.specs2" %% "specs2-core" % specsVersion % "test",
       "org.specs2" %% "specs2-mock" % specsVersion % "test",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.1",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8"
+      jacksonDatabind,
+      jacksonDatatype
     ),
     organization := "com.gu",
     bintrayOrganization := Some("guardian"),
@@ -310,7 +310,7 @@ lazy val eventconsumer = lambda("eventconsumer", "eventconsumer", Some("com.gu.n
         "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
         "com.amazonaws" % "aws-java-sdk-athena" % awsSdkVersion,
         "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
-        "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.1"
+        jacksonDatabind
       ),
       riffRaffArtifactResources += ((baseDirectory.value / "cfn.yaml"), s"${name.value}-cfn/cfn.yaml")
     )


### PR DESCRIPTION
Force jackson-databind and jackson-datatype versions to fix some vulnerability issues:
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONDATATYPE-173759
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-174736

NB: remove after upgrading play app to 2.7 (if we should ever do this)