### PR TITLE
Renamed default branch from master to main

### DIFF
--- a/.github/workflows/cdk-test.yml
+++ b/.github/workflows/cdk-test.yml
@@ -7,11 +7,11 @@ defaults:
 on:
   pull_request:
     branches:
-      - master
+      - main
 
   push:
     branches:
-      - master
+      - main
 
   workflow_dispatch:   
 

--- a/api-models/README.markdown
+++ b/api-models/README.markdown
@@ -82,6 +82,6 @@ client.send(...).map { case Left(e: CompositeApiError) => ... }
 ## Releasing the library
 
 Because of the incompatibility of the play-json module between version 2.3 and 2.4, a different branch has been created.
-Each change that has been merged into ````master```` MUST be merged into the ````play-2.4```` branch
+Each change that has been merged into ````main```` MUST be merged into the ````play-2.4```` branch
 
 Once this is done, make sure to run ````sbt release```` on both branches


### PR DESCRIPTION
## What does this change?

We are renaming the default branch from `master` to `main`.

This PR updates the github action `cdk-test` workflow yaml and readme files on the name of default branch.

