### PR TITLE
Re-write lambda to cleanup expired registrations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -326,7 +326,8 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
     riffRaffArtifactResources += (baseDirectory.value / "sender-worker-cfn.yaml", s"ios-edition-notification-worker-cfn/sender-worker-cfn.yaml"),
     riffRaffArtifactResources += (baseDirectory.value / "sender-worker-cfn.yaml", s"android-edition-notification-worker-cfn/sender-worker-cfn.yaml"),
     riffRaffArtifactResources += (baseDirectory.value / "registration-cleaning-worker-cfn.yaml", s"registration-cleaning-worker-cfn/registration-cleaning-worker-cfn.yaml"),
-    riffRaffArtifactResources += (baseDirectory.value / "topic-counter-cfn.yaml", s"topic-counter-cfn/topic-counter-cfn.yaml")
+    riffRaffArtifactResources += (baseDirectory.value / "topic-counter-cfn.yaml", s"topic-counter-cfn/topic-counter-cfn.yaml"),
+    riffRaffArtifactResources += (baseDirectory.value / "expired-registration-cleaner-cfn.yaml", s"expired-registration-cleaner-cfn/expired-registration-cleaner-cfn.yaml")
   )
 
 lazy val fakebreakingnewslambda = lambda("fakebreakingnewslambda", "fakebreakingnewslambda", Some("fakebreakingnews.LocalRun"))

--- a/common/src/main/scala/db/RegistrationRepository.scala
+++ b/common/src/main/scala/db/RegistrationRepository.scala
@@ -10,5 +10,6 @@ trait RegistrationRepository[F[_], S[_[_], _]] {
   def insert(reg: Registration): ConnectionIO[Int]
   def delete(sub: Registration): ConnectionIO[Int]
   def deleteByToken(token: String): ConnectionIO[Int]
+  def deleteByDate(olderThanDays: Int): ConnectionIO[Int]
   def topicCounts(countsThreshold: Int): S[F, TopicCount]
 }

--- a/common/src/main/scala/db/RegistrationService.scala
+++ b/common/src/main/scala/db/RegistrationService.scala
@@ -36,6 +36,9 @@ class RegistrationService[F[_]: Async, S[_[_], _]](repository: RegistrationRepos
     repository.delete(registration).transact(xa)
   }
 
+  def deleteByDate(olderThanDays: Int): F[Int] =
+    repository.deleteByDate(olderThanDays).transact(xa)
+
   def removeAllByToken(token: String): F[Int] = {
     repository.deleteByToken(token).transact(xa)
   }

--- a/common/src/main/scala/db/SqlRegistrationRepository.scala
+++ b/common/src/main/scala/db/SqlRegistrationRepository.scala
@@ -41,6 +41,13 @@ class SqlRegistrationRepository[F[_]: Async](xa: Transactor[F])
     .update.run
   }
 
+
+  override def deleteByDate(olderThanDays: Int): ConnectionIO[Int] = {
+    sql"""
+      delete from registrations.registrations where lastmodified <= now() - make_interval(days => $olderThanDays);
+    """.update.run
+  }
+
   def insert(reg: Registration): ConnectionIO[Int] =
     sql"""
         INSERT INTO registrations (token, platform, topic, shard, lastModified)

--- a/notificationworkerlambda/expired-registration-cleaner-cfn.yaml
+++ b/notificationworkerlambda/expired-registration-cleaner-cfn.yaml
@@ -1,0 +1,112 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Cleans the database of outdated tokens regularly
+Parameters:
+  Stack:
+    Description: Stack name
+    Type: String
+    Default: mobile-notifications
+  App:
+    Description: Application name
+    Type: String
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+      - CODE
+      - PROD
+    Default: CODE
+  DeployBucket:
+    Description: Bucket where RiffRaff uploads artifacts on deploy
+    Type: String
+  VpcSubnets:
+    Description: Subnets to use in the VPC
+    Type: List<AWS::EC2::Subnet::Id>
+  VPCSecurityGroup:
+    Type: AWS::EC2::SecurityGroup::Id
+    Description: The default security group of the VPC
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: logs
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+              Resource: arn:aws:logs:*:*:*
+        - PolicyName: lambda
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - lambda:InvokeFunction
+              Resource: "*"
+        - PolicyName: Conf
+          PolicyDocument:
+            Statement:
+              Action:
+                - ssm:GetParametersByPath
+              Effect: Allow
+              Resource:
+                !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/notifications/${Stage}/workers/cleaner
+        - PolicyName: VPC
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - ec2:CreateNetworkInterface
+                - ec2:DescribeNetworkInterfaces
+                - ec2:DeleteNetworkInterface
+              Resource: "*"
+  Lambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub ${Stack}-${App}-${Stage}
+      Code:
+        S3Bucket:
+          Ref: DeployBucket
+        S3Key: !Sub ${Stack}/${Stage}/notificationworkerlambda/notificationworkerlambda.jar
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Stack: !Ref Stack
+          App: !Ref App
+      Description: Cleans the database of outdated tokens regularly
+      Handler: com.gu.notifications.worker.ExpiredRegistrationCleaner::handleRequest
+      MemorySize: 512
+      Role: !GetAtt ExecutionRole.Arn
+      Runtime: java8
+      Timeout: 60
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref VPCSecurityGroup
+        SubnetIds: !Ref VpcSubnets
+
+  DailyEvent:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Event sent to process the previous day of data
+      ScheduleExpression: cron(4 23 * * ? *)
+      Targets:
+        - Id: Lambda
+          Arn: !GetAtt Lambda.Arn
+
+  DailyEventLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt Lambda.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt DailyEvent.Arn

--- a/notificationworkerlambda/expired-registration-cleaner-cfn.yaml
+++ b/notificationworkerlambda/expired-registration-cleaner-cfn.yaml
@@ -84,7 +84,7 @@ Resources:
           Stack: !Ref Stack
           App: !Ref App
       Description: Cleans the database of outdated tokens regularly
-      Handler: com.gu.notifications.worker.ExpiredRegistrationCleaner::handleRequest
+      Handler: com.gu.notifications.worker.ExpiredRegistrationCleanerLambda::handleRequest
       MemorySize: 512
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8

--- a/notificationworkerlambda/riff-raff.yaml
+++ b/notificationworkerlambda/riff-raff.yaml
@@ -15,6 +15,7 @@ deployments:
         - registration-cleaning-worker-
         - topic-counter-
         - mobile-notifications-harvester-
+        - expired-registration-cleaner-
       fileName: notificationworkerlambda.jar
       prefixStack: false
     dependencies:
@@ -25,6 +26,7 @@ deployments:
       - registration-cleaning-worker-cfn
       - topic-counter-cfn
       - harvester-cfn
+      - expired-registration-cleaner-cfn
   harvester-cfn:
     type: cloud-formation
     app: harvester
@@ -72,4 +74,11 @@ deployments:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: topic-counter-cfn
       templatePath: topic-counter-cfn.yaml
+  expired-registration-cleaner-cfn:
+    type: cloud-formation
+    app: expired-registration-cleaner
+    parameters:
+      prependStackToCloudFormationStackName: false
+      cloudFormationStackName: expired-registration-cleaner-cfn
+      templatePath: expired-registration-cleaner-cfn.yaml
 

--- a/notificationworkerlambda/riff-raff.yaml
+++ b/notificationworkerlambda/riff-raff.yaml
@@ -15,7 +15,7 @@ deployments:
         - registration-cleaning-worker-
         - topic-counter-
         - mobile-notifications-harvester-
-        - expired-registration-cleaner-
+        - mobile-notifications-expired-registration-cleaner-
       fileName: notificationworkerlambda.jar
       prefixStack: false
     dependencies:

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/ExpiredRegistrationCleaner.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/ExpiredRegistrationCleaner.scala
@@ -3,11 +3,24 @@ package com.gu.notifications.worker
 import com.gu.notifications.worker.utils.Logging
 import org.slf4j.{Logger, LoggerFactory}
 
-class ExpiredRegistrationCleanerLambda extends Logging {
-
+class ExpiredRegistrationCleaner {
   def logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  def handleRequest(): Unit = {
+  def clean(): Unit = {
     logger.info("Hello")
+  }
+}
+
+class ExpiredRegistrationCleanerLambda {
+  def handleRequest(): Unit = {
+    val cleaner = new ExpiredRegistrationCleaner
+    cleaner.clean()
+  }
+}
+
+object ExpiredRegistrationCleanerLocalRun {
+  def main(args: Array[String]): Unit = {
+    val cleaner = new ExpiredRegistrationCleaner
+    cleaner.clean()
   }
 }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/ExpiredRegistrationCleaner.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/ExpiredRegistrationCleaner.scala
@@ -1,0 +1,13 @@
+package com.gu.notifications.worker
+
+import com.gu.notifications.worker.utils.Logging
+import org.slf4j.{Logger, LoggerFactory}
+
+class ExpiredRegistrationCleaner extends Logging {
+
+  def logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  def handleRequest(): Unit = {
+    logger.info("Hello")
+  }
+}

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/ExpiredRegistrationCleaner.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/ExpiredRegistrationCleaner.scala
@@ -1,7 +1,13 @@
 package com.gu.notifications.worker
 
-import com.gu.notifications.worker.utils.Logging
+import cats.effect.{ContextShift, IO}
+import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.gu.notifications.worker.utils.Aws
+import db.DatabaseConfig
+import doobie.util.transactor.Transactor
 import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 class ExpiredRegistrationCleaner {
   def logger: Logger = LoggerFactory.getLogger(this.getClass)
@@ -12,6 +18,16 @@ class ExpiredRegistrationCleaner {
 }
 
 class ExpiredRegistrationCleanerLambda {
+  def env = Env()
+
+  lazy val credentials: AWSCredentialsProviderChain = Aws.credentialsProvider
+
+  implicit val ec: ExecutionContextExecutor = ExecutionContext.global
+  implicit val ioContextShift: ContextShift[IO] = IO.contextShift(ec)
+
+  val config: CleanerConfiguration = Configuration.fetchCleaner()
+  val transactor: Transactor[IO] = DatabaseConfig.transactor[IO](config.jdbcConfig)
+
   def handleRequest(): Unit = {
     val cleaner = new ExpiredRegistrationCleaner
     cleaner.clean()
@@ -20,7 +36,7 @@ class ExpiredRegistrationCleanerLambda {
 
 object ExpiredRegistrationCleanerLocalRun {
   def main(args: Array[String]): Unit = {
-    val cleaner = new ExpiredRegistrationCleaner
-    cleaner.clean()
+    val cleaner = new ExpiredRegistrationCleanerLambda
+    cleaner.handleRequest()
   }
 }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/ExpiredRegistrationCleaner.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/ExpiredRegistrationCleaner.scala
@@ -1,8 +1,6 @@
 package com.gu.notifications.worker
 
 import cats.effect.{ContextShift, IO}
-import com.amazonaws.auth.AWSCredentialsProviderChain
-import com.gu.notifications.worker.utils.Aws
 import db.{DatabaseConfig, RegistrationService}
 import doobie.util.transactor.Transactor
 import org.slf4j.{Logger, LoggerFactory}
@@ -11,9 +9,6 @@ import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 class ExpiredRegistrationCleanerLambda {
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  def env = Env()
-
-  lazy val credentials: AWSCredentialsProviderChain = Aws.credentialsProvider
 
   implicit val ec: ExecutionContextExecutor = ExecutionContext.global
   implicit val ioContextShift: ContextShift[IO] = IO.contextShift(ec)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/ExpiredRegistrationCleaner.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/ExpiredRegistrationCleaner.scala
@@ -3,7 +3,7 @@ package com.gu.notifications.worker
 import com.gu.notifications.worker.utils.Logging
 import org.slf4j.{Logger, LoggerFactory}
 
-class ExpiredRegistrationCleaner extends Logging {
+class ExpiredRegistrationCleanerLambda extends Logging {
 
   def logger: Logger = LoggerFactory.getLogger(this.getClass)
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/ExpiredRegistrationCleaner.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/ExpiredRegistrationCleaner.scala
@@ -9,14 +9,6 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
-class ExpiredRegistrationCleaner {
-  def logger: Logger = LoggerFactory.getLogger(this.getClass)
-
-  def clean(): Unit = {
-    logger.info("Hello")
-  }
-}
-
 class ExpiredRegistrationCleanerLambda {
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
   def env = Env()


### PR DESCRIPTION
This replaces the lambda written in Rust that didn't work.

The lambda connects to the database to run a single query to cleanup older registrations