### PR TITLE
updated dependancy apache:libthrift to 0.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ val catsVersion: String = "2.1.1"
 val simpleConfigurationVersion: String = "1.5.2"
 val okHttpVersion: String = "3.14.8"
 val paClientVersion: String = "7.0.4"
+val apacheThrift: String = "0.13.0"
 
 val standardSettings = Seq[Setting[_]](
   resolvers ++= Seq(
@@ -284,6 +285,7 @@ lazy val football = lambda("football", "football")
       "org.scanamo" %% "scanamo" % "1.0.0-M12",
       "org.scanamo" %% "scanamo-testkit" % "1.0.0-M12" % "test",
       "com.gu" %% "content-api-client-default" % "15.9",
+      "org.apache.thrift" % "libthrift" % apacheThrift,
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
       "com.gu" %% "pa-client" % paClientVersion,
       "com.squareup.okhttp3" % "okhttp" % okHttpVersion,

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -65,7 +65,7 @@ object Lambda extends Logging {
 
   def getZonedDateTime(): ZonedDateTime = {
     val zonedDateTime = if (configuration.stage == "CODE") {
-      val is = new URL("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").openStream()
+      val is = new URL("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/prod/getTime").openStream()
       val json = Json.parse(Source.fromInputStream(is).mkString)
       ZonedDateTime.parse((json \ "currentDate").as[String])
     } else {

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -65,7 +65,7 @@ object Lambda extends Logging {
 
   def getZonedDateTime(): ZonedDateTime = {
     val zonedDateTime = if (configuration.stage == "CODE") {
-      val is = new URL("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/prod/getTime").openStream()
+      val is = new URL("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").openStream()
       val json = Json.parse(Source.fromInputStream(is).mkString)
       ZonedDateTime.parse((json \ "currentDate").as[String])
     } else {


### PR DESCRIPTION
## What does this change?
Part of the security/vulnerabilities updates for SNYK
mobile-n10n - org.apache.thrift:libthrift@0.13.0 - DoS

## What changes?
Tried updating the ‘parent’ library content-api-client-default (`"com.gu" %% "content-api-client-default" % "17.15"`)

This accorrding to Maven/Sonotype updating content-api-client-default was supposed to update the Apache thriftlib to version 0.14. 
However upon building this did not work:
https://mvnrepository.com/artifact/com.gu/content-api-client-default_2.12/17.2 

- added direct dependancy for this with `"org.apache.thrift" % "libthrift" % apacheThrift,`

To pull out and evict version 0.12 with 0.13



## How to test
Doc in shared drive: https://docs.google.com/document/d/1stB9KiPFEtjAMOvDjnbN_l9vHYQ4ZQYgQ_H1XXNUsGA/edit

Also see READ ME

## How can we measure success?
- upon checking SNYK at the next deployment the security risk should be eliminated

## Have we considered potential risks?
Rather than update `content-api-client-default` from 15.9 to 17.2 (which didnt update libthrift) it has been kept to 15.9 to reduce potential risk to other dependancies.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
