### PR TITLE
update log4j dependency to fix security vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -252,7 +252,7 @@ def lambda(projectName: String, directoryName: String, mainClassName: Option[Str
     ),
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
-      "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0",
+      "com.amazonaws" % "aws-lambda-java-log4j2" % "1.3.0",
       "org.slf4j" % "slf4j-api" % "1.7.30",
       "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.15.0",
       "com.gu" %% "simple-configuration-core" % simpleConfigurationVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -254,7 +254,7 @@ def lambda(projectName: String, directoryName: String, mainClassName: Option[Str
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
       "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0",
       "org.slf4j" % "slf4j-api" % "1.7.30",
-      "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.13.3",
+      "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.15.0",
       "com.gu" %% "simple-configuration-core" % simpleConfigurationVersion,
       "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
       specs2 % Test


### PR DESCRIPTION
## What does this change?
Update log4j dependency to fix security vulnerability - see [doc](https://docs.google.com/document/d/1nVKsXiEXLviHOMY1iQEoyacvN93_SYCQwsOFfaP-dxo)

## How to test

Ran tests locally