### PR TITLE
LIVE-951: Add US Election notification topic

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/Topic.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/Topic.scala
@@ -36,6 +36,7 @@ object Topic {
   val BreakingNewsInternational = Topic(Breaking, International.toString)
   val BreakingNewsSport = Topic(Breaking, "sport")
   val BreakingNewsElection = Topic(Breaking, "uk-general-election")
+  val BreakingNewsUSElection = Topic(Breaking, "us-election-2020-live")
   val BreakingNewsCovid19Uk = Topic(Breaking, "uk-covid-19")
   val BreakingNewsCovid19Us = Topic(Breaking, "us-covid-19")
   val BreakingNewsCovid19Au = Topic(Breaking, "au-covid-19")


### PR DESCRIPTION
## What does this change?
Adds a new US Election notification topic

## How to test
Register a device to the new topic and send a test notification
