### PR TITLE
Resolve snyk issues by bumping jackson modules to latest version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,9 +28,9 @@ val catsVersion: String = "2.1.1"
 val okHttpVersion: String = "3.14.8"
 val paClientVersion: String = "7.0.5"
 val apacheThrift: String = "0.15.0"
-val jacksonDatabind: String = "2.10.5.1"
-val jacksonCbor: String = "2.12.1"
-val jacksonScalaModule: String = "2.12.3"
+val jacksonDatabind: String = "2.13.3"
+val jacksonCbor: String = "2.13.3"
+val jacksonScalaModule: String = "2.13.3"
 val simpleConfigurationVersion: String = "1.5.6"
 
 val standardSettings = Seq[Setting[_]](


### PR DESCRIPTION
## What does this change?

Bumping the jackson dependencies to resolve high severity security alerts from snyk.

In MAPI we found that we had errors if not all jackson dependencies were on the same version, hence why we're bumping all 3 jackson dependencies here in one go.