### PR TITLE
Wire up the CDK that was introduced in PR #580

### DIFF
--- a/notificationworkerlambda/cdk/lib/senderworker.ts
+++ b/notificationworkerlambda/cdk/lib/senderworker.ts
@@ -161,7 +161,7 @@ class SenderWorker extends cdk.Construct {
 
     // this advertises the name of the sender queue to the harvester app
     new ssm.StringParameter(this, 'SenderQueueSSMParameter', {
-      parameterName: `/notifications/${scope.stage}/workers/harvester/${opts.paramPrefix}LiveSqsCdkUrl`,
+      parameterName: `/notifications/${scope.stage}/workers/harvester/${opts.paramPrefix}SqsCdkUrl`,
       simpleName: false,
       stringValue: this.senderSqs.queueUrl,
       tier: ssm.ParameterTier.STANDARD,
@@ -241,8 +241,8 @@ export class SenderWorkerStack extends GuStack {
      * platform or app by talking to a different lambda handler function
      */
 
-    addWorker("ios", "ios", "com.gu.notifications.worker.IOSSender::handleChunkTokens")
-    addWorker("android", "android", "com.gu.notifications.worker.AndroidSender::handleChunkTokens")
+    addWorker("ios", "iosLive", "com.gu.notifications.worker.IOSSender::handleChunkTokens")
+    addWorker("android", "androidLive", "com.gu.notifications.worker.AndroidSender::handleChunkTokens")
     addWorker("ios-edition", "iosEdition", "com.gu.notifications.worker.IOSSender::handleChunkTokens")
     addWorker("android-edition", "androidEdition", "com.gu.notifications.worker.AndroidSender::handleChunkTokens")
     addWorker("android-beta", "androidBeta", "com.gu.notifications.worker.AndroidSender::handleChunkTokens")

--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -118,12 +118,8 @@ Resources:
             Resource:
               "Fn::Split":
                 - ","
-                - "Fn::Sub":
-                    - "${CfnParam},${ImportedValue}"
-                    - CfnParam: !Join [ ",", !Ref WorkerSqsArns ]
-                      ImportedValue:
-                        "Fn::ImportValue":
-                          "Fn::Sub": 'NotificationSenderWorkerQueueArns-${Stage}'
+                - "Fn::ImportValue":
+                    "Fn::Sub": 'NotificationSenderWorkerQueueArns-${Stage}'
       - PolicyName: VPC
         PolicyDocument:
           Statement:

--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -35,11 +35,6 @@ Parameters:
   VPCSecurityGroup:
     Type: AWS::EC2::SecurityGroup::Id
     Description: The default security group of the VPC
-  # keep this for now, so that we don't lose it's value on deploy, even though
-  # it is not actively being used
-  WorkerSqsArns:
-    Type: List<String>
-    Description: The ARNs of all the worker's queues
   AlarmTopic:
     Type: String
     Description: The ARN of the SNS topic to send all the cloudwatch alarms to

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -68,18 +68,11 @@ object Configuration {
     val config = fetchConfiguration("harvester")
     HarvesterConfiguration(
       jdbcConfig = jdbcConfig(config),
-      // currently this will ignore the CDK stack. To change to CDK, we should
-      // comment the next 5 lines, and uncomment the 5 lines following them.
-      iosLiveSqsUrl = config.getString("iosLiveSqsUrl"),
-      iosEditionSqsUrl = config.getString("iosEditionSqsUrl"),
-      androidLiveSqsUrl = config.getString("androidLiveSqsUrl"),
-      androidEditionSqsUrl = config.getString("androidEditionSqsUrl"),
-      androidBetaSqsUrl = config.getString("androidBetaSqsUrl")
-      // iosLiveSqsUrl = config.getString("iosLiveSqsCdkUrl"),
-      // iosEditionSqsUrl = config.getString("iosEditionSqsUrl"),
-      // androidLiveSqsUrl = config.getString("androidLiveSqsCdkUrl"),
-      // androidEditionSqsUrl = config.getString("androidEditionSqsUrl"),
-      // androidBetaSqsUrl = config.getString("androidBetaSqsUrl")
+      iosLiveSqsUrl = config.getString("iosLiveSqsCdkUrl"),
+      iosEditionSqsUrl = config.getString("iosEditionSqsCdkUrl"),
+      androidLiveSqsUrl = config.getString("androidLiveSqsCdkUrl"),
+      androidEditionSqsUrl = config.getString("androidEditionSqsCdkUrl"),
+      androidBetaSqsUrl = config.getString("androidBetaSqsCdkUrl")
     )
   }
 


### PR DESCRIPTION
PR #580 introduced a CDK version of the n10n sender lambdas, but in order to deploy it with an easy backout route, it was merged and deployed but not activated (i.e. Harvester is still using the old SQS queues which exist in parallel).

Everything looks like it went smoothly (and there have been numerous notifications sent out since it was deployed), so I think we are good to do the switchover now. 

As such, this change will activate the new CDK stack, after which time, once everything is confirmed to be working, we can tear down the old stack. This change is currently deployed on CODE and I have tested that it works and that it causes the notifications to switch over to the new stack.