### PR TITLE
LIVE-2059 - notification - Set associatePublicIpAddress to false

### DIFF
--- a/notification/conf/notification.yaml
+++ b/notification/conf/notification.yaml
@@ -325,7 +325,7 @@ Resources:
   NotificationLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      AssociatePublicIpAddress: True
+      AssociatePublicIpAddress: false
       IamInstanceProfile: !Ref NotificationInstanceProfile
       ImageId: !Ref AMI
       InstanceType: !FindInMap [StageVariables, !Ref Stage, InstanceType]


### PR DESCRIPTION
## What does this change?
This PR removes the public IPv4 address from the EC2 instances. This change would resolve the relevant security issue in AWS security Hub.

Find more info in https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-9-remediation

Deployed and tested in code
