### PR TITLE
Refactor the harvester such that SQL connections are short-lived

### DIFF
--- a/common/src/main/scala/db/DatabaseConfig.scala
+++ b/common/src/main/scala/db/DatabaseConfig.scala
@@ -28,7 +28,7 @@ object DatabaseConfig {
       config.password
     )
   }
-  private def transactorAndDataSource[F[_] : Async](config: JdbcConfig)(implicit cs: ContextShift[F]): (Transactor[F], HikariDataSource) = {
+  def transactorAndDataSource[F[_] : Async](config: JdbcConfig)(implicit cs: ContextShift[F]): (Transactor[F], HikariDataSource) = {
     val connectEC = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(10))
     val transactEC = ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
     val hikariConfig = new HikariConfig()

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -26,7 +26,7 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
 
   "the WorkerRequestHandler" should {
     "Queue one multi platform breaking news notification" in new WRHSScope {
-      workerRequestHandler.doTheWork(sqsEventShardNotification(breakingNewsNotification), tokenService)
+      workerRequestHandler.processNotification(sqsEventShardNotification(breakingNewsNotification), tokenService)
       tokenStreamCount.get() shouldEqual 0
       tokenPlatformStreamCount.get() shouldEqual 1
       firebaseSqsDeliveriesCount.get() shouldEqual 3


### PR DESCRIPTION
## What does this change?
For a while now, we sporadically can't process some shards of a notification. Usually a breaking news notification. We investigated and noticed some I/O errors in the logs of our database.

Full write up to investigation here with @jacobwinch help: https://docs.google.com/document/d/1fLjXzmZ5e3XribxqtZ5E5lEs5N4peQ3QuZoYXrLwKds/edit?ts=5fbcf540#

This PR is to see if shortening our connections help with failed database connections. So instead of leaving a connection open to be reused, everything we need to create a new connection we open and close immediately after processing the notification.

This has been tested in CODE with the help of @marjisound but we will monitor the effects in PROD too after merging.

This was written with @alexduf 

## How to test
Deploy to CODE and test sending multiple CODE breaking news notifications in quick succession.

## How can we measure success?
If the errors in the logs subside, and we no longer get DLQ alerts.

## Have we considered potential risks?
- We need to consider if this will slow down the delivery of notifications, and if it will impact on editorial