### PR TITLE
LIVE-4203: log system metrics for the notifications app

### DIFF
--- a/common/src/main/scala/models/NotificationLogging.scala
+++ b/common/src/main/scala/models/NotificationLogging.scala
@@ -1,0 +1,30 @@
+package models
+
+import net.logstash.logback.marker.LogstashMarker
+import net.logstash.logback.marker.Markers.appendEntries
+import org.slf4j.Logger
+
+import java.util.UUID
+
+import scala.jdk.CollectionConverters.MapHasAsJava
+
+sealed trait LoggingField {
+  val name: String
+  val value: Any
+}
+case class NotificationIdMarker(value: UUID, name: String = "notificationId") extends LoggingField
+case class NotificationTypeMarker(value: String, name: String = "notificationType") extends LoggingField
+case class NotificationTitleMarker(value: String, name: String = "notificationTitle") extends LoggingField
+case class ProcessingTimeMarker(value: Long, name: String = "processingTime") extends LoggingField
+
+trait NotificationLogging {
+  private def customLogstashMarkers(fields: List[LoggingField]): LogstashMarker = {
+    val customLogstashMarkers = fields.map(field => (field.name, field.value)).toMap.asJava
+    appendEntries(customLogstashMarkers)
+  }
+
+  def logInfoWithCustomMarkers(message: String, fields: List[LoggingField])(implicit logger: Logger): Unit =
+    logger.info(customLogstashMarkers(fields), message)
+}
+
+object NotificationLogging extends NotificationLogging

--- a/common/src/main/scala/models/NotificationLogging.scala
+++ b/common/src/main/scala/models/NotificationLogging.scala
@@ -16,6 +16,7 @@ case class NotificationIdField(value: UUID, name: String = "notificationId") ext
 case class NotificationTypeField(value: String, name: String = "notificationType") extends LoggingField
 case class NotificationTitleField(value: String, name: String = "notificationTitle") extends LoggingField
 case class ProcessingTimeField(value: Long, name: String = "processingTime") extends LoggingField
+case class NotificationStartTimeField(value: Long, name: String = "notificationStartTime") extends LoggingField
 
 trait NotificationLogging {
   private def customLogstashFields(fields: List[LoggingField]): LogstashMarker = {

--- a/common/src/main/scala/models/NotificationLogging.scala
+++ b/common/src/main/scala/models/NotificationLogging.scala
@@ -12,19 +12,19 @@ sealed trait LoggingField {
   val name: String
   val value: Any
 }
-case class NotificationIdMarker(value: UUID, name: String = "notificationId") extends LoggingField
-case class NotificationTypeMarker(value: String, name: String = "notificationType") extends LoggingField
-case class NotificationTitleMarker(value: String, name: String = "notificationTitle") extends LoggingField
-case class ProcessingTimeMarker(value: Long, name: String = "processingTime") extends LoggingField
+case class NotificationIdField(value: UUID, name: String = "notificationId") extends LoggingField
+case class NotificationTypeField(value: String, name: String = "notificationType") extends LoggingField
+case class NotificationTitleField(value: String, name: String = "notificationTitle") extends LoggingField
+case class ProcessingTimeField(value: Long, name: String = "processingTime") extends LoggingField
 
 trait NotificationLogging {
-  private def customLogstashMarkers(fields: List[LoggingField]): LogstashMarker = {
-    val customLogstashMarkers = fields.map(field => (field.name, field.value)).toMap.asJava
-    appendEntries(customLogstashMarkers)
+  private def customLogstashFields(fields: List[LoggingField]): LogstashMarker = {
+    val customFields = fields.map(field => (field.name, field.value)).toMap.asJava
+    appendEntries(customFields)
   }
 
   def logInfoWithCustomMarkers(message: String, fields: List[LoggingField])(implicit logger: Logger): Unit =
-    logger.info(customLogstashMarkers(fields), message)
+    logger.info(customLogstashFields(fields), message)
 }
 
 object NotificationLogging extends NotificationLogging

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -73,10 +73,10 @@ final class Main(
         result.foreach(_ => logInfoWithCustomMarkers(
             s"Spent ${System.currentTimeMillis() - startTime} milliseconds processing notification ${notification.id}",
             List(
-              NotificationIdMarker(notification.id),
-              ProcessingTimeMarker(System.currentTimeMillis() - startTime),
-              NotificationTypeMarker(notification.`type`.toString),
-              NotificationTitleMarker(notification.title.getOrElse("Unknown")),
+              NotificationIdField(notification.id),
+              ProcessingTimeField(System.currentTimeMillis() - startTime),
+              NotificationTypeField(notification.`type`.toString),
+              NotificationTitleField(notification.title.getOrElse("Unknown")),
         )))
         result
     }) recoverWith {

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -77,6 +77,7 @@ final class Main(
               ProcessingTimeField(System.currentTimeMillis() - startTime),
               NotificationTypeField(notification.`type`.toString),
               NotificationTitleField(notification.title.getOrElse("Unknown")),
+              NotificationStartTimeField(startTime)
         )))
         result
     }) recoverWith {

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -70,7 +70,10 @@ final class Main(
         Future.successful(Unauthorized(s"This API key is not valid for ${topics.filterNot(topic => request.isPermittedTopicType(topic.`type`))}."))
       case _ =>
         val result = pushWithDuplicateProtection(notification)
-        result.foreach(_ => logger.info(s"Spent ${System.currentTimeMillis() - startTime} milliseconds processing notification ${notification.id}"))
+        result.foreach(_ => logger.info(
+          s"Spent ${System.currentTimeMillis() - startTime} milliseconds processing notification ${notification.id}",
+          Map("notificationId" -> notification.id, "notificationAppProcessingTime" -> (System.currentTimeMillis() - startTime))
+        ))
         result
     }) recoverWith {
       case NonFatal(exception) => {

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -78,7 +78,7 @@ final class Main(
       case _ =>
         val result = pushWithDuplicateProtection(notification)
         result.foreach(_ => logger.info(
-          customFieldMarkers(Map("notificationId" -> notification.id)),
+          customFieldMarkers(Map("notificationId" -> notification.id, "processingTime" -> (System.currentTimeMillis() - startTime))),
           s"Spent ${System.currentTimeMillis() - startTime} milliseconds processing notification ${notification.id}",
         ))
         result

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -5,6 +5,7 @@ import authentication.AuthAction
 import com.amazonaws.services.cloudwatch.model.StandardUnit
 import metrics.{CloudWatchMetrics, MetricDataPoint}
 import models.{TopicTypes, _}
+import models.NotificationLogging._
 import notification.models.PushResult
 import notification.services
 import notification.services.{ArticlePurge, Configuration, NewsstandSender, NotificationSender}
@@ -14,12 +15,9 @@ import play.api.libs.json.Json.toJson
 import play.api.mvc._
 import tracking.Repository.RepositoryResult
 import tracking.SentNotificationReportRepository
-import net.logstash.logback.marker.LogstashMarker
-import net.logstash.logback.marker.Markers._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
-import scala.jdk.CollectionConverters.MapHasAsJava
 
 final class Main(
   configuration: Configuration,
@@ -33,7 +31,7 @@ final class Main(
 )(implicit executionContext: ExecutionContext)
   extends AbstractController(controllerComponents) {
 
-  private val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  implicit private val logger: Logger = LoggerFactory.getLogger(this.getClass)
   val weekendReadingTopic = Topic(TopicTypes.TagSeries, "membership/series/weekend-reading")
   val weekendRoundUpTopic = Topic(TopicTypes.TagSeries, "membership/series/weekend-round-up")
 
@@ -60,11 +58,6 @@ final class Main(
     }
   }
 
-  def customFieldMarkers(fields: Map[String, Any]): LogstashMarker = {
-    val fieldsMap = fields.asJava
-    appendEntries(fieldsMap)
-  }
-
   def pushTopics: Action[Notification] = authAction.async(parse.json[Notification]) { request =>
     val startTime = System.currentTimeMillis()
     val notification = request.body
@@ -77,15 +70,14 @@ final class Main(
         Future.successful(Unauthorized(s"This API key is not valid for ${topics.filterNot(topic => request.isPermittedTopicType(topic.`type`))}."))
       case _ =>
         val result = pushWithDuplicateProtection(notification)
-        result.foreach(_ => logger.info(
-          customFieldMarkers(Map(
-            "notificationId" -> notification.id,
-            "processingTime" -> (System.currentTimeMillis() - startTime),
-            "notificationType" -> notification.`type`.toString,
-            "notificationTitle" -> notification.title.getOrElse("Unknown"),
-          )),
-          s"Spent ${System.currentTimeMillis() - startTime} milliseconds processing notification ${notification.id}",
-        ))
+        result.foreach(_ => logInfoWithCustomMarkers(
+            s"Spent ${System.currentTimeMillis() - startTime} milliseconds processing notification ${notification.id}",
+            List(
+              NotificationIdMarker(notification.id),
+              ProcessingTimeMarker(System.currentTimeMillis() - startTime),
+              NotificationTypeMarker(notification.`type`.toString),
+              NotificationTitleMarker(notification.title.getOrElse("Unknown")),
+        )))
         result
     }) recoverWith {
       case NonFatal(exception) => {

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -81,7 +81,7 @@ final class Main(
           customFieldMarkers(Map(
             "notificationId" -> notification.id,
             "processingTime" -> (System.currentTimeMillis() - startTime),
-            "notificationType" -> notification.`type`,
+            "notificationType" -> notification.`type`.toString,
             "notificationTitle" -> notification.title.getOrElse("Unknown"),
           )),
           s"Spent ${System.currentTimeMillis() - startTime} milliseconds processing notification ${notification.id}",

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -78,7 +78,12 @@ final class Main(
       case _ =>
         val result = pushWithDuplicateProtection(notification)
         result.foreach(_ => logger.info(
-          customFieldMarkers(Map("notificationId" -> notification.id, "processingTime" -> (System.currentTimeMillis() - startTime))),
+          customFieldMarkers(Map(
+            "notificationId" -> notification.id,
+            "processingTime" -> (System.currentTimeMillis() - startTime),
+            "notificationType" -> notification.`type`,
+            "notificationTitle" -> notification.title.getOrElse("Unknown"),
+          )),
           s"Spent ${System.currentTimeMillis() - startTime} milliseconds processing notification ${notification.id}",
         ))
         result


### PR DESCRIPTION
## What does this change?

This change adds some custom logging into the notification app (the harvester and workers apps will have additional logging in subsequent PRs). The aim is to increase observability of the performance of the notification send flow and forms part of a task to implement a test rig in CODE that enables us to understand/measure changes to our system.

Some rationale for the abstraction of the custom logging fields:
- I moved it into common because multiple apps will probably want to log with custom fields
- The custom log fields rely on a change to the index pattern in our elk stack. The additional fields that have been manually added include a specified type, which now matches the types for the `value` in the case classes.

The custom logs will power a [dashboard](https://logs.gutools.co.uk/s/mobile/goto/2ee47100-f637-11ec-a2fe-3d2cf57c73cd)

The notification start time on its own may not be super helpful (it's also being sent as a long, milliseconds since the epoch) - however, in the worker lambda I plan to log the eventual end time. I'm hoping I'll be able to diff the start and end times to get a ms duration for the overall send time.

## How to test

When a notification is sent we should see additional properties included, eg:
<img width="1436" alt="Screenshot 2022-06-27 at 17 36 28" src="https://user-images.githubusercontent.com/45561419/175991161-fab13ca8-eb75-4071-bb57-61d28ef68449.png">


## How can we measure success?

We can utilise the custom log fields to power our dashboard.

