### PR TITLE
Update sbt version to 1.5.6 to fix security vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ dynamodb-local-schedule-lambda/
 .scala_dependencies
 .worksheet
 **.DS_Store
+
+.metals/
+.vscode/
+.bloop/
+project/.bloop/
+project/metals.sbt
+.bsp/

--- a/api-models/version.sbt
+++ b/api-models/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.15"
+ThisBuild / version := "1.0.15"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.5.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,4 +20,4 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
 
-addSbtPlugin("net.virtual-void"   % "sbt-dependency-graph" % "0.10.0-RC1")
+addDependencyTreePlugin

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.10"
+ThisBuild / version := "1.0.10"


### PR DESCRIPTION
## What does this change?

Updates the sbt version to 1.5.6 to fix a security vulnerability introduced through log4j

## How to test

run sbt and test locally