### PR TITLE
Bump Play To 2.8.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val compilerOptions = Seq(
 
 scalacOptions in ThisBuild ++= compilerOptions
 
-val playJsonVersion = "2.7.4"
+val playJsonVersion = "2.8.1"
 val specsVersion: String = "4.5.1"
 val awsSdkVersion: String = "1.11.772"
 val doobieVersion: String = "0.9.0"
@@ -80,7 +80,7 @@ lazy val common = project
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
       "com.googlecode.concurrentlinkedhashmap" % "concurrentlinkedhashmap-lru" % "1.4.2",
-      "ai.x" %% "play-json-extensions" % "0.40.2",
+      "ai.x" %% "play-json-extensions" % "0.42.0",
       "org.tpolecat" %% "doobie-core"      % doobieVersion,
       "org.tpolecat" %% "doobie-hikari"    % doobieVersion,
       "org.tpolecat" %% "doobie-postgres"  % doobieVersion,

--- a/common/src/main/scala/metrics/Metrics.scala
+++ b/common/src/main/scala/metrics/Metrics.scala
@@ -35,9 +35,9 @@ class CloudWatchMetrics(applicationLifecycle: ApplicationLifecycle, env: Environ
 
   private val metricActor = actorSystem.actorOf(Props(classOf[MetricActor], cloudWatchClient, identity, env))
 
-  actorSystem.scheduler.schedule(
+  actorSystem.scheduler.scheduleWithFixedDelay(
     initialDelay = 0.second,
-    interval = 1.minute,
+    delay = 1.minute,
     receiver = metricActor,
     message = MetricActor.Aggregate
   )

--- a/common/src/main/scala/models/Notification.scala
+++ b/common/src/main/scala/models/Notification.scala
@@ -7,6 +7,7 @@ import play.api.libs.json._
 import java.net.URI
 
 import ai.x.play.json.Jsonx
+import ai.x.play.json.Encoders.encoder
 
 sealed trait Notification {
   def id: UUID

--- a/common/src/main/scala/utils/CustomApplicationLoader.scala
+++ b/common/src/main/scala/utils/CustomApplicationLoader.scala
@@ -22,7 +22,7 @@ abstract class CustomApplicationLoader extends ApplicationLoader {
       case AwsIdentity(app, stack, stage, _) => SSMConfigurationLocation(s"/notifications/$stage/$stack")
     }
     val loadedConfig = Configuration(config)
-    val newContext = context.copy(initialConfiguration = context.initialConfiguration ++ loadedConfig )
+    val newContext = context.copy(initialConfiguration = context.initialConfiguration.withFallback(loadedConfig))
     buildComponents(identity, newContext).application
   }
 }

--- a/common/src/main/scala/utils/CustomApplicationLoader.scala
+++ b/common/src/main/scala/utils/CustomApplicationLoader.scala
@@ -22,7 +22,7 @@ abstract class CustomApplicationLoader extends ApplicationLoader {
       case AwsIdentity(app, stack, stage, _) => SSMConfigurationLocation(s"/notifications/$stage/$stack")
     }
     val loadedConfig = Configuration(config)
-    val newContext = context.copy(initialConfiguration = context.initialConfiguration.withFallback(loadedConfig))
+    val newContext = context.copy(initialConfiguration = loadedConfig.withFallback(context.initialConfiguration))
     buildComponents(identity, newContext).application
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.0")
 


### PR DESCRIPTION
## What does this change?

Upgrades from Play 2.7.4 to Play 2.8.2. Also upgrades `play-json` to 2.8.1, and `play-json-extensions` to 0.42.0.

Two changes have been made to handle deprecated methods:

1. Switched from `schedule` method to `scheduleWithFixedDelay`. This is in the `CloudWatchMetrics` class, and reflects a change in Akka (which was bumped in 2.8). A description of the new method can be found [here](https://doc.akka.io/docs/akka/current/scheduler.html#schedule-periodically). There's an alternative called `scheduleAtFixedRate` which achieves a slightly different outcome; I'm not sure which more accurately reflects our previous behaviour, but the docs recommend the first if unsure.

2. Used `withFallback` over `++` to merge `ApplicationLoader` configurations. By my understanding, our previous behaviour had the `loadedConfig` taking precedence over the `initialConfiguration`, as specified in [the docs](https://www.playframework.com/documentation/2.8.x/api/scala/play/api/Configuration.html#++(other:play.api.Configuration):play.api.Configuration) (if you click on the entry for `++` it gives you a longer description that explains this). Therefore I've flipped the order for `withFallback`, as that produces the same precedence order by my reading of [the docs](https://www.playframework.com/documentation/2.8.x/api/scala/play/api/Configuration.html#withFallback(other:play.api.Configuration):play.api.Configuration) (again, click on the method to get a longer description).

A further change has been made to import a missing implicit from `play-json-extensions`.

**Note:** I've verified that this compiles, and that the tests pass, but nothing more than that, as I'm not very familiar with this project. What other checks ought we to perform @alexduf @jacobwinch?

## How can we measure success?

We're on a more recent Play version, functionality doesn't change, and no bugs are introduced.
