### PR TITLE
fixing cloudwatch logs permissions

### DIFF
--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -100,7 +100,7 @@ Resources:
             - logs:CreateLogStream
             - logs:PutLogEvents
             Resource:
-            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/${Stack}-${App}-${Stage}:*"
+            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/*:*"
       - PolicyName: SQSInput
         PolicyDocument:
           Statement:

--- a/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
+++ b/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
@@ -82,7 +82,7 @@ Resources:
             - logs:CreateLogStream
             - logs:PutLogEvents
             Resource:
-            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/${Stack}-${App}-${Stage}:*"
+            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/*:*"
       - PolicyName: SQS
         PolicyDocument:
           Statement:

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -107,7 +107,7 @@ Resources:
             - logs:CreateLogStream
             - logs:PutLogEvents
             Resource:
-            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/${Stack}-${App}-sender-${Stage}:*"
+            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/*:*"
       - PolicyName: SQSInput
         PolicyDocument:
           Statement:

--- a/notificationworkerlambda/topic-counter-cfn.yaml
+++ b/notificationworkerlambda/topic-counter-cfn.yaml
@@ -58,7 +58,7 @@ Resources:
             - logs:CreateLogStream
             - logs:PutLogEvents
             Resource:
-            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/${Stack}-${App}-${Stage}:*"
+            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/*:*"
       - PolicyName: VPC
         PolicyDocument:
           Statement:


### PR DESCRIPTION
A sneaky use of explicit Lambda names was hiding in the cloudformation, meaning that the policy which gives the notification lambdas permission to write to the cloudwatch logs was not being applied after PR#565.

This PR fixes this and also makes the policy less specific which I think is a reasonable comporomise, and it means that if the names change again for some reason we won't have this problem again.