### PR TITLE
updated report launch config to use IMDSv2

### DIFF
--- a/report/conf/report.yaml
+++ b/report/conf/report.yaml
@@ -280,6 +280,8 @@ Resources:
       - !Ref InstanceSecurityGroup
       - !Ref GuardianAccessSecurityGroup
       - !Ref VPCSecurityGroup
+      MetadataOptions:
+        HttpTokens: required
       UserData:
         Fn::Base64:
            !Sub


### PR DESCRIPTION
to resolve https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-8-remediation by making HTTPTokens 'required' when using the EC2 metadata service. Essentially amazon has released a more secure way of fetching metadata and they think that it should be enforced on all instances as the previous approach presented a security risk.

This was tested in CODE