### PR TITLE
Adding a version check to the registration service

### DIFF
--- a/common/src/main/scala/db/Registration.scala
+++ b/common/src/main/scala/db/Registration.scala
@@ -55,20 +55,20 @@ object BuildTier extends Enumeration {
 
   def fromString(s: String): Option[BuildTier] = values.find(_.toString == s)
 
-  def versionAboveOrEqual(appVersion: Option[String], targetBuild: Int): Boolean = appVersion match {
-    case None => false
+  def versionBefore(appVersion: Option[String], targetBuild: Int): Boolean = appVersion match {
+    case None => true
     case Some(versionString) =>
       versionString
         .split("\\.")
         .lastOption
         .flatMap(build => Try(build.toInt).toOption)
-        .exists( _ >= targetBuild)
+        .exists( _ < targetBuild)
   }
 
   def chooseTier(buildTier: Option[String], platform: Platform, appVersion: Option[String]): Option[BuildTier] = {
     buildTier.flatMap { tier =>
       val tierFromClient = BuildTier.fromString(tier)
-      if (tierFromClient.contains(BETA) && platform == Android && versionAboveOrEqual(appVersion, 10000)) { //This case is a temporary lie to cope with the Android Firebase migration; it should be removed with https://theguardian.atlassian.net/browse/MSS-1392
+      if (tierFromClient.contains(BETA) && platform == Android && versionBefore(appVersion, 10000)) { //This case is a temporary lie to cope with the Android Firebase migration; it should be removed with https://theguardian.atlassian.net/browse/MSS-1392
         Some(RELEASE)
       } else {
         tierFromClient

--- a/common/src/main/scala/db/Registration.scala
+++ b/common/src/main/scala/db/Registration.scala
@@ -9,6 +9,8 @@ import db.BuildTier.BuildTier
 import doobie.util.Meta
 import models.{Android, DeviceToken, Platform}
 
+import scala.util.Try
+
 object Registration {
   implicit val PlatformMeta: Meta[Platform] =
     Meta[String].timap(
@@ -53,10 +55,20 @@ object BuildTier extends Enumeration {
 
   def fromString(s: String): Option[BuildTier] = values.find(_.toString == s)
 
+  def versionAboveOrEqual(appVersion: Option[String], targetBuild: Int): Boolean = appVersion match {
+    case None => false
+    case Some(versionString) =>
+      versionString
+        .split("\\.")
+        .lastOption
+        .flatMap(build => Try(build.toInt).toOption)
+        .exists( _ >= targetBuild)
+  }
+
   def chooseTier(buildTier: Option[String], platform: Platform, appVersion: Option[String]): Option[BuildTier] = {
     buildTier.flatMap { tier =>
       val tierFromClient = BuildTier.fromString(tier)
-      if (tierFromClient.contains(BETA) && platform == Android && appVersion.isEmpty) { //This case is a temporary lie to cope with the Android Firebase migration; it should be removed with https://theguardian.atlassian.net/browse/MSS-1392
+      if (tierFromClient.contains(BETA) && platform == Android && versionAboveOrEqual(appVersion, 10000)) { //This case is a temporary lie to cope with the Android Firebase migration; it should be removed with https://theguardian.atlassian.net/browse/MSS-1392
         Some(RELEASE)
       } else {
         tierFromClient

--- a/common/src/test/scala/db/VersionSpec.scala
+++ b/common/src/test/scala/db/VersionSpec.scala
@@ -1,0 +1,21 @@
+package db
+
+import org.specs2.mutable.Specification
+
+class VersionSpec extends Specification {
+  "db.BuildTier.versionAboveOrEqual" should {
+    "return false when the client sends no appVersion" in {
+      BuildTier.versionAboveOrEqual(None, 2000) should beFalse
+    }
+    "return false if the build version is bellow" in {
+      BuildTier.versionAboveOrEqual(Some("6.40.1999"), 2000) should beFalse
+    }
+    "return true if the build version is equal or above" in {
+      BuildTier.versionAboveOrEqual(Some("6.40.2000"), 2000) should beTrue
+      BuildTier.versionAboveOrEqual(Some("6.40.2001"), 2000) should beTrue
+    }
+    "return false if the build number can't be parsed" in {
+      BuildTier.versionAboveOrEqual(Some("6.40.2000-beta"), 2000) should beFalse
+    }
+  }
+}

--- a/common/src/test/scala/db/VersionSpec.scala
+++ b/common/src/test/scala/db/VersionSpec.scala
@@ -5,17 +5,17 @@ import org.specs2.mutable.Specification
 class VersionSpec extends Specification {
   "db.BuildTier.versionAboveOrEqual" should {
     "return false when the client sends no appVersion" in {
-      BuildTier.versionAboveOrEqual(None, 2000) should beFalse
+      BuildTier.versionBefore(None, 2000) should beTrue
     }
-    "return false if the build version is bellow" in {
-      BuildTier.versionAboveOrEqual(Some("6.40.1999"), 2000) should beFalse
+    "return false if the build version is equal or greater" in {
+      BuildTier.versionBefore(Some("6.40.2001"), 2000) should beFalse
+      BuildTier.versionBefore(Some("6.40.2000"), 2000) should beFalse
     }
-    "return true if the build version is equal or above" in {
-      BuildTier.versionAboveOrEqual(Some("6.40.2000"), 2000) should beTrue
-      BuildTier.versionAboveOrEqual(Some("6.40.2001"), 2000) should beTrue
+    "return true if the build version is lower" in {
+      BuildTier.versionBefore(Some("6.40.1999"), 2000) should beTrue
     }
     "return false if the build number can't be parsed" in {
-      BuildTier.versionAboveOrEqual(Some("6.40.2000-beta"), 2000) should beFalse
+      BuildTier.versionBefore(Some("6.40.2000-beta"), 2000) should beFalse
     }
   }
 }

--- a/common/src/test/scala/db/VersionSpec.scala
+++ b/common/src/test/scala/db/VersionSpec.scala
@@ -3,8 +3,8 @@ package db
 import org.specs2.mutable.Specification
 
 class VersionSpec extends Specification {
-  "db.BuildTier.versionAboveOrEqual" should {
-    "return false when the client sends no appVersion" in {
+  "db.BuildTier.versionBefore" should {
+    "return true when the client sends no appVersion" in {
       BuildTier.versionBefore(None, 2000) should beTrue
     }
     "return false if the build version is equal or greater" in {

--- a/registration/test/registration/db/BuildTierSpec.scala
+++ b/registration/test/registration/db/BuildTierSpec.scala
@@ -15,7 +15,7 @@ class BuildTierSpec extends Specification {
     }
 
     "Mark an Android beta build which includes an app version as a beta build" in {
-      val result = BuildTier.chooseTier(Some("BETA"), Android, Some("3000"))
+      val result = BuildTier.chooseTier(Some("BETA"), Android, Some("6.40.12000"))
       result.contains(BuildTier.BETA)
     }
 


### PR DESCRIPTION
Context: this is related to our ongoing problem with our beta users on Android. This should mitigate the issue in the immediate future, and provide a solution once the new beta is released.

All app version bellow build 10000 will be put into the PROD bucket. 

cc @mohammad-haque for your information.

We'll merge that first to put everyone in the PROD bucket, then we'll raise another PR with the correct build number once you've released or are about to release