### PR TITLE
Live:2269 updated jackson-dataformat-cbor for Snyk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ val okHttpVersion: String = "3.14.8"
 val paClientVersion: String = "7.0.4"
 val apacheThrift: String = "0.13.0"
 val jacksonDatabind: String = "2.10.5.1"
+val jacksonCbor: String = "2.12.1"
 
 val standardSettings = Seq[Setting[_]](
   resolvers ++= Seq(
@@ -55,7 +56,8 @@ lazy val commoneventconsumer = project
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "org.specs2" %% "specs2-core" % specsVersion % "test",
-      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabind
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabind,
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCbor
     ),
   ))
 
@@ -64,7 +66,8 @@ lazy val commontest = project
     libraryDependencies ++= Seq(
       specs2,
       playCore,
-      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabind
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabind,
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCbor
     ),
   ))
 
@@ -110,6 +113,7 @@ lazy val commonscheduledynamodb = project
     libraryDependencies ++= List(
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabind,
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCbor,
       specs2 % Test
 
     ),
@@ -193,7 +197,8 @@ lazy val apiModels = {
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "org.specs2" %% "specs2-core" % specsVersion % "test",
       "org.specs2" %% "specs2-mock" % specsVersion % "test",
-      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabind
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabind,
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCbor
     ),
     organization := "com.gu",
     publishTo := sonatypePublishToBundle.value,

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ val paClientVersion: String = "7.0.4"
 val apacheThrift: String = "0.13.0"
 val jacksonDatabind: String = "2.10.5.1"
 val jacksonCbor: String = "2.12.1"
+val jacksonScalaModule: String = "2.12.3"
 
 val standardSettings = Seq[Setting[_]](
   resolvers ++= Seq(
@@ -57,7 +58,8 @@ lazy val commoneventconsumer = project
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "org.specs2" %% "specs2-core" % specsVersion % "test",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabind,
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCbor
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCbor,
+      "com.fasterxml.jackson.module" % "jackson-module-scala_2.13" % jacksonScalaModule
     ),
   ))
 
@@ -67,7 +69,8 @@ lazy val commontest = project
       specs2,
       playCore,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabind,
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCbor
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCbor,
+      "com.fasterxml.jackson.module" % "jackson-module-scala_2.13" % jacksonScalaModule
     ),
   ))
 
@@ -114,6 +117,7 @@ lazy val commonscheduledynamodb = project
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabind,
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCbor,
+      "com.fasterxml.jackson.module" % "jackson-module-scala_2.13" % jacksonScalaModule,
       specs2 % Test
 
     ),
@@ -198,7 +202,8 @@ lazy val apiModels = {
       "org.specs2" %% "specs2-core" % specsVersion % "test",
       "org.specs2" %% "specs2-mock" % specsVersion % "test",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabind,
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCbor
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCbor,
+      "com.fasterxml.jackson.module" % "jackson-module-scala_2.13" % jacksonScalaModule
     ),
     organization := "com.gu",
     publishTo := sonatypePublishToBundle.value,


### PR DESCRIPTION
## What does this change?
Affected versions of this package are vulnerable to Denial of Service (DoS). Unchecked allocation of byte buffer can cause a java.lang.OutOfMemoryError exception.

## How to test
-**Ran SBT from terminal:**
```
> project notificationworkerlambda + reportextractor + football + schedule + eventconmsumer + fakebreakingnewslambda
> test
```
Also tested in AWS Lambda functions

-**Debug App:**
Sent UK alerts notification through Fronts and succesfully recieved on Debug app

## How can we measure success?
No alert in Snyk to be displayed for this update

## Have we considered potential risks?
Forced the update on top level as the updating of the parent Library is too big and causes breaking changes