### PR TITLE
replace the accidentally removed cleaning worker

### DIFF
--- a/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
+++ b/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
@@ -135,7 +135,7 @@ Resources:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
-      Description: Consumes queue events and sends notifications
+      Description: Pick tokens that have been marked for deletion from an SQS queue, and deletes them from the database
       ImageConfig:
         Command: [!Ref FullyQualifiedHandler]
       MemorySize: 1024

--- a/notificationworkerlambda/riff-raff.yaml
+++ b/notificationworkerlambda/riff-raff.yaml
@@ -23,6 +23,13 @@ deployments:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: topic-counter-cfn
       templatePath: topic-counter-cfn.yaml
+  mobile-notifications-registration-cleaning-worker-cfn:
+    type: cloud-formation
+    app: registration-cleaning-worker
+    parameters:
+      prependStackToCloudFormationStackName: false
+      cloudFormationStackName: registration-cleaning-worker-cfn
+      templatePath: registration-cleaning-worker-cfn.yaml
   mobile-notifications-expired-registration-cleaner-cfn:
     type: cloud-formation
     app: expired-registration-cleaner


### PR DESCRIPTION
When updating the `riffraff.yaml` for PR #580 , we accidentally removed one of the lambdas from the riffraff file which was still being used.

The effect of this is only that it has not been being redeployed, it wasn't actually deleted from AWS.

But we do need to reinsert this missing line in case we want to update its code later on.

I am also updating the description as it doesn't seem to match what this lambda does.