### PR TITLE
Update aws-lambda-java-log4j2 to fix security vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -249,7 +249,7 @@ def lambda(projectName: String, directoryName: String, mainClassName: Option[Str
     ),
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
-      "com.amazonaws" % "aws-lambda-java-log4j2" % "1.3.0",
+      "com.amazonaws" % "aws-lambda-java-log4j2" % "1.4.0",
       "org.slf4j" % "slf4j-api" % "1.7.30",
       "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.16.0",
       "com.gu" %% "simple-configuration-core" % simpleConfigurationVersion,


### PR DESCRIPTION
## What does this change?
Updates aws-lambda-java-log4j2 to the latest version to help fix security vulnerability