### PR TITLE
alarms need to be updated for new lambda names

### DIFF
--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -189,7 +189,7 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
       - Name: FunctionName
-        Value: !Sub ${Stack}-${App}-${Stage}
+        Value: !Ref HarvesterLambdaCtr
       EvaluationPeriods: 1
       MetricName: Throttles
       Namespace: AWS/Lambda
@@ -226,7 +226,7 @@ Resources:
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Stack}-${App}-${Stage}
+          Value: !Ref HarvesterLambdaCtr
       EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda

--- a/notificationworkerlambda/sender-worker-cfn.yaml
+++ b/notificationworkerlambda/sender-worker-cfn.yaml
@@ -183,7 +183,7 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Stack}-${App}-sender-${Stage}
+          Value: !Ref SenderLambdaCtr
       EvaluationPeriods: 1
       MetricName: Throttles
       Namespace: AWS/Lambda
@@ -201,7 +201,7 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Stack}-${App}-sender-${Stage}
+          Value: !Ref SenderLambdaCtr
       EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
@@ -220,7 +220,7 @@ Resources:
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName
-          Value: !Sub ${Stack}-${App}-sender-${Stage}
+          Value: !Ref SenderLambdaCtr
       EvaluationPeriods: 1
       MetricName: Invocations
       Namespace: AWS/Lambda


### PR DESCRIPTION
As discussed on the call, this PR updates the alarms to use the new lambda names. In fact, I have updated them to use `!Ref`s to the actual lambda so they shouldn't be dependent on the name any more.

This is currently deploy on `CODE` and all seems well:

![image](https://user-images.githubusercontent.com/2242307/135503774-3dee934e-b30e-4e8e-abf3-79355b516008.png)
