### PR TITLE
LIVE-2060 - report - Set AssociatePublicIpAddress to false

### DIFF
--- a/report/conf/report.yaml
+++ b/report/conf/report.yaml
@@ -272,7 +272,7 @@ Resources:
   ReportLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      AssociatePublicIpAddress: True
+      AssociatePublicIpAddress: false
       IamInstanceProfile: !Ref NotificationsReportInstanceProfile
       ImageId: !Ref AMI
       InstanceType: !FindInMap [StageVariables, !Ref Stage, InstanceType]


### PR DESCRIPTION
## What does this change?
This PR removes the public IPv4 address from the EC2 instances. This change would resolve the relevant security issue in AWS security Hub.

Find more info in https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-9-remediation