### PR TITLE
Upgrade to log4j 2.17.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -249,9 +249,9 @@ def lambda(projectName: String, directoryName: String, mainClassName: Option[Str
     ),
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
-      "com.amazonaws" % "aws-lambda-java-log4j2" % "1.4.0",
+      "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.0",
       "org.slf4j" % "slf4j-api" % "1.7.30",
-      "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.16.0",
+      "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.17.0",
       "com.gu" %% "simple-configuration-core" % simpleConfigurationVersion,
       "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
       specs2 % Test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.6.0-RC2


### PR DESCRIPTION
## What does this change?

Upgrading version of log4j used to address identified [security vulnerability](https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.0)

- Upgrades version of log4j-core, aws-lambda-java-log4j2
- Upgrades SBT version that uses the upgraded log4j version

## How to test
Deploy in CODE.