### PR TITLE
Add mismatched-credential to invalid tokens

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -27,9 +27,10 @@ class FcmClient private (firebaseMessaging: FirebaseMessaging, firebaseApp: Fire
   type Payload = FcmPayload
   val dryRun = config.dryRun
 
-  private val invalidTokenErrorCodes = Seq(
+  private val invalidTokenErrorCodes = Set(
     "invalid-registration-token",
-    "registration-token-not-registered"
+    "registration-token-not-registered",
+    "mismatched-credential"
   )
 
   def close(): Unit = firebaseApp.delete()


### PR DESCRIPTION
Add `mismatched-credential` error message to invalid tokens so they are deleted from the DB.

Tested on CODE