### PR TITLE
Snyk does not support the new addDependencyTreePlugin annotation

### DIFF
--- a/.github/workflows/cdk-test.yml
+++ b/.github/workflows/cdk-test.yml
@@ -8,14 +8,12 @@ on:
   pull_request:
     branches:
       - master
-    paths:
-      - "notificationworkerlambda/cdk/**"
 
   push:
     branches:
       - master
-    paths:
-      - "notificationworkerlambda/cdk/**"
+
+  workflow_dispatch:   
 
 jobs:
   cdk-test:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,4 +25,4 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
 
-addDependencyTreePlugin
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
## What does this change?

The snyk execution in the teamcity build failed because it does not support the new addDependencyTreePlugin annotation in `plugins.sbt`.  This PR is to change the way we added the dependency tree plugin to the project as instructed by Snyk.

## How to test

We started the build `mobile-notifications-snyk` in teamcity and it was successful.
