### PR TITLE
Re-introduce firebase-admin dep upgrade to 6.16.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -366,7 +366,7 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
     dockerAlias := DockerAlias(registryHost = dockerRepository.value, username = None, name = (packageName in Docker).value, tag = buildNumber),
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
-      "com.google.firebase" % "firebase-admin" % "6.3.0",
+      "com.google.firebase" % "firebase-admin" % "6.16.0",
       "io.netty" % "netty-codec" % "4.1.46.Final",
       "io.netty" % "netty-codec-http" % "4.1.44.Final",
       "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -53,7 +53,7 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
     def notification: Notification
     def expected: Option[String]
 
-    private def expectedTrimmedJson = expected.map(s => new JsonParser().parse(s).toString)
+    private def expectedTrimmedJson = expected.map(s => JsonParser.parseString(s).toString)
     def checkPayload() = {
       val dummyConfig = new ApnsConfig(
         teamId = "",


### PR DESCRIPTION
This fixes the following snyk issue, as described in ticket [LIVE-2317](https://theguardian.atlassian.net/browse/LIVE-2317):

https://app.snyk.io/org/guardian-mobile/project/36f1c54a-4463-4454-8da5-4bd3fc14dfc8#issue-SNYK-JAVA-COMGOOGLEOAUTHCLIENT-575276

which is related to a transitive dependency on `google-oauth-client` as introduced by `firebase-admin`.

This fix was introduced in [PR 553](https://github.com/guardian/mobile-n10n/pull/553), but it was then reverted because it was not possible to deploy it due to hitting the maximum size of a jar-based lambda.

Now that these lambdas have been [converted to container images](https://github.com/guardian/mobile-n10n/pull/565), this [deploys cleanly](https://riffraff.gutools.co.uk/deployment/view/da4fe24d-76f0-43ec-9779-b43eb7a45d24).

_Note_: an intermittent deployment problem, not specifically related to this issue, might cause the to deploy to fail the first time, this is harmless and is described in more detail in ticket [LIVE-3140](https://theguardian.atlassian.net/browse/LIVE-3140).