### PR TITLE
Improve Duplicate logging, and treat missing data as notBreaching

### DIFF
--- a/football/cfn.yaml
+++ b/football/cfn.yaml
@@ -81,7 +81,7 @@ Resources:
           App: !Ref App
           Stack: !Ref Stack
           Stage: !Ref Stage
-          
+
       Description: Send Goal Alert notifications
       Handler: com.gu.mobile.notifications.football.Lambda::handler
       MemorySize: 512
@@ -158,6 +158,7 @@ Resources:
       Period: 300
       EvaluationPeriods: 1
       AlarmActions: [ !Ref DynamoNotificationTopic ]
+      TreatMissingData: notBreaching
 
   MobileNotificationsFootballConsumedWriteThrottleEvents:
     Type: AWS::CloudWatch::Alarm
@@ -174,3 +175,4 @@ Resources:
       Period: 300
       EvaluationPeriods: 1
       AlarmActions: [ !Ref DynamoNotificationTopic ]
+      TreatMissingData: notBreaching

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoDistinctCheck.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoDistinctCheck.scala
@@ -50,8 +50,8 @@ class DynamoDistinctCheck(client: AmazonDynamoDBAsync, tableName: String) extend
       case Right(_) =>
         logger.info(s"Distinct notification ${notification.id} written to dynamodb")
         Distinct
-      case Left(_) =>
-        logger.debug(s"Notification ${notification.id} already exists in dynamodb - discarding")
+      case Left(error) =>
+        logger.info(s"Received $error when attempting to write ${notification.id} to dynamo, assuming it's a duplicate")
         Duplicate
     } recover {
       case e =>


### PR DESCRIPTION
## What does this change?
Following on from a football notifications alert we received:

https://chat.google.com/room/AAAAEJXWFvQ/grVF4xRW7bc

In future we should be able to debug the assumed Duplicate events better, by logging to info rather than debug. 

Also, in order to get us out of an "in alarm" state, treat the missing data as nonBreaching