### PR TITLE
updated parent library firebase-admin to 6.14.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -316,7 +316,8 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
   .settings(
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
-      "com.google.firebase" % "firebase-admin" % "6.14.0",
+      "com.google.firebase" % "firebase-admin" % "6.3.0",
+      "io.netty" % "netty-codec" % "4.1.46.Final",
       "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",
       "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -316,7 +316,7 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
   .settings(
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
-      "com.google.firebase" % "firebase-admin" % "6.3.0",
+      "com.google.firebase" % "firebase-admin" % "6.14.0",
       "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",
       "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -3,7 +3,7 @@ package com.gu.notifications.worker.delivery.apns.models.payload
 import java.net.URI
 import java.util.UUID
 
-import com.google.gson.JsonParser
+import com.google.gson.{JsonElement, JsonParser}
 import com.gu.notifications.worker.delivery.apns.models.ApnsConfig
 import models.Importance.Major
 import models.Link.Internal
@@ -53,7 +53,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
     def notification: Notification
     def expected: Option[String]
 
-    private def expectedTrimmedJson = expected.map(s => new JsonParser().parse(s).toString)
+    private def expectedTrimmedJson = expected.map(s => JsonParser.parseString(s).toString)
     def checkPayload() = {
       val dummyConfig = new ApnsConfig(
         teamId = "",

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -3,7 +3,7 @@ package com.gu.notifications.worker.delivery.apns.models.payload
 import java.net.URI
 import java.util.UUID
 
-import com.google.gson.{JsonElement, JsonParser}
+import com.google.gson.{JsonParser}
 import com.gu.notifications.worker.delivery.apns.models.ApnsConfig
 import models.Importance.Major
 import models.Link.Internal
@@ -53,7 +53,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
     def notification: Notification
     def expected: Option[String]
 
-    private def expectedTrimmedJson = expected.map(s => JsonParser.parseString(s).toString)
+    private def expectedTrimmedJson = expected.map(s => new JsonParser().parse(s).toString)
     def checkPayload() = {
       val dummyConfig = new ApnsConfig(
         teamId = "",

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -3,7 +3,7 @@ package com.gu.notifications.worker.delivery.apns.models.payload
 import java.net.URI
 import java.util.UUID
 
-import com.google.gson.{JsonParser}
+import com.google.gson.JsonParser
 import com.gu.notifications.worker.delivery.apns.models.ApnsConfig
 import models.Importance.Major
 import models.Link.Internal


### PR DESCRIPTION
## What does this change?
Affected versions of this package are vulnerable to Uncontrolled Memory Allocation while decoding a ZlibEncoded byte stream. An attacker could send a large ZlibEncoded byte stream to the Netty server, forcing the server to allocate all of its free memory to a single decoder.

Updated parent Library Firebase to 6.14 to facilitate the upgrade of netty:handler to 4.1.50

## How to test


## How can we measure success?


## Have we considered potential risks?
The update to parent Library was the minimal to facilitate the upgrade to netty sufficiently 

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
