### PR TITLE
Do not merge: Embedded metric format proof of concept

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -127,6 +127,15 @@ trait HarvesterRequestHandler extends Logging {
       val end = Instant.now
       records.foreach(record =>
         logger.info(Map(
+          "_aws" -> Map("Timestamp" -> end.toEpochMilli,
+          "CloudWatchMetrics" -> List(Map(
+            "Namespace" -> s"Notifications/${env.stage}/harvester",
+            "Dimensions" -> List()),
+            "Metrics" -> List(Map(
+              "Name" -> "harvester.notificationProcessingTime",
+              "Unit" -> "Milliseconds"
+            ))
+          )),
           "notificationId" -> record.notification.id,
           "notificationType" -> record.notification.`type`.toString,
           "harvester.notificationProcessingTime" -> Duration.between(start, end).toMillis,

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -127,15 +127,17 @@ trait HarvesterRequestHandler extends Logging {
       val end = Instant.now
       records.foreach(record =>
         logger.info(Map(
-          "_aws" -> Map("Timestamp" -> end.toEpochMilli,
-          "CloudWatchMetrics" -> List(Map(
-            "Namespace" -> s"Notifications/${env.stage}/harvester",
-            "Dimensions" -> List()),
-            "Metrics" -> List(Map(
-              "Name" -> "harvester.notificationProcessingTime",
-              "Unit" -> "Milliseconds"
+          "_aws" -> Map(
+            "Timestamp" -> end.toEpochMilli,
+            "CloudWatchMetrics" -> List(Map(
+              "Namespace" -> s"Notifications/${env.stage}/harvester",
+              "Dimensions" -> List(List()),
+              "Metrics" -> List(Map(
+                "Name" -> "harvester.notificationProcessingTime",
+                "Unit" -> "Milliseconds"
+              ))
             ))
-          )),
+          ),
           "notificationId" -> record.notification.id,
           "notificationType" -> record.notification.`type`.toString,
           "harvester.notificationProcessingTime" -> Duration.between(start, end).toMillis,


### PR DESCRIPTION
## What does this change?
This is a proof of concept PR to demonstate the validity of using the [AWS embedded metric format](https://aws.amazon.com/about-aws/whats-new/2019/11/amazon-cloudwatch-launches-embedded-metric-format/) to capture metrics directly from the log processing without incurring the cost or potential blocking of a cloudwatch.putMetric() command.
This is a solution to a problem tracking historical SLI's for the mobile team. The root of the problem is that, as the metrics are pulled from the logs by a kibana or grafana dashboard, there is currently no way to persist the vaues beyond the lifetime of those log files.

The solution we propose is to log these values as cloudwatch metrics. These persist more or less permanently 
and can then be accesed by dashboarding software - eg grafana - and displayed at will. 

Normally metrics are sent to cloudwatch using a putMetric() request. However this is both a blocking call - so adds risk and slows things down - and has a specific cost of $US0.01 per 1000 requests.
AWS embedded metric format avoids both of these. The processing cost falls on AWS as it is handled as part of their log processing procedures and as we are not using a putMetric() request, we avoid the above mentioned cost.

This code contains a working example of a metric being sent as part of a log message. We have tested in code and confirmed that this metric is indeed created.
Full details on the format needed to take advantage of this is [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html#CloudWatch_Embedded_Metric_Format_Specification_structure_metricdirective) 

In addition an excellent study of using these metrics is in the first 10 minutes of [this video](https://youtu.be/HdopVzW6pX0)