### PR TITLE
Fix eventconsumer athena logging

### DIFF
--- a/eventconsumer/cfn.yaml
+++ b/eventconsumer/cfn.yaml
@@ -56,9 +56,7 @@ Resources:
             - logs:CreateLogStream
             - logs:PutLogEvents
             Resource:
-            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/eventconsumer-${Stage}:*"
-            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/eventconsumer-sqs-${Stage}:*"
-            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/eventconsumer-athena-${Stage}:*"
+            - !Sub "arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:/aws/lambda/${Stack}-${App}-athena-${Stage}:*"
       - PolicyName: Athena
         PolicyDocument:
           Statement:


### PR DESCRIPTION
The athena lambda cannot currently log to cloudwatch because stack has been added as a prefix to the function name but the corresponding policy not updated.

This PR also removes 2 resources that are no longer needed because the corresponding lambdas have been deleted.