### PR TITLE
Bump the protobuf library to 3.19.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -401,6 +401,7 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
       "com.google.firebase" % "firebase-admin" % "8.1.0",
+      "com.google.protobuf" % "protobuf-java" % "3.19.2",
       "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",
       "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,


### PR DESCRIPTION
## What does this change?

This PR bumps the protocol buffer library to 3.19.2 to fix the snyk vulnerability of Denial of Service.

## How to test

All unit tests passed.
