### PR TITLE
Add links to runbook from several alerts

### DIFF
--- a/notification/conf/notification.yaml
+++ b/notification/conf/notification.yaml
@@ -89,10 +89,9 @@ Parameters:
   S3TopicCountBucket:
     Type: String
     Description: Name of the bucket storing the persisted topic subscription counts
-  DashboardCopy:
+  RunbookCopy:
     Type: String
-    Description: Copy and link to CloudWatch dashboard (used for alerts)
-    Default: Check the dashboard for more details - https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#dashboards:name=NotificationsN10N.
+    Default: <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>
 
 Resources:
   DnsRecord:
@@ -365,7 +364,7 @@ Resources:
     Properties:
       AlarmActions: [!Ref AlarmTopic]
       OKActions: [!Ref AlarmTopic]
-      AlarmDescription: !Sub Triggers if notification errors in ${Stage} with 5XX. ${DashboardCopy}
+      AlarmDescription: !Sub Triggers if notification errors in ${Stage} with 5XX. ${RunbookCopy}
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: LoadBalancerName
@@ -383,7 +382,7 @@ Resources:
     Properties:
       AlarmActions: [!Ref AlarmTopic]
       OKActions: [!Ref AlarmTopic]
-      AlarmDescription: !Sub Triggers if load balancer errors in ${Stage} with 5XX. ${DashboardCopy}
+      AlarmDescription: !Sub Triggers if load balancer errors in ${Stage} with 5XX. ${RunbookCopy}
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: LoadBalancerName

--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -37,6 +37,9 @@ Parameters:
   AlarmTopic:
     Type: String
     Description: The ARN of the SNS topic to send all the cloudwatch alarms to
+  RunbookCopy:
+    Type: String
+    Default: <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>
 
 Conditions:
   IsProdStage: !Equals [!Ref Stage, PROD]
@@ -178,7 +181,7 @@ Resources:
     Properties:
       AlarmActions: [!Ref AlarmTopic]
       OKActions: [!Ref AlarmTopic]
-      AlarmDescription: !Sub Triggers if the ${App} lambda is throttled in ${Stage}
+      AlarmDescription: !Sub Triggers if the ${App} lambda is throttled in ${Stage}. ${RunbookCopy}
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
       - Name: FunctionName
@@ -194,7 +197,7 @@ Resources:
   DlqDepthAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: !Sub Triggers if the ${App} lambda failed to process some messages in ${Stage}. Check the logs of ${App} for errors.
+      AlarmDescription: !Sub Triggers if the ${App} lambda failed to process some messages in ${Stage}. ${RunbookCopy}.
       Namespace: AWS/SQS
       MetricName: ApproximateNumberOfMessagesVisible
       Dimensions:
@@ -215,7 +218,7 @@ Resources:
       AlarmActions: [!Ref AlarmTopic]
       OKActions: [!Ref AlarmTopic]
       ActionsEnabled: !If [IsProdStage, true, false]
-      AlarmDescription: !Sub Triggers if the ${App} lambda is not frequently invoked in ${Stage}
+      AlarmDescription: !Sub Triggers if the ${App} lambda is not frequently invoked in ${Stage}. ${RunbookCopy}
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -43,6 +43,9 @@ Parameters:
   ReservedConcurrency:
     Type: String
     Description: How many concurrent execution to provision the lamdba with
+  RunbookCopy:
+    Type: String
+    Default: <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>
 
 Conditions:
   IsProdStage: !Equals [!Ref Stage, PROD]
@@ -174,7 +177,7 @@ Resources:
     Properties:
       AlarmActions: [!Ref AlarmTopic]
       OKActions: [!Ref AlarmTopic]
-      AlarmDescription: !Sub Triggers if the ${App} sender lambda is throttled in ${Stage}
+      AlarmDescription: !Sub Triggers if the ${App} sender lambda is throttled in ${Stage}. ${RunbookCopy}
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: FunctionName
@@ -192,7 +195,7 @@ Resources:
     Properties:
       AlarmActions: [!Ref AlarmTopic]
       OKActions: [!Ref AlarmTopic]
-      AlarmDescription: !Sub Triggers if the ${App} sender lambda errors in ${Stage}
+      AlarmDescription: !Sub Triggers if the ${App} sender lambda errors in ${Stage}. ${RunbookCopy}
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: FunctionName
@@ -211,7 +214,7 @@ Resources:
       AlarmActions: [!Ref AlarmTopic]
       OKActions: [!Ref AlarmTopic]
       ActionsEnabled: !If [IsProdStage, true, false]
-      AlarmDescription: !Sub Triggers if the ${App} senderlambda is not frequently invoked in ${Stage}
+      AlarmDescription: !Sub Triggers if the ${App} senderlambda is not frequently invoked in ${Stage}. ${RunbookCopy}
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName

--- a/registration/conf/registration.yaml
+++ b/registration/conf/registration.yaml
@@ -75,6 +75,9 @@ Parameters:
   NotEnough200sPerDayThreshold:
     Type: Number
     Description: Alarm if less than too many 200s. This value was based on just below 2 standard deviations from the mean over 6 weeks of data.
+  RunbookCopy:
+    Type: String
+    Default: <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>
 Resources:
   DistributionInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -313,7 +316,7 @@ Resources:
     Properties:
       AlarmActions: [!Ref AlarmTopic]
       OKActions: [!Ref AlarmTopic]
-      AlarmDescription: !Sub Triggers if load balancer in ${Stage} does not have enough 200s in half an hour
+      AlarmDescription: !Sub Triggers if load balancer in ${Stage} does not have enough 200s in half an hour. ${RunbookCopy}
       ComparisonOperator: LessThanThreshold
       Dimensions:
         - Name: LoadBalancerName
@@ -332,7 +335,7 @@ Resources:
     Properties:
       AlarmActions: [!Ref AlarmTopic]
       OKActions: [!Ref AlarmTopic]
-      AlarmDescription: !Sub Triggers if load balancer in ${Stage} does not have enough 200s in a whole day
+      AlarmDescription: !Sub Triggers if load balancer in ${Stage} does not have enough 200s in a whole day. ${RunbookCopy}
       ComparisonOperator: LessThanThreshold
       Dimensions:
         - Name: LoadBalancerName


### PR DESCRIPTION
## What does this change?

This makes it easier to take action in response to our alerts. See https://github.com/guardian/google-chat-bots/pull/51 for more details.

## How can we measure success?

The next time these alerts fire they should have a button which links to the relevant runbook.

I've tested this in `CODE`:

- [x] [Notification](https://riffraff.gutools.co.uk/deployment/view/0ff2e336-73bd-4d58-b18c-1e4e28e952e5)
- [x] [Registration](https://riffraff.gutools.co.uk/deployment/view/f9d90553-908b-4049-9d43-ea4ebef2c8f9)
- [x] [Sender Workers and Harvester](https://riffraff.gutools.co.uk/deployment/view/d02aa80b-215c-4c19-a4d8-ff0689d2be66)
