### PR TITLE
Bump sbt riffraff artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,8 +41,6 @@ val standardSettings = Seq[Setting[_]](
     "Guardian GitHub Snapshots" at "https://guardian.github.com/maven/repo-snapshots"
   ),
   riffRaffManifestProjectName := s"mobile-n10n:${name.value}",
-  riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
-  riffRaffUploadManifestBucket := Option("riffraff-builds"),
   libraryDependencies ++= Seq(
     "com.github.nscala-time" %% "nscala-time" % "2.24.0",
     "com.softwaremill.macwire" %% "macros" % "2.3.3" % "provided",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.8")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 


### PR DESCRIPTION
## What does this change?

In this [PR](https://github.com/guardian/mobile-n10n/pull/660#discussion_r906032803) it was suggested to bump sbt-riffraff-artifact to the latest version and then remove redundant configuration. This change implements the recommendations.

We can see in the corresponding build that team city has published [artifacts](https://teamcity.gutools.co.uk/buildConfiguration/Mobile_MobileNotificationsAll/782984?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandCode+inspection=true&showLog=782984_7618_5362&logView=flowAware) to the expected bucket and the associated build can be deployed via riffraff.

## How to test

Push commit
Validate team city publishes artifacts correctly
Validate build can be deployed via riffraff

