### PR TITLE
Add stream to notifications-reports dynamo table

### DIFF
--- a/dynamo.yaml
+++ b/dynamo.yaml
@@ -35,3 +35,5 @@ Resources:
       TimeToLiveSpecification:
         Enabled: true
         AttributeName: ttl
+      StreamSpecification:
+        StreamViewType: NEW_IMAGE


### PR DESCRIPTION
For the apps metering project we need an event stream from the notifications table. We can use this to exclude articles from metering.
Because the notifications service writes to the dynamo table before initiating the send, we should get these events ahead of the mobile apps.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-streamspecification.html