### PR TITLE
Include a label within the container image which identifies which base image was used

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -332,30 +332,27 @@ lazy val eventconsumer = lambda("eventconsumer", "eventconsumer", Some("com.gu.n
   })
 
 lazy val latestVersionOfLambdaSDK = {
+  import scala.jdk.CollectionConverters._
   import com.github.dockerjava.core.DefaultDockerClientConfig
   import com.github.dockerjava.httpclient5.ApacheDockerHttpClient
   import com.github.dockerjava.core.DockerClientImpl
 
+  val imageName = "public.ecr.aws/lambda/java:latest"
+
   val dockerCfg = DefaultDockerClientConfig.createDefaultConfigBuilder().build()
-  val dockerHttp = new ApacheDockerHttpClient.Builder().build()
-  val docker = DockerClientImpl.getInstance(dockerCfg, dockerHttp);
+  val dockerHttp = new ApacheDockerHttpClient.Builder()
+    .dockerHost(dockerCfg.getDockerHost())
+    .sslConfig(dockerCfg.getSSLConfig())
+    .build();
+  val docker = DockerClientImpl.getInstance(dockerCfg, dockerHttp)
 
-  //  import com.spotify.docker.client.{DefaultDockerClient, DockerClient}
-  // import scala.jdk.CollectionConverters._
-  // // val imageName = "aperturedevelopment/friendup:latest"
-  // val imageName = "public.ecr.aws/lambda/java:latest"
+  val image = docker.inspectImageCmd(imageName).exec()
 
-  // docker.pull(imageName)
-  // for(image <- docker.listImages(DockerClient.ListImagesParam.filter("reference", imageName)).asScala) {
-  //   println(image.repoDigests())
-  // }
-  // // val imageDetails = .filter(_.repoDigests.size() > 0).head.repoDigests().asScala.head //inspectImage(imageName)
-  // // println(s"[PMR 1704] ${imageDetails}")
-  "latest"
+  image.getRepoDigests().asScala.head
 }
 
 lazy val lambdaDockerCommands = dockerCommands := Seq(
-  Cmd    ( "FROM",   s"public.ecr.aws/lambda/java@${latestVersionOfLambdaSDK}"),
+  Cmd    ( "FROM",   latestVersionOfLambdaSDK),
   Cmd    ( "LABEL",  s"sdkBaseVersion=${latestVersionOfLambdaSDK}"),
   ExecCmd( "COPY",   "1/opt/docker/*", "${LAMBDA_TASK_ROOT}/lib/"),
   ExecCmd( "COPY",   "2/opt/docker/*", "${LAMBDA_TASK_ROOT}/lib/"),

--- a/build.sbt
+++ b/build.sbt
@@ -346,6 +346,8 @@ lazy val latestVersionOfLambdaSDK = {
     .build();
   val docker = DockerClientImpl.getInstance(dockerCfg, dockerHttp)
 
+  docker.pullImageCmd(imageName).start().awaitCompletion()
+
   val image = docker.inspectImageCmd(imageName).exec()
 
   image.getRepoDigests().asScala.head

--- a/build.sbt
+++ b/build.sbt
@@ -331,8 +331,32 @@ lazy val eventconsumer = lambda("eventconsumer", "eventconsumer", Some("com.gu.n
     )
   })
 
+lazy val latestVersionOfLambdaSDK = {
+  import com.github.dockerjava.core.DefaultDockerClientConfig
+  import com.github.dockerjava.httpclient5.ApacheDockerHttpClient
+  import com.github.dockerjava.core.DockerClientImpl
+
+  val dockerCfg = DefaultDockerClientConfig.createDefaultConfigBuilder().build()
+  val dockerHttp = new ApacheDockerHttpClient.Builder().build()
+  val docker = DockerClientImpl.getInstance(dockerCfg, dockerHttp);
+
+  //  import com.spotify.docker.client.{DefaultDockerClient, DockerClient}
+  // import scala.jdk.CollectionConverters._
+  // // val imageName = "aperturedevelopment/friendup:latest"
+  // val imageName = "public.ecr.aws/lambda/java:latest"
+
+  // docker.pull(imageName)
+  // for(image <- docker.listImages(DockerClient.ListImagesParam.filter("reference", imageName)).asScala) {
+  //   println(image.repoDigests())
+  // }
+  // // val imageDetails = .filter(_.repoDigests.size() > 0).head.repoDigests().asScala.head //inspectImage(imageName)
+  // // println(s"[PMR 1704] ${imageDetails}")
+  "latest"
+}
+
 lazy val lambdaDockerCommands = dockerCommands := Seq(
-  Cmd    ( "FROM",   "public.ecr.aws/lambda/java:latest"),
+  Cmd    ( "FROM",   s"public.ecr.aws/lambda/java@${latestVersionOfLambdaSDK}"),
+  Cmd    ( "LABEL",  s"sdkBaseVersion=${latestVersionOfLambdaSDK}"),
   ExecCmd( "COPY",   "1/opt/docker/*", "${LAMBDA_TASK_ROOT}/lib/"),
   ExecCmd( "COPY",   "2/opt/docker/*", "${LAMBDA_TASK_ROOT}/lib/"),
   Cmd    ( "EXPOSE", "8080"), // this is the local lambda run time for testing

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,8 @@
+libraryDependencies ++= Seq(
+  "com.github.docker-java" % "docker-java-core" % "3.2.12",
+  "com.github.docker-java" % "docker-java-transport-httpclient5" % "3.2.12"
+)
+
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")


### PR DESCRIPTION
The first thing we do when creating the Docker image which is use for the notification lambdas, is to include set the parent image to be the latest instance of the [AWS Java Lambda runtime](https://gallery.ecr.aws/lambda/java):

```scala
// build.sbt
lazy val lambdaDockerCommands = dockerCommands := Seq(
Cmd    ( "FROM",   "public.ecr.aws/lambda/java:latest"),
```

This works fine, but there is no way to identify afterwards, by looking at the image, which version of the AWS lambda runtime image it was built from. This means that if a new version of the upstream image is released after this image was built, there is no way to show that this image was built on an old version and therefore needs to be updated.

What this change does is add a Docker `LABEL` to the freshly built image, which captures the checksum of the specific version of the lambda runtime that has been used during the building of this image. This is then permenantly baked into the image defintion and can therefore be queried later.

For example, after building an image with this new process, and uploading it to ECR, we can use the Docker `image inspect` [command](https://docs.docker.com/engine/reference/commandline/image_inspect/) to get the labels:

```
$ docker image inspect --format='{{.Config.Labels.sdkBaseVersion}}' 201359054765.dkr.ecr.eu-west-1.amazonaws.com/notificationworker-lambda-images:2553
public.ecr.aws/lambda/java@sha256:1dc489d4334b7135ac136c7b8dcb8c51e1bf58cebc28ff346e180279391b04e5
```

This then means that at a later date, we can get the current image pointed to by `latest`:

```
$ docker image inspect --format='{{join .RepoDigests "\n"}}' public.ecr.aws/lambda/java:latest
public.ecr.aws/lambda/java@sha256:1dc489d4334b7135ac136c7b8dcb8c51e1bf58cebc28ff346e180279391b04e5
```

and compare them.

Of course, once we have this information embedded in the image, we can also use it programmatically to automate this version check.

## How do we get the latest version?

In order to actually get the latest version, we need to communicate with the docker client to ask it to get the information for us. For this, we have introduced a dependency on the [docker-java library](https://github.com/docker-java/docker-java) which provides a handy Java API which we can use to talk to Docker. We could of course have just done this by making HTTP requests directly to the docker daemon, but this library handles that for us so it seems to make sense to do it this way instead.