### PR TITLE
Live-2317: updated google-oauth-client 1.31.0 snyk vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,7 @@ lazy val common = project
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
       "com.googlecode.concurrentlinkedhashmap" % "concurrentlinkedhashmap-lru" % "1.4.2",
+      "com.google.oauth-client" % "google-oauth-client" % "1.31.0",
       "ai.x" %% "play-json-extensions" % "0.42.0",
       "org.tpolecat" %% "doobie-core"      % doobieVersion,
       "org.tpolecat" %% "doobie-hikari"    % doobieVersion,


### PR DESCRIPTION
## What does this change?
com.google.oauth-client:google-oauth-client is a powerful and easy-to-use Java library for the OAuth 1.0a and OAuth 2.0 authorization standards.

Affected versions of this package are vulnerable to Improper Authorization. PKCE support is not implemented in accordance with the RFC for OAuth 2.0 for Native Apps. Without the use of PKCE, the authorization code returned by an authorization server is not enough to guarantee that the client that issued the initial authorization request is the one that will be authorized. An attacker is able to obtain the authorization code using a malicious app on the client-side and use it to gain authorization to the protected resource.

## How to test
-**Ran SBT from terminal:** (one at a time)
```
> project notificationworkerlambda + notification
> test
```
-**Debug App:**
Sent UK alerts notification through Fronts and successfully received on Debug app## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
We chose not to update the parent Firebase Library to 6.14.0 (which would have updated google-oaugh-client) as this would have caused other breaking changes.

