### PR TITLE
Live:2304 - updated: netty-codec-http to 4.1.44

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -323,6 +323,7 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
       "com.turo" % "pushy" % "0.13.10",
       "com.google.firebase" % "firebase-admin" % "6.3.0",
       "io.netty" % "netty-codec" % "4.1.46.Final",
+      "io.netty" % "netty-codec-http" % "4.1.44.Final",
       "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",
       "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,


### PR DESCRIPTION
## What does this change?
io.netty:netty-codec-http is a network application framework for rapid development of maintainable high performance protocol servers & clients.

Affected versions of this package are vulnerable to HTTP Request Smuggling. It allows an HTTP header that lacks a colon, which might be interpreted as a separate header with an incorrect syntax or as an "invalid fold."


## How to test
-**Ran SBT from terminal:** (one at a time)
```
> project notificationworkerlambda + reportextractor + football + schedule + eventconmsumer + fakebreakingnewslambda
> test
```
Also tested in AWS Lambda functions

-**Debug App:**
Sent UK alerts notification through Fronts and succesfully recieved on Debug app

## How can we measure success?
No alert in Snyk to be displayed for this update

## Have we considered potential risks?
Forced the update on top level as the updating of the parent Library is too big and causes breaking changes

