### PR TITLE
Use IMDSv2 metadata service

### DIFF
--- a/notification/conf/notification.yaml
+++ b/notification/conf/notification.yaml
@@ -329,6 +329,8 @@ Resources:
       IamInstanceProfile: !Ref NotificationInstanceProfile
       ImageId: !Ref AMI
       InstanceType: !FindInMap [StageVariables, !Ref Stage, InstanceType]
+      MetadataOptions:
+        HttpTokens: required
       SecurityGroups:
       - !Ref InstanceSecurityGroup
       - !Ref GuardianAccessSecurityGroup


### PR DESCRIPTION
## What does this change?
Make HTTPTokens 'required' when using the EC2 metadata service.