### PR TITLE
Upgrade mobile-logstash-encoder version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val common = project
       "org.tpolecat" %% "doobie-specs2"    % doobieVersion % Test,
       "org.tpolecat" %% "doobie-scalatest" % doobieVersion % Test,
       "org.tpolecat" %% "doobie-h2"        % doobieVersion % Test,
-      "com.gu" %% "mobile-logstash-encoder" % "1.1.2",
+      "com.gu" %% "mobile-logstash-encoder" % "1.1.6",
       "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion
     ),
     fork := true,


### PR DESCRIPTION
## What does this change?

The `mobile-logstash-encoder` library has been released with a few enhancements / bug fixes. Updating n10n to use that upgraded library.

## How to test

Deploy branch in CODE; log lines should continue to include EC2 instance ID.