### PR TITLE
Add riffRaff upload settings to sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,9 @@ val standardSettings = Seq[Setting[_]](
     "Guardian GitHub Releases" at "https://guardian.github.com/maven/repo-releases",
     "Guardian GitHub Snapshots" at "https://guardian.github.com/maven/repo-snapshots"
   ),
+  riffRaffManifestProjectName := s"mobile-n10n:${name.value}",
+  riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
+  riffRaffUploadManifestBucket := Option("riffraff-builds"),
   libraryDependencies ++= Seq(
     "com.github.nscala-time" %% "nscala-time" % "2.24.0",
     "com.softwaremill.macwire" %% "macros" % "2.3.3" % "provided",


### PR DESCRIPTION
## What does this change?

We saw that we could not deploy a number of mobile-n10n modules (e.g. notification API, registration) in riff-raff.  Further investigation showed that some configurations were missing in the sbt:

<img width="1163" alt="Screenshot 2022-06-24 at 12 11 39" src="https://user-images.githubusercontent.com/89925410/175524035-a4b18a21-d80a-4549-a605-dbb4237cc04a.png">

This PR adds the required settings to sbt so that the riffRaffUpload could work for all modules.

## How to test

All mobile-n10n modules could be shown in riffraff deployment page after teamcity build.  We succeeded to deploy `notification` via riff-raff.

## Have we considered potential risks?

Yes, no risks were found as it changes the riffraff upload settings only.
