### PR TITLE
Revert "LIVE-4234 increase shard size"

### DIFF
--- a/notification/app/notification/services/guardian/GuardianNotificationSender.scala
+++ b/notification/app/notification/services/guardian/GuardianNotificationSender.scala
@@ -26,7 +26,7 @@ class GuardianNotificationSender(
   harvesterSqsUrl: String,
 )(implicit ec: ExecutionContext) extends NotificationSender {
 
-  val WORKER_BATCH_SIZE: Int = 20000
+  val WORKER_BATCH_SIZE: Int = 10000
   val SQS_BATCH_SIZE: Int = 10
 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)

--- a/notification/test/notification/services/guardian/GuardianNotificationSenderSpec.scala
+++ b/notification/test/notification/services/guardian/GuardianNotificationSenderSpec.scala
@@ -65,7 +65,7 @@ class GuardianNotificationSenderSpec(implicit ee: ExecutionEnv) extends Specific
       val futureResult = notificationSender.sendNotification(notification)
       val result = Await.result(futureResult, 10.seconds)
 
-      there was exactly(15)(sqsClient).sendMessageBatchAsync(any[SendMessageBatchRequest], any[AsyncHandler[SendMessageBatchRequest, SendMessageBatchResult]])
+      there was exactly(30)(sqsClient).sendMessageBatchAsync(any[SendMessageBatchRequest], any[AsyncHandler[SendMessageBatchRequest, SendMessageBatchResult]])
 
       result should beRight.which { senderReport =>
         senderReport.senderName shouldEqual "Guardian"


### PR DESCRIPTION
Reverts guardian/mobile-n10n#659

Looking at the stats for our 90% in 2mins target, it appears that this change hasn't improved the situation:

<img width="1680" alt="90-in-2-Shard-Change-Before-And-After" src="https://user-images.githubusercontent.com/45561419/178442254-1bb089d4-76ad-498d-8643-4fcac11b6126.png">

We agreed to revert and continue to monitor.
