### PR TITLE
LIVE-2061 - registration - Set AssociatePublicIpAddress to false

### DIFF
--- a/registration/conf/registration.yaml
+++ b/registration/conf/registration.yaml
@@ -277,7 +277,7 @@ Resources:
   RegistrationLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      AssociatePublicIpAddress: True
+      AssociatePublicIpAddress: false
       IamInstanceProfile: !Ref DistributionInstanceProfile
       ImageId: !Ref AMI
       InstanceType: !FindInMap [StageVariables, !Ref Stage, InstanceType]


### PR DESCRIPTION
## What does this change?
This PR removes the public IPv4 address from the EC2 instances. This change would resolve the relevant security issue in AWS security Hub.

Find more info in https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-9-remediation

Deployed and tested in code