### PR TITLE
Revert "Bump Firebase Admin To `6.16.0`"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -338,7 +338,7 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
   .settings(
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
-      "com.google.firebase" % "firebase-admin" % "6.16.0",
+      "com.google.firebase" % "firebase-admin" % "6.3.0",
       "io.netty" % "netty-codec" % "4.1.46.Final",
       "io.netty" % "netty-codec-http" % "4.1.44.Final",
       "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -53,7 +53,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
     def notification: Notification
     def expected: Option[String]
 
-    private def expectedTrimmedJson = expected.map(s => JsonParser.parseString(s).toString)
+    private def expectedTrimmedJson = expected.map(s => new JsonParser().parse(s).toString)
     def checkPayload() = {
       val dummyConfig = new ApnsConfig(
         teamId = "",


### PR DESCRIPTION
Reverts guardian/mobile-n10n#553

The lambda deployment failed, so have to revert the change