### PR TITLE
Bump the Postgresql library to 42.4.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,7 @@ lazy val common = project
       "io.netty" % "netty-codec-http" % nettyVersion,
       "io.netty" % "netty-codec-http2" % nettyVersion,
       "io.netty" % "netty-common" % nettyVersion,
-      "org.postgresql" % "postgresql" % "42.3.3",
+      "org.postgresql" % "postgresql" % "42.4.1",
     ),
     fork := true,
     startDynamoDBLocal := startDynamoDBLocal.dependsOn(Test / compile).value,


### PR DESCRIPTION
## What does this change?

The PR bumps the Postgresql client library to version 42.4.1 to fix the snyk vulnerability of sql injection.

## How to test

All unit tests pass.


