### PR TITLE
Deploy a new android beta worker

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -325,6 +325,7 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
     riffRaffArtifactResources += (baseDirectory.value / "sender-worker-cfn.yaml", s"android-notification-worker-cfn/sender-worker-cfn.yaml"),
     riffRaffArtifactResources += (baseDirectory.value / "sender-worker-cfn.yaml", s"ios-edition-notification-worker-cfn/sender-worker-cfn.yaml"),
     riffRaffArtifactResources += (baseDirectory.value / "sender-worker-cfn.yaml", s"android-edition-notification-worker-cfn/sender-worker-cfn.yaml"),
+    riffRaffArtifactResources += (baseDirectory.value / "sender-worker-cfn.yaml", s"android-beta-notification-worker-cfn/sender-worker-cfn.yaml"),
     riffRaffArtifactResources += (baseDirectory.value / "registration-cleaning-worker-cfn.yaml", s"registration-cleaning-worker-cfn/registration-cleaning-worker-cfn.yaml"),
     riffRaffArtifactResources += (baseDirectory.value / "topic-counter-cfn.yaml", s"topic-counter-cfn/topic-counter-cfn.yaml"),
     riffRaffArtifactResources += (baseDirectory.value / "expired-registration-cleaner-cfn.yaml", s"expired-registration-cleaner-cfn/expired-registration-cleaner-cfn.yaml")

--- a/notificationworkerlambda/riff-raff.yaml
+++ b/notificationworkerlambda/riff-raff.yaml
@@ -11,6 +11,7 @@ deployments:
         - ios-notification-worker-sender-
         - android-notification-worker-sender-
         - ios-edition-notification-worker-sender-
+        - android-beta-notification-worker-sender-
         - android-edition-notification-worker-sender-
         - registration-cleaning-worker-
         - topic-counter-
@@ -22,6 +23,7 @@ deployments:
       - ios-notification-worker-cfn
       - android-notification-worker-cfn
       - ios-edition-notification-worker-cfn
+      - android-beta-notification-worker-cfn
       - android-edition-notification-worker-cfn
       - registration-cleaning-worker-cfn
       - topic-counter-cfn
@@ -59,6 +61,13 @@ deployments:
     parameters:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: android-edition-notification-worker-cfn
+      templatePath: sender-worker-cfn.yaml
+  android-beta-notification-worker-cfn:
+    type: cloud-formation
+    app: android-beta-notification-worker
+    parameters:
+      prependStackToCloudFormationStackName: false
+      cloudFormationStackName: android-beta-notification-worker-cfn
       templatePath: sender-worker-cfn.yaml
   registration-cleaning-worker-cfn:
     type: cloud-formation

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -40,6 +40,9 @@ Parameters:
   SenderTooFewInvocationsAlarmPeriod:
     Type: String
     Description: How long until no execution is suspicious, in seconds
+  ReservedConcurrency:
+    Type: String
+    Description: How many concurrent execution to provision the lamdba with
 
 Conditions:
   IsProdStage: !Equals [!Ref Stage, PROD]
@@ -146,7 +149,7 @@ Resources:
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 90
-      ReservedConcurrentExecutions: 1000
+      ReservedConcurrentExecutions: !Ref ReservedConcurrency
       Tags:
         - Key: Stage
           Value: !Ref Stage

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -33,6 +33,7 @@ Parameters:
     Description: The platform handled by this worker
     AllowedValues:
       - android
+      - android-beta
       - ios
       - android-edition
       - ios-edition
@@ -58,7 +59,7 @@ Resources:
   SenderSqs:
     Type: AWS::SQS::Queue
     Properties:
-      VisibilityTimeout: 45
+      VisibilityTimeout: 100
       MessageRetentionPeriod: 3600 # 1 hour
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt SenderDlq.Arn


### PR DESCRIPTION
To help the firebase migration we need to deploy a new set of SQS/Lambda specifically for the android beta population

- Add a new platform for the android beta population
- Fix the `VisibilityTimeout` to be higher than the lambda `Timeout`
- I created the stack in CODE and PROD