### PR TITLE
Reinstate automated alarm resolution

### DIFF
--- a/fakebreakingnewslambda/fakebreakingnewslambda-cfn.yaml
+++ b/fakebreakingnewslambda/fakebreakingnewslambda-cfn.yaml
@@ -113,6 +113,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       AlarmDescription: !Sub Triggers if not enough Ios dry run notifications are happening on ${Stage}
       ComparisonOperator: LessThanThreshold
       Dimensions:
@@ -130,6 +131,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       AlarmDescription: !Sub Triggers if not enough Android dry run notifications are happening on ${Stage}
       ComparisonOperator: LessThanThreshold
       Dimensions:

--- a/notification/conf/notification.yaml
+++ b/notification/conf/notification.yaml
@@ -39,7 +39,7 @@ Parameters:
     Description: AMI used by the instances
     Type: AWS::EC2::Image::Id
   Stage:
-    AllowedValues: 
+    AllowedValues:
     - CODE
     - PROD
     Description: Environment name
@@ -221,7 +221,7 @@ Resources:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
-        - Action: 
+        - Action:
             - sts:AssumeRole
           Effect: Allow
           Principal:
@@ -364,6 +364,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       AlarmDescription: !Sub Triggers if notification errors in ${Stage} with 5XX. ${DashboardCopy}
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
@@ -381,6 +382,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       AlarmDescription: !Sub Triggers if load balancer errors in ${Stage} with 5XX. ${DashboardCopy}
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
@@ -398,6 +400,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       AlarmDescription: !Sub
           - triggers if less that ${DailyNewsstandPushCount} daily edition notification was sent for ${Stage} in the last 24 hours..
           - DailyNewsstandPushCount: !FindInMap [ StageVariables, !Ref Stage, DailyNewsstandPushCount ]
@@ -405,13 +408,13 @@ Resources:
       EvaluationPeriods: 1
       Namespace: !FindInMap [ StageVariables, !Ref Stage, MetricNamespace ]
       MetricName:
-        !FindInMap [ StageVariables, !Ref Stage, NewsstandNotificationMetricName ] 
+        !FindInMap [ StageVariables, !Ref Stage, NewsstandNotificationMetricName ]
       Period: 86400
       Statistic: Sum
       Threshold: !FindInMap [ StageVariables, !Ref Stage, NewsstandNotificationAlarmThreshold ]
       TreatMissingData: breaching
 
 
-      
+
 
 

--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -177,6 +177,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       AlarmDescription: !Sub Triggers if the ${App} lambda is throttled in ${Stage}
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
@@ -204,12 +205,14 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Threshold: 0
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       TreatMissingData: notBreaching
 
   TooFewInvocationsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       ActionsEnabled: !If [IsProdStage, true, false]
       AlarmDescription: !Sub Triggers if the ${App} lambda is not frequently invoked in ${Stage}
       ComparisonOperator: LessThanOrEqualToThreshold

--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -189,6 +189,7 @@ Resources:
       Period: 360
       Statistic: Sum
       Threshold: 0
+      TreatMissingData: notBreaching
 
   DlqDepthAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -185,6 +185,7 @@ Resources:
       Period: 360
       Statistic: Sum
       Threshold: 0
+      TreatMissingData: notBreaching
 
   SenderErrorAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -173,6 +173,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       AlarmDescription: !Sub Triggers if the ${App} sender lambda is throttled in ${Stage}
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
@@ -189,6 +190,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       AlarmDescription: !Sub Triggers if the ${App} sender lambda errors in ${Stage}
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
@@ -206,6 +208,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       ActionsEnabled: !If [IsProdStage, true, false]
       AlarmDescription: !Sub Triggers if the ${App} senderlambda is not frequently invoked in ${Stage}
       ComparisonOperator: LessThanOrEqualToThreshold

--- a/registration/conf/registration.yaml
+++ b/registration/conf/registration.yaml
@@ -2,29 +2,29 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Registration for mobile notifications
 Mappings:
   Constants:
-    App: 
+    App:
       Value: registration
     Stack:
       Value: mobile-notifications
   StageVariables:
-    CODE: 
+    CODE:
       CPUAlarmPeriodLower: 300
       CPUAlarmPeriodUpper: 1200
       CPUAlarmThresholdLower: 20
       CPUAlarmThresholdUpper: 50
       NotificationAlarmPeriod: 1200
-    PROD: 
+    PROD:
       CPUAlarmPeriodLower: 300
       CPUAlarmPeriodUpper: 60
       CPUAlarmThresholdLower: 20
-      CPUAlarmThresholdUpper: 50 
+      CPUAlarmThresholdUpper: 50
       NotificationAlarmPeriod: 1200
 Outputs:
   LoadBalancerUrl:
     Value:
       !GetAtt LoadBalancerToPrivateASG.DNSName
 Parameters:
-  AMI: 
+  AMI:
     Type: AWS::EC2::Image::Id
     Description: AMI used by the instances
   Stage:
@@ -312,6 +312,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       AlarmDescription: !Sub Triggers if load balancer in ${Stage} does not have enough 200s in half an hour
       ComparisonOperator: LessThanThreshold
       Dimensions:
@@ -330,6 +331,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions: [!Ref AlarmTopic]
+      OKActions: [!Ref AlarmTopic]
       AlarmDescription: !Sub Triggers if load balancer in ${Stage} does not have enough 200s in a whole day
       ComparisonOperator: LessThanThreshold
       Dimensions:


### PR DESCRIPTION
This is a second attempt at https://github.com/guardian/mobile-n10n/pull/507. The only change is [this commit](https://github.com/guardian/mobile-n10n/commit/118af8f567f73d1c5eeb2fd6829e5a6d1233c833), which implements the fix identified [here](https://github.com/guardian/mobile-n10n/pull/507#issuecomment-624580161).