### PR TITLE
Change ami recipe to use bionic bake instead of xenial

### DIFF
--- a/notification/conf/riff-raff.yaml
+++ b/notification/conf/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: notification
     parameters:
       amiTags:
-        Recipe: xenial-mobile-ARM
+        Recipe: bionic-mobile-ARM
         AmigoStage: PROD
       templatePath: cfn.yaml
   notification:

--- a/registration/conf/riff-raff.yaml
+++ b/registration/conf/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: registration
     parameters:
       amiTags:
-        Recipe: xenial-mobile-ARM
+        Recipe: bionic-mobile-ARM
         AmigoStage: PROD
       templatePath: cfn.yaml
   registration:

--- a/report/conf/riff-raff.yaml
+++ b/report/conf/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: report
     parameters:
       amiTags:
-        Recipe: xenial-mobile-ARM
+        Recipe: bionic-mobile-ARM
         AmigoStage: PROD
       templatePath: cfn.yaml
   report:


### PR DESCRIPTION
## Why are you doing this?

Ubuntu Xenial is near EOL, and we've had problems with the Xenial AMI on other repos. This bumps us to the more recent Bionic AMI.

There have been similar changes on other repos:

- https://github.com/guardian/mobile-apps-api/pull/1712
- https://github.com/guardian/apps-rendering/pull/1301

FYI @philmcmahon

## Changes

- Migrate from ubuntu xenial to bionic AMI

(copied PR description from https://github.com/guardian/mobile-entry/pull/42)