### PR TITLE
Convert our Notification Lambdas to use Container Images

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
-REPOSITORY_URL=201359054765.dkr.ecr.eu-west-1.amazonaws.com/notificationworkerlambda-image
-
 BUILD_NUMBER=${BUILD_NUMBER:-unknown}
 
 # login with docker to the ecr repository
 
 # as per: <https://docs.aws.amazon.com/cli/latest/reference/ecr/get-authorization-token.html>
 
-AUTH_TOKEN=$(aws ecr get-authorization-token --registry-ids 201359054765 --output text --query 'authorizationData[].authorizationToken' --region eu-west-1 | base64 --decode | cut -d: -f2)
+AUTH_TOKEN=$(aws ecr get-authorization-token --registry-ids ${NOTIFICATION_LAMBDA_REPOSITORY_ID} --output text --query 'authorizationData[].authorizationToken' --region eu-west-1 | base64 --decode | cut -d: -f2)
 
-docker login -u AWS -p ${AUTH_TOKEN} ${REPOSITORY_URL}
+docker login -u AWS -p ${AUTH_TOKEN} ${NOTIFICATION_LAMBDA_REPOSITORY_URL}
 
-docker push ${REPOSITORY_URL}:${BUILD_NUMBER}
+docker push ${NOTIFICATION_LAMBDA_REPOSITORY_URL}:${BUILD_NUMBER}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+REPOSITORY_URL=201359054765.dkr.ecr.eu-west-1.amazonaws.com/notificationworkerlambda-image
+
+BUILD_NUMBER=${BUILD_NUMBER:-unknown}
+
+# login with docker to the ecr repository
+
+# as per: <https://docs.aws.amazon.com/cli/latest/reference/ecr/get-authorization-token.html>
+
+AUTH_TOKEN=$(aws ecr get-authorization-token --registry-ids 201359054765 --output text --query 'authorizationData[].authorizationToken' --region eu-west-1 | base64 --decode | cut -d: -f2)
+
+docker login -u AWS -p ${AUTH_TOKEN} ${REPOSITORY_URL}
+
+docker push ${REPOSITORY_URL}:${BUILD_NUMBER}

--- a/notificationworkerlambda/ecr.yaml
+++ b/notificationworkerlambda/ecr.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: ECR repositories for MSS notification worker lambdas
+Resources:
+  Repository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: notificationworkerlambda-image
+      RepositoryPolicyText:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowPushPull
+            Effect: Allow
+            Principal:
+              # this is the developer tools account which allows
+              # teamcity to upload the images that it builds
+              AWS: "arn:aws:iam::095768028460:root"
+            Action:
+              - "ecr:GetAuthorizationToken"
+              - "ecr:BatchCheckLayerAvailability"
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:GetRepositoryPolicy"
+              - "ecr:SetRepositoryPolicy"              
+              - "ecr:DescribeRepositories"
+              - "ecr:ListImages"
+              - "ecr:DescribeImages"
+              - "ecr:BatchGetImage"
+              - "ecr:InitiateLayerUpload"
+              - "ecr:UploadLayerPart"
+              - "ecr:CompleteLayerUpload"
+              - "ecr:PutImage"

--- a/notificationworkerlambda/ecr.yaml
+++ b/notificationworkerlambda/ecr.yaml
@@ -1,10 +1,10 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: ECR repositories for MSS notification worker lambdas
 Resources:
-  Repository:
+  NotificationLambdaRepository:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryName: notificationworkerlambda-image
+      RepositoryName: notificationworker-lambda-images
       RepositoryPolicyText:
         Version: 2012-10-17
         Statement:
@@ -28,3 +28,13 @@ Resources:
               - "ecr:UploadLayerPart"
               - "ecr:CompleteLayerUpload"
               - "ecr:PutImage"
+
+Outputs:
+  NotificationLambdaRepositoryUri:
+    Description: >
+      URI for the notification lambda image repository, which should
+      be inserted into the CodeImage configuration to use an image
+      from this repository as the basis for a Lambda
+    Value: !GetAtt NotificationLambdaRepository.RepositoryUri
+    Export:
+      Name: NotificationLambdaRepositoryUri

--- a/notificationworkerlambda/expired-registration-cleaner-cfn.yaml
+++ b/notificationworkerlambda/expired-registration-cleaner-cfn.yaml
@@ -77,7 +77,7 @@ Resources:
   Lambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub ${Stack}-${App}-${Stage}
+      FunctionName: !Sub ${Stack}-${App}-ctr-${Stage}
       PackageType: Image
       Code:
         ImageUri: !Join [':', [!ImportValue NotificationLambdaRepositoryUri, !Ref BuildId]]

--- a/notificationworkerlambda/expired-registration-cleaner-cfn.yaml
+++ b/notificationworkerlambda/expired-registration-cleaner-cfn.yaml
@@ -15,6 +15,10 @@ Parameters:
       - CODE
       - PROD
     Default: CODE
+  BuildId:
+    Description: Tag to be used for the image URL, e.g. riff raff build id
+    Type: String
+    Default: dev
   DeployBucket:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
@@ -74,20 +78,19 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub ${Stack}-${App}-${Stage}
+      PackageType: Image
       Code:
-        S3Bucket:
-          Ref: DeployBucket
-        S3Key: !Sub ${Stack}/${Stage}/notificationworkerlambda/notificationworkerlambda.jar
+        ImageUri: !Join [':', [!ImportValue NotificationLambdaRepositoryUri, !Ref BuildId]]
       Environment:
         Variables:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
       Description: Cleans the database of outdated tokens regularly
-      Handler: com.gu.notifications.worker.ExpiredRegistrationCleanerLambda::handleRequest
+      ImageConfig:
+        Command: [com.gu.notifications.worker.ExpiredRegistrationCleanerLambda::handleRequest]
       MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
       Timeout: 60
       VpcConfig:
         SecurityGroupIds:

--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -173,7 +173,7 @@ Resources:
     Type: AWS::Lambda::EventSourceMapping
     DependsOn:
     - Sqs
-    - HavesterLambdaCtr
+    - HarvesterLambdaCtr
     Properties:
       BatchSize: 1
       Enabled: True

--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -18,6 +18,10 @@ Parameters:
     - CODE
     - PROD
     Default: CODE
+  BuildId:
+    Description: Tag to be used for the image URL, e.g. riff raff build id
+    Type: String
+    Default: dev
   DeployBucket:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
@@ -133,24 +137,24 @@ Resources:
             Action: cloudwatch:PutMetricData
             Resource: "*"
 
-  HavesterLambda:
+  HarvesterLambda:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub ${Stack}-${App}-${Stage}
+      PackageType: Image
       Code:
-        S3Bucket:
-          Ref: DeployBucket
-        S3Key: !Sub ${Stack}/${Stage}/notificationworkerlambda/notificationworkerlambda.jar
+        ImageUri: !Join [':', [!ImportValue NotificationLambdaRepositoryUri, !Ref BuildId]]
+      ImageConfig:
+        Command:
+          - com.gu.notifications.worker.Harvester::handleHarvesting
       Environment:
         Variables:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
       Description: Consumes events produced by the notification service and fetches batches of tokens for senders to send
-      Handler: com.gu.notifications.worker.Harvester::handleHarvesting
       MemorySize: 3008
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
       Timeout: 60
       ReservedConcurrentExecutions: 200
       VpcConfig:
@@ -169,7 +173,7 @@ Resources:
     Type: AWS::Lambda::EventSourceMapping
     DependsOn:
     - Sqs
-    - HavesterLambda
+    - HarvesterLambda
     Properties:
       BatchSize: 1
       Enabled: True

--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -137,10 +137,10 @@ Resources:
             Action: cloudwatch:PutMetricData
             Resource: "*"
 
-  HarvesterLambda:
+  HarvesterLambdaCtr:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub ${Stack}-${App}-${Stage}
+      FunctionName: !Sub ${Stack}-${App}-ctr-${Stage}
       PackageType: Image
       Code:
         ImageUri: !Join [':', [!ImportValue NotificationLambdaRepositoryUri, !Ref BuildId]]
@@ -173,12 +173,12 @@ Resources:
     Type: AWS::Lambda::EventSourceMapping
     DependsOn:
     - Sqs
-    - HarvesterLambda
+    - HavesterLambdaCtr
     Properties:
       BatchSize: 1
       Enabled: True
       EventSourceArn: !GetAtt Sqs.Arn
-      FunctionName: !Sub ${Stack}-${App}-${Stage}
+      FunctionName: !Ref HarvesterLambdaCtr
 
   ThrottleAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
+++ b/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
@@ -126,7 +126,7 @@ Resources:
   WorkerLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub ${Stack}-${App}-${Stage}
+      FunctionName: !Sub ${Stack}-${App}-ctr-${Stage}
       PackageType: Image
       Code:
         ImageUri: !Join [':', [!ImportValue NotificationLambdaRepositoryUri, !Ref BuildId]]

--- a/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
+++ b/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
@@ -15,6 +15,10 @@ Parameters:
     - CODE
     - PROD
     Default: CODE
+  BuildId:
+    Description: Tag to be used for the image URL, e.g. riff raff build id
+    Type: String
+    Default: dev
   DeployBucket:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
@@ -123,20 +127,19 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub ${Stack}-${App}-${Stage}
+      PackageType: Image
       Code:
-        S3Bucket:
-          Ref: DeployBucket
-        S3Key: !Sub ${Stack}/${Stage}/notificationworkerlambda/notificationworkerlambda.jar
+        ImageUri: !Join [':', [!ImportValue NotificationLambdaRepositoryUri, !Ref BuildId]]
       Environment:
         Variables:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
       Description: Consumes queue events and sends notifications
-      Handler: !Ref FullyQualifiedHandler
+      ImageConfig:
+        Command: [!Ref FullyQualifiedHandler]
       MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
       Timeout: 300
       ReservedConcurrentExecutions: 100
       VpcConfig:

--- a/notificationworkerlambda/riff-raff.yaml
+++ b/notificationworkerlambda/riff-raff.yaml
@@ -2,33 +2,6 @@ stacks: [mobile-notifications]
 regions: [eu-west-1]
 
 deployments:
-  notificationworkerlambda:
-    type: aws-lambda
-    app: notificationworkerlambda
-    parameters:
-      bucket: mobile-notifications-dist
-      functionNames:
-        - mobile-notifications-ios-worker-sender-
-        - mobile-notifications-android-worker-sender-
-        - mobile-notifications-ios-edition-worker-sender-
-        - mobile-notifications-android-beta-worker-sender-
-        - mobile-notifications-android-edition-worker-sender-
-        - mobile-notifications-registration-cleaning-worker-
-        - mobile-notifications-topic-counter-
-        - mobile-notifications-harvester-
-        - mobile-notifications-expired-registration-cleaner-
-      fileName: notificationworkerlambda.jar
-      prefixStack: false
-    dependencies:
-      - mobile-notifications-ios-worker-cfn
-      - mobile-notifications-android-worker-cfn
-      - mobile-notifications-ios-edition-worker-cfn
-      - mobile-notifications-android-beta-worker-cfn
-      - mobile-notifications-android-edition-worker-cfn
-      - mobile-notifications-registration-cleaning-worker-cfn
-      - mobile-notifications-topic-counter-cfn
-      - mobile-notifications-harvester-cfn
-      - mobile-notifications-expired-registration-cleaner-cfn
   mobile-notifications-harvester-cfn:
     type: cloud-formation
     app: harvester

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -15,6 +15,14 @@ Parameters:
     - CODE
     - PROD
     Default: CODE
+  CodeImage:
+    Description: The container image URL from the ECR repository
+    Type: String
+    Default: 201359054765.dkr.ecr.eu-west-1.amazonaws.com/notificationworkerlambda-image
+  BuildId:
+    Description: Tag to be used for the image URL, e.g. riff raff build id
+    Type: String
+    Default: dev
   DeployBucket:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
@@ -136,21 +144,20 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub ${Stack}-${App}-sender-${Stage}
+      PackageType: Image
       Code:
-        S3Bucket:
-          Ref: DeployBucket
-        S3Key: !Sub ${Stack}/${Stage}/notificationworkerlambda/notificationworkerlambda.jar
+        ImageUri: !Join [':', [!Ref CodeImage, !Ref BuildId]]
+      ImageConfig:
+        Command: [!Ref SenderFullyQualifiedHandler]
       Environment:
         Variables:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
           Platform: !Ref Platform
-      Description: Sends notifications
-      Handler: !Ref SenderFullyQualifiedHandler
       MemorySize: 3008
+      Description: Sends notifications
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
       Timeout: 90
       ReservedConcurrentExecutions: !Ref ReservedConcurrency
       Tags:

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -135,11 +135,10 @@ Resources:
             Action: cloudwatch:PutMetricData
             Resource: "*"
 
-
-  SenderLambda:
+  SenderLambdaCtr:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub ${Stack}-${App}-sender-${Stage}
+      FunctionName: !Sub ${Stack}-${App}-sender-ctr-${Stage}
       PackageType: Image
       Code:
         ImageUri: !Join [':', [!ImportValue NotificationLambdaRepositoryUri, !Ref BuildId]]
@@ -168,12 +167,12 @@ Resources:
     Type: AWS::Lambda::EventSourceMapping
     DependsOn:
       - SenderSqs
-      - SenderLambda
+      - SenderLambdaCtr
     Properties:
       BatchSize: 1
       Enabled: True
       EventSourceArn: !GetAtt SenderSqs.Arn
-      FunctionName: !Ref SenderLambda
+      FunctionName: !Ref SenderLambdaCtr
 
   SenderThrottleAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -173,7 +173,7 @@ Resources:
       BatchSize: 1
       Enabled: True
       EventSourceArn: !GetAtt SenderSqs.Arn
-      FunctionName: !Sub ${Stack}-${App}-sender-${Stage}
+      FunctionName: !Ref SenderLambda
 
   SenderThrottleAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -15,10 +15,6 @@ Parameters:
     - CODE
     - PROD
     Default: CODE
-  CodeImage:
-    Description: The container image URL from the ECR repository
-    Type: String
-    Default: 201359054765.dkr.ecr.eu-west-1.amazonaws.com/notificationworkerlambda-image
   BuildId:
     Description: Tag to be used for the image URL, e.g. riff raff build id
     Type: String
@@ -146,7 +142,7 @@ Resources:
       FunctionName: !Sub ${Stack}-${App}-sender-${Stage}
       PackageType: Image
       Code:
-        ImageUri: !Join [':', [!Ref CodeImage, !Ref BuildId]]
+        ImageUri: !Join [':', [!ImportValue NotificationLambdaRepositoryUri, !Ref BuildId]]
       ImageConfig:
         Command: [!Ref SenderFullyQualifiedHandler]
       Environment:

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -14,4 +14,3 @@ class AndroidSender extends SenderRequestHandler[FcmClient] {
     FcmClient(config.fcmConfig).fold(e => IO.raiseError(e), c => IO.delay(new Fcm(c)))
   override val maxConcurrency = 100
 }
-

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/IOSSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/IOSSender.scala
@@ -15,4 +15,3 @@ class IOSSender extends SenderRequestHandler[ApnsClient] {
   override val maxConcurrency = 100
 
 }
-

--- a/notificationworkerlambda/topic-counter-cfn.yaml
+++ b/notificationworkerlambda/topic-counter-cfn.yaml
@@ -15,6 +15,10 @@ Parameters:
     - CODE
     - PROD
     Default: CODE
+  BuildId:
+    Description: Tag to be used for the image URL, e.g. riff raff build id
+    Type: String
+    Default: dev
   DeployBucket:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
@@ -103,20 +107,19 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub ${Stack}-${App}-${Stage}
+      PackageType: Image
       Code:
-         S3Bucket:
-           Ref: DeployBucket
-         S3Key: !Sub ${Stack}/${Stage}/notificationworkerlambda/notificationworkerlambda.jar
+        ImageUri: !Join [':', [!ImportValue NotificationLambdaRepositoryUri, !Ref BuildId]]
       Environment:
          Variables:
            Stage: !Ref Stage
            Stack: !Ref Stack
            App: !Ref App
       Description: Persists registrations per topic to s3 ( for counts of over 1000 )
-      Handler: com.gu.notifications.worker.TopicCounterLambda::handleRequest
+      ImageConfig:
+        Command: [com.gu.notifications.worker.TopicCounterLambda::handleRequest]
       MemorySize: 3008
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
       Timeout: 300
       VpcConfig:
         SecurityGroupIds:

--- a/notificationworkerlambda/topic-counter-cfn.yaml
+++ b/notificationworkerlambda/topic-counter-cfn.yaml
@@ -106,7 +106,7 @@ Resources:
   TopicCounterWorker:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub ${Stack}-${App}-${Stage}
+      FunctionName: !Sub ${Stack}-${App}-ctr-${Stage}
       PackageType: Image
       Code:
         ImageUri: !Join [':', [!ImportValue NotificationLambdaRepositoryUri, !Ref BuildId]]


### PR DESCRIPTION
Currently our notification Lambdas are skirting very close to the limit of 250MB available for an S3 based Lambda (in fact strictly speaking we are over the limit at somewhere around 300MB but there must be some buffer). As a result, a change in our dependencies risks pushing us over the edge and making it so we can no longer deploy our Lambdas.

An alternative would be to use container images for our Lambdas instead:

> When you create a Lambda function, you use a deployment package to deploy your function code. Lambda supports two types of deployment packages: .zip file archives and container images.
>
> You can use the Lambda console and the Lambda API to create a function defined as a container image, update and test the image code, and configure other function settings.

(from https://docs.aws.amazon.com/lambda/latest/dg/configuration-images.html#configuration-images-optimization)

According to the docs this should give us a size limit of 10GB, which is plenty of room to grow.

I think it will offer us two other advantages in terms of future work:

* This is a pre-requisite for using ECS instead of Lambdas for this or other services, and so this brings us one step closer to that.
* It may help us to streamline our Lambdas going forward by being able to combine multiple code packages into one docker image with potentially different endpoints.

For the time being however, everything is still done using Lambdas, and we are just converting over to storing the code as a docker image. This means that we don’t need to make any significant modifications to our code or to our cloudformation setup.

After this PR is merged, the deployment process should be the same as before from our point of view: TeamCity will build the code using SBT as before, and then if the build is successful it will push the resulting docker image to our Elastic Container Repository (also created as part of this PR). These images are tagged with the teamcity build number, so we are then able to deploy the build as before using RiffRaff, and it will know to pick up the image that is associated with the build number.

There's a few moving parts to this PR, but essentially it consists of:

* Changing the SBT build (within the file `build.sbt`) so that it creates a Docker image. This is all done within the build.sbt file using the [sbt-native-packager](https://www.scala-sbt.org/sbt-native-packager/) plugin and its Docker image support.

  * The resulting image contains the same deliverables as before, as they are copied over from the file system into the docker image as part of the build

  * The base image for the docker build is the AWS Lambda image, which means that our code sees exactly the same runtime environment as it would do if it was running as a JVM lambda (which is what it is currently doing).

* Within the `Dockerfile` (which is generated within the SBT build) the `CMD` parameter tells the lambda runtime environment which handler function should be called for this instance of the lambda. This is the part that is overwritten in the cloud formation for each instance of the lambda, to implement different behaviour for, e.g. Android vs iOS. This is analagous to the existing handler function configuration variable that is associated with a traditional Lambda.

* We create an Elastic Container Registry (ECR) repository which stores the docker images that are produced by the build step above. This ECR repository is defined in a new cloudformation file, ecr.yaml and the deploy tools root account is given write access to this repository, which allows Team City to upload the images after a successful build.

* The cloudformation which defines the lambdas (described in `sender-worker-cfn.yaml`) sets the `PackageType` for the Lambdas to Image, which is how we tell AWS that these lambdas are defined in a docker image. We point to the above ECR repository so that it knows where to find these images. The actual image to use is defined by the `BuildId` parameter for the CloudFormation stack, and this is set by RiffRaff during the deployment.

* The TeamCity build configuration is modified so that it runs the newly added `deploy.sh` script after succesfully building the image. This script will login to the ECR repository using `docker login` and the credentials that are available in team city, and it will then upload the image, tagging it with the build number.

  * Note that this change to the TeamCity settings really needs to be done after this PR is merged, otherwise it would cause the build to fail because it couldn't find the `deploy.sh` script. Currently it is wrapped in a condition so that it is only applied to this dev branch:

![image](https://user-images.githubusercontent.com/2242307/133412413-d2a7a01a-cc9b-4fc2-868c-0871c876945f.png)

There is at least one gotcha with deploying this: annoyingly you cannot change the `ImageType` of an existing Lambda, you have to destroy it and recreate it. This isn’t a problem as they are stateless, but it is annoying, as there are quite a few lambdas involved. In CODE I dealt this this by temporarily changing the name of the lambdas, deploying the cloudformation, then changing the name back again and redeploying it. Assuming there isn't a notification in progress then this shouldn't be observable by any users.

Another disadvantage is that it takes slightly longer to start up a lambda that uses a container image. However, I think this is reasonable, my testing suggests we are still up and running within a minute or so of triggering the notification alert in the Fronts tool, so I think this is still within the area of expected behaviour from this tool. But I am open to hearing otherwise!
