### PR TITLE
Temporarily increase the database execution timeout to 45 seconds

### DIFF
--- a/common/src/main/scala/db/DatabaseConfig.scala
+++ b/common/src/main/scala/db/DatabaseConfig.scala
@@ -37,7 +37,7 @@ object DatabaseConfig {
     hikariConfig.setJdbcUrl(config.url)
     hikariConfig.setUsername(config.user)
     hikariConfig.setPassword(config.password)
-    hikariConfig.addDataSourceProperty("socketTimeout", "30")
+    hikariConfig.addDataSourceProperty("socketTimeout", "45")
     val dataSource = new HikariDataSource(hikariConfig)
 
     (Transactor.fromDataSource.apply(dataSource, connectEC, Blocker.liftExecutionContext(transactEC)), dataSource)


### PR DESCRIPTION
## What does this change?
Temporarily increase the database execution timeout to 45 seconds, until we have a long term solution in place. There is currently some issues with database connections in the harvester.
