### PR TITLE
Update the function name for the registration cleaning worker lambda

### DIFF
--- a/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
+++ b/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
@@ -165,7 +165,7 @@ Resources:
       BatchSize: 1
       Enabled: True
       EventSourceArn: !GetAtt Sqs.Arn
-      FunctionName: !Sub ${Stack}-${App}-${Stage}
+      FunctionName: !Sub ${Stack}-${App}-ctr-${Stage}
 
 Outputs:
   SQSArn:


### PR DESCRIPTION
## What does this change?
The function name for the registration cleaning worker lambda sqs queue didn't include the updated "ctr" version, and so the link was broken between the lambda and the queue. This was only noticed when riff-raff made a change and triggered a build which updated the sqsmapping and the cloudformation failed to update. 

## How to test
The cloudformation succeeds in a build

## Have we considered potential risks?
The queue has 1600 messages on it that haven't been processed, hopefully the batch size of 1 means we just process one message at a time and it doesn't overwhelm the database