### PR TITLE
Bump play framework to 2.8.16

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ libraryDependencies ++= Seq(
 
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.0")
 


### PR DESCRIPTION
## What does this change?

This PR bumps the play framework to version 2.8.16.  It fixes the vulnerability "com.typesafe.akka:akka-http-core_2.13
Improper Resource Shutdown or Release" found in snyk scan.

## How to test

All unit tests were passed.  Local snyk scan confirmed the vulnerability concerned was fixed.

