### PR TITLE
LIVE-3899 postgresql upgrade

### DIFF
--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -212,7 +212,9 @@ Disadvantages:
 1. More sophisticated operations
 
 Procedure: https://aws.amazon.com/blogs/database/using-logical-replication-to-replicate-managed-amazon-rds-for-postgresql-and-amazon-aurora-to-self-managed-postgresql/
+
 RDS Supports logical replication: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication
+
 Postgresql: https://www.postgresql.org/docs/10/logical-replication.html
 
 ### Option 5: Manual data copy
@@ -249,3 +251,9 @@ Disadvantages:
 2. Readers may find our system unreliable (subscribing to a topic but later find that it is not on our database)
 
 Reference: https://www.postgresql.org/docs/10/backup-dump.html
+
+## Conclusion and Recommendation
+Since the option 4 has the shortest downtime and the logical replication have been tested on the test rig database, it is recommended to upgrade the database from Postgresql 10.18 to Postgresql 13.4 using this approach.
+
+The detailed procedures have been prepared in this [document](./03-postresql-upgrade-procedure.md).
+

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -1,0 +1,229 @@
+
+# Registrations Database Upgrade
+
+We are working to improve the performance of our notification delivery pipeline.  We are going to upgrade the registrations database from Postgresql 10 to its higher major version because of the following reasons:
+
+1. Improvement to existing features in newer versions of Postgresql
+2. Support for new features which may be useful to our work
+3. Gravitron2 processor (instance class t4g) is supported for Postgresql 12 or above.  The processor delivers up to [40% better price performance](https://aws.amazon.com/about-aws/whats-new/2020/09/announcing-new-amazon-ec2-t4g-instances-powered-by-aws-graviton2-processors/) over T3 instances.
+4. The PostgreSQL community will [discontinue support for PostgreSQL 10 on November 10 2022](https://www.postgresql.org/support/versioning/), and will no longer provide bug fixes or security patches for this version.
+
+## Postgresql version we upgrade to
+
+I list out the major enhancements in each of major versions which may be relevant to registrations database as below
+
+### Postgresql 11
+1. Better support for table partitioning (which may be a good way to optimize our database)
+- Add support for primary key on partitioned tables
+- Allow *default* partition
+- Allow update on partition key columns
+- Enhance partition elimination strategies
+
+Reference: https://www.postgresql.org/docs/11/release.html
+
+### Postgresql 12
+1. Optimizations to space utilization and read/write performance for B-tree indexes
+2. Improve performance of many operations on partitioned tables
+3. REINDEX CONCURRENTLY can rebuild an index without blocking writes to its table
+
+Reference: https://www.postgresql.org/docs/12/release.html
+
+### Postgresql 13
+1. Space savings and performance gains from de-duplication of B-tree index entries
+- Expect a considerable amount of duplicated values of (topic, shard) in the index
+2. Improved performance for queries that use partitioned tables
+- Allow pruning of partitions to happen in more cases
+- Allow partitioned tables in logical replication
+3. Minor: Implement incremental sorting
+
+Reference: https://www.postgresql.org/docs/13/release.html
+
+### Postgresql 14
+1. Improve the performance of updates and deletes on partitioned tables with many partitions
+2. Reduce index bloat on tables whose indexed columns are frequently updated.
+3. Improve vacuum operations in reclaiming space
+
+Reference: https://www.postgresql.org/docs/14/release.html
+
+## RDS Proxy and Progresql upgrade
+The latest major version of Postgreql which RDS proxy supports is [version 13](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html#rds-proxy.support).  So we have two options:
+
+1. Upgrade to Postgresql 14 without RDS proxy 
+2. Upgrade to Postgresql 13 with RDS proxy
+
+The major enhancements of postgresl 14 which are relevant to our system are feature improvement but they are not critical to our DB tuning work.  Moreover, our previous performance test suggests that RDS proxy can help with the performance, probably because it manages a lot of short-lived database connections from harvester functions and move the workload away from the database instance.  So I recommend upgrading to Postgresql 13.  We always have the option of upgrading again from Postgresql 13 to 14.
+
+## Performance test with Postgresql 13
+
+## Upgrade procedure
+In addition to upgrading the database engine, we are going to execute the following operations:
+1. Back up existing PROD
+2. Change the instance class from `t3` to `t4g`
+3. Re-generate optimizer statistics (step 14 in [user guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion.Process)) as the upgrade process does not transfer the optimizer statistics
+4. Re-indexing so that the existing indexes can use new features provided by the upgraded database engine (for example, check E.8.3.1.2. Indexes in this [release note](https://www.postgresql.org/docs/13/release-13.html#id-1.11.6.12.5))
+
+I came up with the following options to perform the major version ugprade.
+
+### Option 1: Use AWS RDS in-place upgrade
+
+We just go ahead with modifying the DB engine via AWS console.
+
+```mermaid
+gantt
+    title Approach 1 - In-place upgrade
+    dateFormat  HH:mm:ss
+    axisFormat  %H:%M:%S
+    section Operation
+    Upgrade to postgres13             :crit,active, a1, 00:00:00, 30min
+    Change instance class             :crit,active, a2, after a1, 20min
+    Reindexing and optimizer stats    :crit,active, a3, after a2, 10min
+    Service restored                  :milestone, after a3, 0min
+    section Impact 
+    No registration                   :crit, c1a, 00:00:00, 60min
+    No notification                   :crit, c1b, 00:00:00, 60min
+```
+
+Rollback:
+1. Restore the latest snapshot
+Pro:
+1. Simplest way
+Con:
+1. Service downtime throughout the upgrade
+
+
+### Option 2: Create a new instance for Postgres13 database
+
+We create a new instance from the latest snapshot from registrations database and make changes to it.
+
+```mermaid
+gantt
+    title Approach 2 - Create new Postgres13 database
+    dateFormat  HH:mm:ss
+    axisFormat  %H:%M:%S
+    section PROD DB
+    Backup                            :a1, 00:00:00, 5min
+    section PG13 DB
+    Restore                           :b1, after a1, 20min
+    Upgrade to postgres13             :crit,active, b2, after b1, 30min
+    Change instance class             :crit,active, b3, after b2, 20min
+    Reindexing / optimizer stats      :crit,active, b4, after b3, 10min
+    Switchover                        :b5, after b4, 5min
+    Serving notifications             :milestone, after b5, 0min
+    section Impact 
+    Registration lost       :crit, c1a, 00:00:00, 90min
+    Notification available  :done, c1b, 00:00:00, 90min
+    Normal                  :done, c2, after c1a c1b, 5min
+```
+
+Rollback:
+1. Before switchover, no action is needed
+2. After switchover, we have to switch back to roll back
+Pro:
+1. No downtime to breaking news notification
+Con:
+1. Changes to registrations database that happen during upgrade will be lost after switchover
+2. Readers may find our system unreliable (subscribing to a topic but later find that it is not on our database)
+
+### Option 3: Maintain breaking news notification service in temporary database
+
+We create a tempoarary instance from the latest snapshot from registrations database and serve the breaking news notifications there.
+
+```mermaid
+gantt
+    title Approach 3 - Create temporary database to serve breaking news
+    dateFormat  HH:mm:ss
+    axisFormat  %H:%M:%S
+    section PROD DB
+    Backup                            :a1, 00:00:00, 5min
+    Upgrade to postgres13             :crit,active, a2, after b2, 30min
+    Change instance class             :crit,active, a3, after a2, 20min
+    Reindexing / optimizer stats      :crit,active, a4, after a3, 10min
+    Switch back                       :a5, after a4, 5min
+    Serving all                       :milestone, after a5, 0min
+    section Temp DB
+    Restore                           :b1, after a1, 20min
+    Switchover lambda workers         :b2, after b1, 5min
+    Serving harvester                 :milestone, after b2, 0min
+    section Impact 
+    Normal                  :done, c1, 00:00:00, 30min
+    No registration         :crit, c2b, after c1, 60min
+    Notification available  :done, c2a, after c1, 60min
+    Normal                  :done, c3, after c2a c2b, 5min    
+```
+
+Rollback:
+1. *Promote* the temporary database to be the primary registration database
+2. Switch all services to the temporary database
+Pro:
+1. No downtime to breaking news notification
+2. Readers is not able to register for a topic (rather than able to register but later the registration is lost).  *Arguably* it is better for the system to give a predictable outcome.
+Con:
+1. Downtime to registrations API
+
+
+### Option 4: Logical replication
+
+We create an empty Postgresql 13 database and use logical replication to continuously replicate data from production database.
+
+Logical replication has some limitations, which however does not affect us in our case.
+
+```mermaid
+gantt
+    title Approach 4 - Logical replicaton
+    dateFormat  HH:mm:ss
+    axisFormat  %H:%M:%S
+    section PROD DB
+    Enable replication                :a1, 00:00:00, 5min
+    Create publication                :a2, after a1, 5min
+    Synchronise                       :a3, after b1, 30min
+    section PG13 DB
+    Create subscription               :b1, after a2, 5min
+    Synchronise                       :b2, after b1, 30min
+    Stop subscription                 :b3, after b2, 5min
+    Switchover                        :b4, after b3, 5min
+    Serving all                       :milestone, after b4, 0min
+    section Impact 
+    No registration                   :crit, c1a, 00:00:00, 5min
+    No notification                   :crit, c1b, 00:00:00, 5min
+    Normal                            :done, c2, after c1a c1b, 35min
+    Registration lost                 :crit, c3a, after b3, 5min
+    Notification available            :done, c3b, after b3, 5min
+    Normal                            :done, c4, after c3a c3b, 5min    
+```
+
+Rollback:
+1. Before switchover, no action
+2. After switchover, switch back to the original PROD DB
+Pro:
+1. Minimal downtime
+2. Prepare an empty Postgresql 13 database beforehand
+Con:
+1. More sophisticated operations
+
+Procedure: https://aws.amazon.com/blogs/database/using-logical-replication-to-replicate-managed-amazon-rds-for-postgresql-and-amazon-aurora-to-self-managed-postgresql/
+RDS Supports logical replication: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication
+Postgresql: https://www.postgresql.org/docs/10/logical-replication.html
+
+### Option 5: Manual data copy
+
+We create an empty Postgresql 13 database and use pg_dump to copy data across the database
+
+```mermaid
+gantt
+    title Approach 5 - Manual data copy
+    dateFormat  HH:mm:ss
+    axisFormat  %H:%M:%S
+    section PROD DB
+    Create database dump              :a1, 00:00:00, 15min
+    section PG13 DB
+    Restore from dump                 :b1, after a1, 15min
+    Reindexing and optimizer stats    :b2, after a1, 10min
+    Switchover                        :b3, after b2, 5min
+    Serving all                       :milestone, after b2, 0min
+    section Impact 
+    Registration lost                 :crit, c1a, 00:00:00, 45min
+    Notification available            :done, c1b, 00:00:00, 45min
+    Normal                            :done, c2, after b2, 5min
+```
+
+Reference: https://www.postgresql.org/docs/10/backup-dump.html

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -232,13 +232,13 @@ gantt
     section PROD DB
     Create database dump              :a1, 00:00:00, 25min
     section PG13 DB
-    Restore from dump                 :b1, after a1, 20min
-    Reindexing and optimizer stats    :b2, after b1, 5min
+    Restore from dump                 :b1, after a1, 25min
+    Reindexing and optimizer stats    :b2, after b1, 10min
     Switchover                        :b3, after b2, 5min
     Serving all                       :milestone, after b3, 0min
     section Impact 
-    Registration lost                 :crit, c1a, 00:00:00, 55min
-    Notification available            :done, c1b, 00:00:00, 55min
+    Registration lost                 :crit, c1a, 00:00:00, 65min
+    Notification available            :done, c1b, 00:00:00, 65min
     Normal                            :done, c2, after b3, 5min
 ```
 

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -214,16 +214,16 @@ gantt
     dateFormat  HH:mm:ss
     axisFormat  %H:%M:%S
     section PROD DB
-    Create database dump              :a1, 00:00:00, 15min
+    Create database dump              :a1, 00:00:00, 25min
     section PG13 DB
-    Restore from dump                 :b1, after a1, 15min
-    Reindexing and optimizer stats    :b2, after a1, 10min
+    Restore from dump                 :b1, after a1, 25min
+    Reindexing and optimizer stats    :b2, after b1, 10min
     Switchover                        :b3, after b2, 5min
-    Serving all                       :milestone, after b2, 0min
+    Serving all                       :milestone, after b3, 0min
     section Impact 
-    Registration lost                 :crit, c1a, 00:00:00, 45min
-    Notification available            :done, c1b, 00:00:00, 45min
-    Normal                            :done, c2, after b2, 5min
+    Registration lost                 :crit, c1a, 00:00:00, 65min
+    Notification available            :done, c1b, 00:00:00, 65min
+    Normal                            :done, c2, after b3, 5min
 ```
 
 Reference: https://www.postgresql.org/docs/10/backup-dump.html

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -53,6 +53,8 @@ The latest major version of Postgreql which RDS proxy supports is [version 13](h
 
 The major enhancements of postgresl 14 which are relevant to our system are feature improvement but they are not critical to our DB tuning work.  Moreover, our previous performance test suggests that RDS proxy can help with the performance, probably because it manages a lot of short-lived database connections from harvester functions and move the workload away from the database instance.  So I recommend upgrading to Postgresql 13.  We always have the option of upgrading again from Postgresql 13 to 14.
 
+At this moment, if we use AWS in-place upgrade, the registrations database (version 10.18) can be upgraded to [version 13.4](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion).  The database will be automatically upgraded to the latest "automatic upgrade version", which is version 13.6 at the moment, during maintenance window.
+
 ## Performance test with Postgresql 13
 The test result can be found in this [document](../testing/06-postgresql-upgrade.md).  Apparently it does not have direct impact on the performance.  However, Postgresql 13 improves the way the index is maintained and the way it does the vacuum and index rebuilding operations, which are useful to our database in the long run.  In addition, it provides a much better support in table partitioning which potentailly helps us to fine tune the registrations table further.
 
@@ -173,7 +175,7 @@ Disadvantages:
 
 We create an empty Postgresql 13 database and use logical replication to continuously replicate data from production database.
 
-Logical replication has some limitations, which however does not affect us in our case.
+Logical replication has [some restrictions](https://www.postgresql.org/docs/10/logical-replication-restrictions.html), but they do not affect the registrations database as the restricted features are not used.
 
 ```mermaid
 gantt
@@ -205,8 +207,9 @@ Rollback:
 
 Advantages:
 1. Minimal downtime
-2. Prepare an empty Postgresql 13 database beforehand
+2. Prepare an empty Postgresql 13.6 database beforehand
 3. The initial 5-min downtime on notification can be avoided by setting up a temporary database to serve breaking news tool
+4. Use Postgresql 13.6 directly (rather than 13.4)
 
 Disadvantages:
 1. More sophisticated operations
@@ -244,7 +247,8 @@ Rollback:
 2. After switchover, switch back to the original PROD DB
 
 Advantages:
-1. Prepare an empty Postgresql 13 database beforehand
+1. Prepare an empty Postgresql 13.6 database beforehand
+2. Use Postgresql 13.6 directly (rather than 13.4)
 
 Disadvantages:
 1. Changes to registrations database that happen during upgrade will be lost after switchover

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -257,7 +257,7 @@ Disadvantages:
 Reference: https://www.postgresql.org/docs/10/backup-dump.html
 
 ## Conclusion and Recommendation
-Since the option 4 has the shortest downtime and the logical replication have been tested on the test rig database, it is recommended to upgrade the database from Postgresql 10.18 to Postgresql 13.4 using this approach.
+Since the option 4 has the shortest downtime and the logical replication have been tested on the test rig database, it is recommended to upgrade the database from Postgresql 10.18 to Postgresql 13.6 using this approach.
 
 The detailed procedures have been prepared in this [document](./03-postresql-upgrade-procedure.md).
 

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -216,13 +216,13 @@ gantt
     section PROD DB
     Create database dump              :a1, 00:00:00, 25min
     section PG13 DB
-    Restore from dump                 :b1, after a1, 25min
-    Reindexing and optimizer stats    :b2, after b1, 10min
+    Restore from dump                 :b1, after a1, 20min
+    Reindexing and optimizer stats    :b2, after b1, 5min
     Switchover                        :b3, after b2, 5min
     Serving all                       :milestone, after b3, 0min
     section Impact 
-    Registration lost                 :crit, c1a, 00:00:00, 65min
-    Notification available            :done, c1b, 00:00:00, 65min
+    Registration lost                 :crit, c1a, 00:00:00, 55min
+    Notification available            :done, c1b, 00:00:00, 55min
     Normal                            :done, c2, after b3, 5min
 ```
 

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -206,6 +206,7 @@ Rollback:
 Advantages:
 1. Minimal downtime
 2. Prepare an empty Postgresql 13 database beforehand
+3. The initial 5-min downtime on notification can be avoided by setting up a temporary database to serve breaking news tool
 
 Disadvantages:
 1. More sophisticated operations

--- a/docs/architecture/03-postresql-upgrade-procedure.md
+++ b/docs/architecture/03-postresql-upgrade-procedure.md
@@ -1,0 +1,121 @@
+# Detailed Database Upgrade Procedure
+
+## Setup up a temporary database to serve breaking news notifications
+1. In AWS console, start `Take DB snapshot` action on the current PROD database
+- Name: registrations-PROD-upgrade-temp
+
+2. Run `Restore snapshot` from the created snapshot
+
+- DB instance identifier: `notifications-registrations-db-private-prod-temp`
+- Multi-AZ
+- VPC: notifications (vpc-5dddcb3f)
+- Subnet group: notifications-registrations-db-subnet-group-private-prod
+- VPC security groups: registrations-db-PROD, NO default
+- Instance class: db.t3.medium
+- Storage type: SSD (gp2)
+- Password authentication
+- Disable auto minor version upgrade
+
+3. Run some SQLs to mitigate the effects of [lazy loading](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RestoreFromSnapshot.html)
+- At terminal 1, set up a SSH tunnel to the database with `eval $(ssm ssh --tags registration,mobile-notifications,PROD -p mobile --raw --newest) -L 5432:notifications-registrations-db-private-prod-temp.crwidilr2ofx.eu-west-1.rds.amazonaws.com:5432`
+- At terminal 2, get the password with `aws --profile=mobile --region=eu-west-1 ssm get-parameter --with-decryption --name /notifications/PROD/registrations-db-password | jq -r .Parameter.Value`
+- At terminal 3, open psql with `psql -h localhost -U root registrationsPROD`
+- Run the queries `SELECT COUNT(1) FROM registrations.registrations;`
+- Run the queries `SELECT platform, COUNT(1) FROM registrations.registrations GROUP BY platform;`
+
+4. Switch the worker lambda functions over to the temporary database by 
+- changing the target group of the proxy `registrations-db-proxy-cdk-prod` to `notifications-registrations-db-private-prod-temp`
+
+5. Trigger the lambda [mobile-notifications-fakebreakingnews-PROD](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/mobile-notifications-fakebreakingnews-PROD?tab=code) to check if the service is available
+
+## Enable logical replication
+1. in AWS console, modify the DB `notifications-registrations-db-private-prod` to use the parameter group `logical-replication-publisher`
+- The parameter group has the following specific parameter values
+- `rds.logical_replication` to 1 (which causes AWS to set `wal_level` to `logical`)
+- `max_wal_senders` to 15
+
+2. Reboot the database to make parameters come into effect
+
+3. Switch back from the temporary database
+- Change the target group of the proxy `registrations-db-proxy-cdk-prod` to `notifications-registrations-db-private-prod`
+- Trigger the lambda [mobile-notifications-fakebreakingnews-PROD](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/mobile-notifications-fakebreakingnews-PROD?tab=code)
+
+## Set up publication in old PROD database
+1. Open the SQL client to the old PROD database
+- At terminal 1, set up a SSH tunnel to the database with `eval $(ssm ssh --tags registration,mobile-notifications,PROD -p mobile --raw --newest) -L 5432:notifications-registrations-db-private-prod.crwidilr2ofx.eu-west-1.rds.amazonaws.com:5432`
+- At terminal 2, get the password with `aws --profile=mobile --region=eu-west-1 ssm get-parameter --with-decryption --name /notifications/PROD/registrations-db-password | jq -r .Parameter.Value`
+- At terminal 3, open psql with `psql -h localhost -U root registrationsPROD`
+
+2. Create a publication by running `CREATE PUBLICATION alltables FOR ALL TABLES;` in the psql session
+- To check the publication, run `SELECT * FROM pg_publication;`
+
+3. After the new database makes a subscription, we can check the status of logical replication by running `SELECT * FROM pg_replication_slots;`
+- There should be an entry with the subscription name
+- The `active` column should be `t`
+- We may run `SELECT * FROM pg_stat_replication;` to get some statistics
+
+## Set up subscription in Postgresql 13 database
+1. Open the SQL client to the old PROD database
+- At terminal 1, set up a SSH tunnel to the database with `eval $(ssm ssh --tags registration,mobile-notifications,PROD -p mobile --raw --newest) -L 5432:notifications-registrations-db-private-pg13-prod.crwidilr2ofx.eu-west-1.rds.amazonaws.com:5432`
+- At terminal 2, get the password with `aws --profile=mobile --region=eu-west-1 ssm get-parameter --with-decryption --name /notifications/PROD/registrations-db-password | jq -r .Parameter.Value`
+- At terminal 3, open psql with `psql -h localhost -U root registrationsPROD`
+
+2. Create a subscription by running the following statement in the psql session.  Replace the password placeholder.
+```
+CREATE SUBSCRIPTION mysub
+         CONNECTION 'host=notifications-registrations-db-private-prod.crwidilr2ofx.eu-west-1.rds.amazonaws.com port=5432 user=root dbname=registrationsPROD password=<password>'
+        PUBLICATION alltables;
+```
+
+3. Check the status of the subscription by running `SELECT srsubid, pg_filenode_relation(0,srrelid), srsublsn, srsubstate FROM pg_subscription_rel;`
+- The `srsubstate` shows the current state:
+- `i` – Initialize,
+- `d` – Data is being copied,
+- `s` – Synchronized,
+- `r` – Ready (normal replication)
+
+4. When the state is changed to `r` (ready), make sure that the initial data copy has been completed by running `SELECT COUNT(1) FROM registrations.registrations;`
+
+5. After inital data copy, add primary constraint and an index by running:
+```
+ALTER TABLE ONLY registrations.registrations
+    ADD CONSTRAINT registrations_pkey PRIMARY KEY (token, topic);
+
+CREATE INDEX idx_registration_shard_topic ON registrations.registrations USING btree (shard, topic);   
+```
+
+6. To make sure that data are being synchronised continuously, we may run the queries in both database and compare.  (Change the timestamp)
+```
+SELECT COUNT(1) FROM registrations.registrations;
+
+SELECT token, topic, lastmodified FROM registrations.registrations
+WHERE lastmodified >= TO_TIMESTAMP('2022-08-11 13:00', 'YYYY-MM-DD HH24:MI') 
+ORDER BY lastmodified;
+```
+
+7. When we are ready to switch over, update the optimizer statistics by running `ANALYZE VERBOSE`
+
+## Switch over
+1. Stop the subscription in the new Postgresql 13 database by running `DROP SUBSCRIPTION mysub;`
+
+2. Switch the registrations API over to the new database by
+- changing the parameter in parameter store `/notifications/PROD/mobile-notifications/registration.db.url`
+- from: `jdbc:postgresql://notifications-registrations-db-private-prod.crwidilr2ofx.eu-west-1.rds.amazonaws.com/registrationsPROD?currentSchema=registrations`
+- to:   `jdbc:postgresql://notifications-registrations-db-private-pg13-prod.crwidilr2ofx.eu-west-1.rds.amazonaws.com/registrationsPROD?currentSchema=registrations`
+
+3. Restart the registrations API by redeploying the main branch of `mobile-n10n:registration` via riffraff
+
+4. Switch the worker lambda functions to the new database by
+- Change the target group of the proxy `registrations-db-proxy-cdk-prod` to `notifications-registrations-db-private-pg13-prod`
+- Trigger the lambda [mobile-notifications-fakebreakingnews-PROD](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/mobile-notifications-fakebreakingnews-PROD?tab=code)
+
+## Clean up
+1. Remove `<HOME>/.psql_history` file as it contains the password in the `CREATE SUBSCRIPTION` statement
+
+2. Stop the publication in the old PROD database by running `DROP PUBLICATION alltables`
+
+3. Delete the temporary database `notifications-registrations-db-private-prod-temp`
+
+3. When the notifications system has been running well with the new database, we may remove the old PROD database
+- Enable `create final snapshot`
+

--- a/docs/architecture/03-postresql-upgrade-procedure.md
+++ b/docs/architecture/03-postresql-upgrade-procedure.md
@@ -13,7 +13,7 @@
 - Enable auto minor version upgrade
 - Parameter group: `logical-replication-subscriber` (which sets `rds.logical_replication` to 1)
 
-2. With the same schemas and user accounts
+2. With the same schemas (without indexes) and user accounts
 
 3. No data
 
@@ -47,7 +47,7 @@
 
 ## Step 2: Enable logical replication
 
-Registrations will be affected during (1) and (2).
+==Registrations will be affected during (1) and (2).==
 
 1. in AWS console, modify the DB `notifications-registrations-db-private-prod` to use the parameter group `logical-replication-publisher`
 - The parameter group has the following specific parameter values
@@ -117,7 +117,7 @@ ORDER BY lastmodified;
 
 ## Step 5: Stop subscription and switch over
 
-Registrations data created between (1) and (3) will be lost.
+==Registrations data created between (1) and (3) will be lost.==
 
 1. Stop the subscription in the new Postgresql 13 database by running `DROP SUBSCRIPTION mysub;`
 
@@ -128,7 +128,7 @@ Registrations data created between (1) and (3) will be lost.
 
 3. Restart the registrations API by redeploying the main branch of `mobile-n10n:registration` via riffraff
 
-Registrations may be unstable during (4).
+==Registrations may be unstable during (4).==
 
 4. Disable Logical Replication in the parameter group
 - In AWS console, modify the DB `notifications-registrations-db-private-pg13-prod` to use the parameter group `default.postgres13`

--- a/docs/architecture/03-postresql-upgrade-procedure.md
+++ b/docs/architecture/03-postresql-upgrade-procedure.md
@@ -47,7 +47,7 @@
 
 ## Step 2: Enable logical replication
 
-==Registrations will be affected during (1) and (2).==
+***Registrations will be affected during (1) and (2).***
 
 1. in AWS console, modify the DB `notifications-registrations-db-private-prod` to use the parameter group `logical-replication-publisher`
 - The parameter group has the following specific parameter values
@@ -117,7 +117,7 @@ ORDER BY lastmodified;
 
 ## Step 5: Stop subscription and switch over
 
-==Registrations data created between (1) and (3) will be lost.==
+***Registrations data created between (1) and (3) will be lost.***
 
 1. Stop the subscription in the new Postgresql 13 database by running `DROP SUBSCRIPTION mysub;`
 
@@ -128,7 +128,7 @@ ORDER BY lastmodified;
 
 3. Restart the registrations API by redeploying the main branch of `mobile-n10n:registration` via riffraff
 
-==Registrations may be unstable during (4).==
+***Registrations may be unstable during (4).***
 
 4. Disable Logical Replication in the parameter group
 - In AWS console, modify the DB `notifications-registrations-db-private-pg13-prod` to use the parameter group `default.postgres13`

--- a/docs/testing/05-database-tuning.md
+++ b/docs/testing/05-database-tuning.md
@@ -1,6 +1,6 @@
 # Database tuning - reducing table size
 
-This document summarises the test result and conclusiong for reducing table size.  The corresponding background and research work can be found in [the document](../architecture/02-database-tuning.md).
+This document summarises the test result and conclusion for reducing table size.  The corresponding background and research work can be found in [the document](../architecture/02-database-tuning.md).
 
 ## Results
 

--- a/docs/testing/06-postgresql-upgrade.md
+++ b/docs/testing/06-postgresql-upgrade.md
@@ -42,8 +42,7 @@ Under each scenario, I sent four rounds of breaking news notification.
 | AVG | 22.6175 | 158 | 0 |
 
 ## Conclusion
-
-
+From the test result, I do not notice any consistent changes in the performance.  It suggests that Postgresql 13 delivers similar performance to Postgresql 10 / Postgresql 14 in our test scenario.  According to the release notes, Postgresql 13 has quite a number of improvements over the management of its storage space and indexes, which should be beneficial to the registrations database in the long run.  In addition, Postgresql 13 provides some new features which we may explore to further improve the performance.
 
 
 

--- a/docs/testing/06-postgresql-upgrade.md
+++ b/docs/testing/06-postgresql-upgrade.md
@@ -1,0 +1,50 @@
+# Postgresql Database Upgrade
+
+This document summarises the test result for database upgrade.  The corresponding background and research work can be found in [the document](../architecture/03-postgresql-upgrade.md).
+
+## Results
+
+A performance test was performed for each of the scenarios:
+1. Before upgrade from Postgresql 10
+2. Upgraded to Postgresql 14
+3. Upgraded to Postgresql 13
+
+Under each scenario, I sent four rounds of breaking news notification.
+
+### Before upgrade from Postgresql 10
+
+| # | Total harvester duration (s) | No. harvester invocations | Harvester error "marked as broken" |
+| ----------- | ----------- | ----------- | ----------- |
+| 1	| 32.41 | 159 | 0 |
+| 2	| 12.36 | 159 | 0 |
+| 3	| 11.97 | 159 | 0 |
+| 4	| 11.2 | 159 | 0 |
+| AVG | 16.985 | 159 | 0 |
+
+### Postgresql 14
+
+| # | Total harvester duration (s) | No. harvester invocations | Harvester error "marked as broken" |
+| ----------- | ----------- | ----------- | ----------- |
+| 1 | 28.85 | 162 | 0 |
+| 2 | 15.6 | 159 | 0 |
+| 3 | 10.41 | 159 | 0 |
+| 4 | 13.08 | 159 | 0 |
+| AVG | 16.985 | 159.75 | 0 |
+
+### Postgresql 13
+
+| # | Total harvester duration (s) | No. harvester invocations | Harvester error "marked as broken" |
+| ----------- | ----------- | ----------- | ----------- |
+1 | 33.41| 158 | 0 |
+2 | 14.52| 158 | 0 |
+3 | 17.94| 158 | 0 |
+4 | 24.6 | 158 | 0 |
+| AVG | 22.6175 | 158 | 0 |
+
+## Conclusion
+
+
+
+
+
+


### PR DESCRIPTION
## What does this change?

We are planning to perform database engine upgrade on the registrations database from Postgresql 10.18 to a newer version.

The documents in the PR summaries the study on the database upgrade, the recommendation, the detailed procedures and the test result.

