### PR TITLE
LIVE-3899 fix RDS proxy secrets

### DIFF
--- a/cdk/lib/__snapshots__/registrations-db-proxy.test.ts.snap
+++ b/cdk/lib/__snapshots__/registrations-db-proxy.test.ts.snap
@@ -60,11 +60,8 @@ Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "Description": "Secrets for accessing registration database from cleaner lambdas",
-        "GenerateSecretString": Object {
-          "GenerateStringKey": "password",
-          "SecretStringTemplate": "{\\"username\\":\\"cleaner_user\\",\\"engine\\":\\"postgres\\",\\"host\\":\\"notifications-registrations-db-private-code.crwidilr2ofx.eu-west-1.rds.amazonaws.com\\",\\"port\\":5432,\\"dbname\\":\\"registrationsCODE\\",\\"dbInstanceIdentifier\\":\\"notifications-registrations-db-private-code\\"}",
-        },
         "Name": "registrations-db-cleaner-secret-CODE",
+        "SecretString": "{\\"username\\":\\"cleaner_user\\",\\"password\\":\\"{{resolve:ssm-secure:/notifications/CODE/workers/cleaner/registration.db.password}}\\"}",
         "Tags": Array [
           Object {
             "Key": "gu:cdk:version",
@@ -91,11 +88,8 @@ Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "Description": "Secrets for accessing registration database from worker lambdas",
-        "GenerateSecretString": Object {
-          "GenerateStringKey": "password",
-          "SecretStringTemplate": "{\\"username\\":\\"worker_user\\",\\"engine\\":\\"postgres\\",\\"host\\":\\"notifications-registrations-db-private-code.crwidilr2ofx.eu-west-1.rds.amazonaws.com\\",\\"port\\":5432,\\"dbname\\":\\"registrationsCODE\\",\\"dbInstanceIdentifier\\":\\"notifications-registrations-db-private-code\\"}",
-        },
         "Name": "registrations-db-worker-secret-CODE",
+        "SecretString": "{\\"username\\":\\"worker_user\\",\\"password\\":\\"{{resolve:ssm-secure:/notifications/CODE/workers/harvester/registration.db.password}}\\"}",
         "Tags": Array [
           Object {
             "Key": "gu:cdk:version",
@@ -315,11 +309,8 @@ Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "Description": "Secrets for accessing registration database from cleaner lambdas",
-        "GenerateSecretString": Object {
-          "GenerateStringKey": "password",
-          "SecretStringTemplate": "{\\"username\\":\\"cleaner_user\\",\\"engine\\":\\"postgres\\",\\"host\\":\\"notifications-registrations-db-private-prod.crwidilr2ofx.eu-west-1.rds.amazonaws.com\\",\\"port\\":5432,\\"dbname\\":\\"registrationsPROD\\",\\"dbInstanceIdentifier\\":\\"notifications-registrations-db-private-prod\\"}",
-        },
         "Name": "registrations-db-cleaner-secret-PROD",
+        "SecretString": "{\\"username\\":\\"cleaner_user\\",\\"password\\":\\"{{resolve:ssm-secure:/notifications/PROD/workers/cleaner/registration.db.password}}\\"}",
         "Tags": Array [
           Object {
             "Key": "gu:cdk:version",
@@ -346,11 +337,8 @@ Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "Description": "Secrets for accessing registration database from worker lambdas",
-        "GenerateSecretString": Object {
-          "GenerateStringKey": "password",
-          "SecretStringTemplate": "{\\"username\\":\\"worker_user\\",\\"engine\\":\\"postgres\\",\\"host\\":\\"notifications-registrations-db-private-prod.crwidilr2ofx.eu-west-1.rds.amazonaws.com\\",\\"port\\":5432,\\"dbname\\":\\"registrationsPROD\\",\\"dbInstanceIdentifier\\":\\"notifications-registrations-db-private-prod\\"}",
-        },
         "Name": "registrations-db-worker-secret-PROD",
+        "SecretString": "{\\"username\\":\\"worker_user\\",\\"password\\":\\"{{resolve:ssm-secure:/notifications/PROD/workers/harvester/registration.db.password}}\\"}",
         "Tags": Array [
           Object {
             "Key": "gu:cdk:version",

--- a/cdk/lib/registrations-db-proxy.ts
+++ b/cdk/lib/registrations-db-proxy.ts
@@ -30,15 +30,9 @@ export class RegistrationsDbProxy extends GuStack {
 		);
 
 		const dbPort = 5432;
-		const secretTemplate = {
-			engine: 'postgres',
-			host: props.dbHost,
-			port: dbPort,
-			dbname: props.dbName,
-			dbInstanceIdentifier: props.dbInstanceId,
-		};
-
-		const workerPassword = SecretValue.ssmSecure(`/notifications/${props.stage}/workers/harvester/registration.db.password`);
+		const workerPassword = SecretValue.ssmSecure(
+			`/notifications/${props.stage}/workers/harvester/registration.db.password`,
+		);
 		const dbWorkerSecret = new Secret(this, 'RegistrationDbWorkerSecret', {
 			secretName: `registrations-db-worker-secret-${props.stage}`,
 			description:
@@ -48,7 +42,9 @@ export class RegistrationsDbProxy extends GuStack {
 				password: workerPassword,
 			},
 		});
-		const cleanerPassword = SecretValue.ssmSecure(`/notifications/${props.stage}/workers/cleaner/registration.db.password`);
+		const cleanerPassword = SecretValue.ssmSecure(
+			`/notifications/${props.stage}/workers/cleaner/registration.db.password`,
+		);
 		const dbCleanerSecret = new Secret(this, 'RegistrationDbCleanerSecret', {
 			secretName: `registrations-db-cleaner-secret-${props.stage}`,
 			description:

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,13 +8,13 @@
       "name": "cdk",
       "version": "0.0.0",
       "devDependencies": {
-        "@guardian/cdk": "45.1.3",
+        "@guardian/cdk": "47.0.1",
         "@guardian/eslint-config-typescript": "1.0.1",
         "@guardian/prettier": "1.0.0",
         "@types/jest": "^27.5.0",
         "@types/node": "17.0.42",
-        "aws-cdk": "2.25.0",
-        "aws-cdk-lib": "2.25.0",
+        "aws-cdk": "2.35.0",
+        "aws-cdk-lib": "2.35.0",
         "constructs": "10.1.17",
         "eslint": "^8.16.0",
         "jest": "^27.5.1",
@@ -666,18 +666,18 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "45.1.3",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-45.1.3.tgz",
-      "integrity": "sha512-zonVe0UwurQ3ZF13pooGgBKRTLQJeJYfced1Ogx0OGhmPcu/eUIQqj0bhkmU8QECXeOyx3pouVIHwSWH4mUoYQ==",
+      "version": "47.0.1",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-47.0.1.tgz",
+      "integrity": "sha512-JZFj6G3gV1i/uDlEZEWLXMUJmlttYwX1aq45/KfuaU55Vi92BcQZypEVQmxzdQaZo7wY/uBOHxRE70f2iK9iVQ==",
       "dev": true,
       "dependencies": {
-        "@oclif/core": "1.9.0",
-        "aws-cdk-lib": "2.25.0",
-        "aws-sdk": "^2.1154.0",
+        "@oclif/core": "1.11.0",
+        "aws-cdk-lib": "2.35.0",
+        "aws-sdk": "^2.1173.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.59.0",
-        "constructs": "10.1.17",
-        "git-url-parse": "^11.6.0",
+        "codemaker": "^1.61.0",
+        "constructs": "10.1.70",
+        "git-url-parse": "^12.0.0",
         "inquirer": "^8.2.4",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
@@ -689,9 +689,18 @@
         "gu-cdk": "bin/gu-cdk"
       },
       "peerDependencies": {
-        "aws-cdk": "2.25.0",
-        "aws-cdk-lib": "2.25.0",
-        "constructs": "10.1.17"
+        "aws-cdk": "2.35.0",
+        "aws-cdk-lib": "2.35.0",
+        "constructs": "10.1.70"
+      }
+    },
+    "node_modules/@guardian/cdk/node_modules/constructs": {
+      "version": "10.1.70",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.70.tgz",
+      "integrity": "sha512-6qdvuw4D+Oef7GNwbuXFpGcR/qpOPApZjNOHwV1Tp+bkAWF7lQT+2zXqoCtVr51y5TO8Tpc63Va7yT1UCYkS3A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.17.0"
       }
     },
     "node_modules/@guardian/eslint-config": {
@@ -1245,9 +1254,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.9.0.tgz",
-      "integrity": "sha512-duvlaRQf4JM+mKuwwos1DNa/Q9x6tnF3khV5RU0fy5hhETF7THlTmxioKlIvKMyQDVpySqtZXZ0OKHeCi2EWuQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-snTdQBd0e3YcG1bVgZiuEajBpsbJ2kP/7FBoMLjTBge7Dbk7jlv31ql/igDdoISoUVmbSy+hEzTaLLIGiLWieQ==",
       "dev": true,
       "dependencies": {
         "@oclif/linewrap": "^1.0.0",
@@ -1867,10 +1876,22 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/aws-cdk": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.25.0.tgz",
-      "integrity": "sha512-6NZKDPgCQ0O3xlpk22sR54N4yCvGt2tM2bkKHPrV6n4HCI+a349hsF4xSngiSrHAoaNQKMgAwScpj3GTZcI+oA==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.35.0.tgz",
+      "integrity": "sha512-H8S/tEfnqeHq5aqKHXhZjSm3ck472Nwnw6CJYkzHg5tsV6KB5EludP18SYb1h9pu8ZGWmBQ8vJ82yK9XXxFQvw==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -1883,9 +1904,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.25.0.tgz",
-      "integrity": "sha512-rcQeQu/lTmi1tg5DwV0gBqJtF73khApfHt9n7BIHkKbUWvCB50lIL1Q1/7cHvTicfQ62UnwFoPWwB0YqQceDVQ==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.35.0.tgz",
+      "integrity": "sha512-kt3uuuwxblgLCn3VRtC+lcU1VgCVVL8osQ8UXfi3eA2TAKU+8TS/+wMTXGgMKXUTNP+zzo+tfiE4PyPJseWavw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1903,7 +1924,7 @@
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
         "ignore": "^5.2.0",
-        "jsonschema": "^1.4.0",
+        "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.1.1",
         "semver": "^7.3.7",
@@ -2005,7 +2026,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2086,9 +2107,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1164.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1164.0.tgz",
-      "integrity": "sha512-q/M9E68WabF22G8d8lFgo3NH+9RooYswSY9VG6zqN16C19RRm2sGThp8Sxtz/WUK98BAsxSnkLW1ksmy3BsP7Q==",
+      "version": "2.1193.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1193.0.tgz",
+      "integrity": "sha512-nSbljBZhxNn+LmENc14md+y1Z+U8BUcS1LLlOxeJvjYAkkGbPf29Bl8FvzbRsZuoxtF6N1Mkel3AI5XIx7mkew==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -2098,6 +2119,7 @@
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
+        "util": "^0.12.4",
         "uuid": "8.0.0",
         "xml2js": "0.4.19"
       },
@@ -2740,15 +2762,6 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/dedent": {
       "version": "0.7.0",
@@ -3713,15 +3726,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -3752,6 +3756,15 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
     },
     "node_modules/form-data": {
       "version": "3.0.1",
@@ -3911,22 +3924,22 @@
       }
     },
     "node_modules/git-up": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.5.tgz",
-      "integrity": "sha512-YUvVDg/vX3d0syBsk/CKUTib0srcQME0JyHkL5BaYdwLsiCslPWmDSi8PUMo9pXYjrryMcmsCoCgsTpSCJEQaA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-6.0.0.tgz",
+      "integrity": "sha512-6RUFSNd1c/D0xtGnyWN2sxza2bZtZ/EmI9448n6rCZruFwV/ezeEn2fJP7XnUQGwf0RAtd/mmUCbtH6JPYA2SA==",
       "dev": true,
       "dependencies": {
-        "is-ssh": "^1.3.0",
-        "parse-url": "^6.0.0"
+        "is-ssh": "^1.4.0",
+        "parse-url": "^7.0.2"
       }
     },
     "node_modules/git-url-parse": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.6.0.tgz",
-      "integrity": "sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-12.0.0.tgz",
+      "integrity": "sha512-I6LMWsxV87vysX1WfsoglXsXg6GjQRKq7+Dgiseo+h0skmp5Hp2rzmcEIRQot9CPA+uzU7x1x7jZdqvTFGnB+Q==",
       "dev": true,
       "dependencies": {
-        "git-up": "^4.0.0"
+        "git-up": "^6.0.0"
       }
     },
     "node_modules/glob": {
@@ -4288,6 +4301,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4401,6 +4430,21 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -4537,6 +4581,25 @@
       "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
+      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.20.0",
+        "for-each": "^0.3.3",
+        "has-tostringtag": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5969,40 +6032,25 @@
       }
     },
     "node_modules/parse-path": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.4.tgz",
-      "integrity": "sha512-Z2lWUis7jlmXC1jeOG9giRO2+FsuyNipeQ43HAjqAZjwSe3SEf+q/84FGPHoso3kyntbxa4c4i77t3m6fGf8cw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-5.0.0.tgz",
+      "integrity": "sha512-qOpH55/+ZJ4jUu/oLO+ifUKjFPNZGfnPJtzvGzKN/4oLMil5m9OH4VpOj6++9/ytJcfks4kzH2hhi87GL/OU9A==",
       "dev": true,
       "dependencies": {
-        "is-ssh": "^1.3.0",
-        "protocols": "^1.4.0",
-        "qs": "^6.9.4",
-        "query-string": "^6.13.8"
+        "protocols": "^2.0.0"
       }
-    },
-    "node_modules/parse-path/node_modules/protocols": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
-      "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
-      "dev": true
     },
     "node_modules/parse-url": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.2.tgz",
-      "integrity": "sha512-uCSjOvD3T+6B/sPWhR+QowAZcU/o4bjPrVBQBGFxcDF6J6FraCGIaDBsdoQawiaaAVdHvtqBe3w3vKlfBKySOQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-7.0.2.tgz",
+      "integrity": "sha512-PqO4Z0eCiQ08Wj6QQmrmp5YTTxpYfONdOEamrtvK63AmzXpcavIVQubGHxOEwiIoDZFb8uDOoQFS0NCcjqIYQg==",
       "dev": true,
       "dependencies": {
-        "is-ssh": "^1.3.0",
+        "is-ssh": "^1.4.0",
         "normalize-url": "^6.1.0",
-        "parse-path": "^4.0.4",
-        "protocols": "^1.4.0"
+        "parse-path": "^5.0.0",
+        "protocols": "^2.0.1"
       }
-    },
-    "node_modules/parse-url/node_modules/protocols": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
-      "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
-      "dev": true
     },
     "node_modules/parse5": {
       "version": "6.0.1",
@@ -6341,39 +6389,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dev": true,
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "dev": true,
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/querystring": {
@@ -6880,15 +6895,6 @@
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
     },
-    "node_modules/split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6914,15 +6920,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/string_decoder": {
@@ -7516,6 +7513,20 @@
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
       "dev": true
     },
+    "node_modules/util": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7679,6 +7690,26 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
+      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.20.0",
+        "for-each": "^0.3.3",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8352,24 +8383,32 @@
       }
     },
     "@guardian/cdk": {
-      "version": "45.1.3",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-45.1.3.tgz",
-      "integrity": "sha512-zonVe0UwurQ3ZF13pooGgBKRTLQJeJYfced1Ogx0OGhmPcu/eUIQqj0bhkmU8QECXeOyx3pouVIHwSWH4mUoYQ==",
+      "version": "47.0.1",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-47.0.1.tgz",
+      "integrity": "sha512-JZFj6G3gV1i/uDlEZEWLXMUJmlttYwX1aq45/KfuaU55Vi92BcQZypEVQmxzdQaZo7wY/uBOHxRE70f2iK9iVQ==",
       "dev": true,
       "requires": {
-        "@oclif/core": "1.9.0",
-        "aws-cdk-lib": "2.25.0",
-        "aws-sdk": "^2.1154.0",
+        "@oclif/core": "1.11.0",
+        "aws-cdk-lib": "2.35.0",
+        "aws-sdk": "^2.1173.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.59.0",
-        "constructs": "10.1.17",
-        "git-url-parse": "^11.6.0",
+        "codemaker": "^1.61.0",
+        "constructs": "10.1.70",
+        "git-url-parse": "^12.0.0",
         "inquirer": "^8.2.4",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.upperfirst": "^4.3.1",
         "read-pkg-up": "7.0.1",
         "yargs": "^17.5.1"
+      },
+      "dependencies": {
+        "constructs": {
+          "version": "10.1.70",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.70.tgz",
+          "integrity": "sha512-6qdvuw4D+Oef7GNwbuXFpGcR/qpOPApZjNOHwV1Tp+bkAWF7lQT+2zXqoCtVr51y5TO8Tpc63Va7yT1UCYkS3A==",
+          "dev": true
+        }
       }
     },
     "@guardian/eslint-config": {
@@ -8806,9 +8845,9 @@
       }
     },
     "@oclif/core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.9.0.tgz",
-      "integrity": "sha512-duvlaRQf4JM+mKuwwos1DNa/Q9x6tnF3khV5RU0fy5hhETF7THlTmxioKlIvKMyQDVpySqtZXZ0OKHeCi2EWuQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-snTdQBd0e3YcG1bVgZiuEajBpsbJ2kP/7FBoMLjTBge7Dbk7jlv31ql/igDdoISoUVmbSy+hEzTaLLIGiLWieQ==",
       "dev": true,
       "requires": {
         "@oclif/linewrap": "^1.0.0",
@@ -9287,26 +9326,32 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true
+    },
     "aws-cdk": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.25.0.tgz",
-      "integrity": "sha512-6NZKDPgCQ0O3xlpk22sR54N4yCvGt2tM2bkKHPrV6n4HCI+a349hsF4xSngiSrHAoaNQKMgAwScpj3GTZcI+oA==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.35.0.tgz",
+      "integrity": "sha512-H8S/tEfnqeHq5aqKHXhZjSm3ck472Nwnw6CJYkzHg5tsV6KB5EludP18SYb1h9pu8ZGWmBQ8vJ82yK9XXxFQvw==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.25.0.tgz",
-      "integrity": "sha512-rcQeQu/lTmi1tg5DwV0gBqJtF73khApfHt9n7BIHkKbUWvCB50lIL1Q1/7cHvTicfQ62UnwFoPWwB0YqQceDVQ==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.35.0.tgz",
+      "integrity": "sha512-kt3uuuwxblgLCn3VRtC+lcU1VgCVVL8osQ8UXfi3eA2TAKU+8TS/+wMTXGgMKXUTNP+zzo+tfiE4PyPJseWavw==",
       "dev": true,
       "requires": {
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
         "ignore": "^5.2.0",
-        "jsonschema": "^1.4.0",
+        "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.1.1",
         "semver": "^7.3.7",
@@ -9378,7 +9423,7 @@
           }
         },
         "jsonschema": {
-          "version": "1.4.0",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true
         },
@@ -9429,9 +9474,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1164.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1164.0.tgz",
-      "integrity": "sha512-q/M9E68WabF22G8d8lFgo3NH+9RooYswSY9VG6zqN16C19RRm2sGThp8Sxtz/WUK98BAsxSnkLW1ksmy3BsP7Q==",
+      "version": "2.1193.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1193.0.tgz",
+      "integrity": "sha512-nSbljBZhxNn+LmENc14md+y1Z+U8BUcS1LLlOxeJvjYAkkGbPf29Bl8FvzbRsZuoxtF6N1Mkel3AI5XIx7mkew==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -9441,6 +9486,7 @@
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
+        "util": "^0.12.4",
         "uuid": "8.0.0",
         "xml2js": "0.4.19"
       }
@@ -9913,12 +9959,6 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
-      "dev": true
-    },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true
     },
     "dedent": {
@@ -10666,12 +10706,6 @@
         "to-regex-range": "^5.0.1"
       }
     },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
-      "dev": true
-    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -10696,6 +10730,15 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
     },
     "form-data": {
       "version": "3.0.1",
@@ -10809,22 +10852,22 @@
       }
     },
     "git-up": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.5.tgz",
-      "integrity": "sha512-YUvVDg/vX3d0syBsk/CKUTib0srcQME0JyHkL5BaYdwLsiCslPWmDSi8PUMo9pXYjrryMcmsCoCgsTpSCJEQaA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-6.0.0.tgz",
+      "integrity": "sha512-6RUFSNd1c/D0xtGnyWN2sxza2bZtZ/EmI9448n6rCZruFwV/ezeEn2fJP7XnUQGwf0RAtd/mmUCbtH6JPYA2SA==",
       "dev": true,
       "requires": {
-        "is-ssh": "^1.3.0",
-        "parse-url": "^6.0.0"
+        "is-ssh": "^1.4.0",
+        "parse-url": "^7.0.2"
       }
     },
     "git-url-parse": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.6.0.tgz",
-      "integrity": "sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-12.0.0.tgz",
+      "integrity": "sha512-I6LMWsxV87vysX1WfsoglXsXg6GjQRKq7+Dgiseo+h0skmp5Hp2rzmcEIRQot9CPA+uzU7x1x7jZdqvTFGnB+Q==",
       "dev": true,
       "requires": {
-        "git-up": "^4.0.0"
+        "git-up": "^6.0.0"
       }
     },
     "glob": {
@@ -11089,6 +11132,16 @@
         "side-channel": "^1.0.4"
       }
     },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -11161,6 +11214,15 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-glob": {
       "version": "4.0.3",
@@ -11254,6 +11316,19 @@
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
+      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.20.0",
+        "for-each": "^0.3.3",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -12368,43 +12443,24 @@
       }
     },
     "parse-path": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.4.tgz",
-      "integrity": "sha512-Z2lWUis7jlmXC1jeOG9giRO2+FsuyNipeQ43HAjqAZjwSe3SEf+q/84FGPHoso3kyntbxa4c4i77t3m6fGf8cw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-5.0.0.tgz",
+      "integrity": "sha512-qOpH55/+ZJ4jUu/oLO+ifUKjFPNZGfnPJtzvGzKN/4oLMil5m9OH4VpOj6++9/ytJcfks4kzH2hhi87GL/OU9A==",
       "dev": true,
       "requires": {
-        "is-ssh": "^1.3.0",
-        "protocols": "^1.4.0",
-        "qs": "^6.9.4",
-        "query-string": "^6.13.8"
-      },
-      "dependencies": {
-        "protocols": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
-          "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
-          "dev": true
-        }
+        "protocols": "^2.0.0"
       }
     },
     "parse-url": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.2.tgz",
-      "integrity": "sha512-uCSjOvD3T+6B/sPWhR+QowAZcU/o4bjPrVBQBGFxcDF6J6FraCGIaDBsdoQawiaaAVdHvtqBe3w3vKlfBKySOQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-7.0.2.tgz",
+      "integrity": "sha512-PqO4Z0eCiQ08Wj6QQmrmp5YTTxpYfONdOEamrtvK63AmzXpcavIVQubGHxOEwiIoDZFb8uDOoQFS0NCcjqIYQg==",
       "dev": true,
       "requires": {
-        "is-ssh": "^1.3.0",
+        "is-ssh": "^1.4.0",
         "normalize-url": "^6.1.0",
-        "parse-path": "^4.0.4",
-        "protocols": "^1.4.0"
-      },
-      "dependencies": {
-        "protocols": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
-          "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
-          "dev": true
-        }
+        "parse-path": "^5.0.0",
+        "protocols": "^2.0.1"
       }
     },
     "parse5": {
@@ -12655,27 +12711,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dev": true,
-      "requires": {
-        "side-channel": "^1.0.4"
-      }
-    },
-    "query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "dev": true,
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -13043,12 +13078,6 @@
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "dev": true
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -13071,12 +13100,6 @@
           "dev": true
         }
       }
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
-      "dev": true
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -13492,6 +13515,20 @@
         }
       }
     },
+    "util": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -13633,6 +13670,20 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
+      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.20.0",
+        "for-each": "^0.3.3",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.9"
       }
     },
     "widest-line": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -11,13 +11,13 @@
     "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "45.1.3",
+    "@guardian/cdk": "47.0.1",
     "@guardian/eslint-config-typescript": "1.0.1",
     "@guardian/prettier": "1.0.0",
     "@types/jest": "^27.5.0",
     "@types/node": "17.0.42",
-    "aws-cdk": "2.25.0",
-    "aws-cdk-lib": "2.25.0",
+    "aws-cdk": "2.35.0",
+    "aws-cdk-lib": "2.35.0",
     "constructs": "10.1.17",
     "eslint": "^8.16.0",
     "jest": "^27.5.1",

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -212,7 +212,9 @@ Disadvantages:
 1. More sophisticated operations
 
 Procedure: https://aws.amazon.com/blogs/database/using-logical-replication-to-replicate-managed-amazon-rds-for-postgresql-and-amazon-aurora-to-self-managed-postgresql/
+
 RDS Supports logical replication: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication
+
 Postgresql: https://www.postgresql.org/docs/10/logical-replication.html
 
 ### Option 5: Manual data copy
@@ -249,3 +251,9 @@ Disadvantages:
 2. Readers may find our system unreliable (subscribing to a topic but later find that it is not on our database)
 
 Reference: https://www.postgresql.org/docs/10/backup-dump.html
+
+## Conclusion and Recommendation
+Since the option 4 has the shortest downtime and the logical replication have been tested on the test rig database, it is recommended to upgrade the database from Postgresql 10.18 to Postgresql 13.4 using this approach.
+
+The detailed procedures have been prepared in this [document](./03-postresql-upgrade-procedure.md).
+

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -1,0 +1,229 @@
+
+# Registrations Database Upgrade
+
+We are working to improve the performance of our notification delivery pipeline.  We are going to upgrade the registrations database from Postgresql 10 to its higher major version because of the following reasons:
+
+1. Improvement to existing features in newer versions of Postgresql
+2. Support for new features which may be useful to our work
+3. Gravitron2 processor (instance class t4g) is supported for Postgresql 12 or above.  The processor delivers up to [40% better price performance](https://aws.amazon.com/about-aws/whats-new/2020/09/announcing-new-amazon-ec2-t4g-instances-powered-by-aws-graviton2-processors/) over T3 instances.
+4. The PostgreSQL community will [discontinue support for PostgreSQL 10 on November 10 2022](https://www.postgresql.org/support/versioning/), and will no longer provide bug fixes or security patches for this version.
+
+## Postgresql version we upgrade to
+
+I list out the major enhancements in each of major versions which may be relevant to registrations database as below
+
+### Postgresql 11
+1. Better support for table partitioning (which may be a good way to optimize our database)
+- Add support for primary key on partitioned tables
+- Allow *default* partition
+- Allow update on partition key columns
+- Enhance partition elimination strategies
+
+Reference: https://www.postgresql.org/docs/11/release.html
+
+### Postgresql 12
+1. Optimizations to space utilization and read/write performance for B-tree indexes
+2. Improve performance of many operations on partitioned tables
+3. REINDEX CONCURRENTLY can rebuild an index without blocking writes to its table
+
+Reference: https://www.postgresql.org/docs/12/release.html
+
+### Postgresql 13
+1. Space savings and performance gains from de-duplication of B-tree index entries
+- Expect a considerable amount of duplicated values of (topic, shard) in the index
+2. Improved performance for queries that use partitioned tables
+- Allow pruning of partitions to happen in more cases
+- Allow partitioned tables in logical replication
+3. Minor: Implement incremental sorting
+
+Reference: https://www.postgresql.org/docs/13/release.html
+
+### Postgresql 14
+1. Improve the performance of updates and deletes on partitioned tables with many partitions
+2. Reduce index bloat on tables whose indexed columns are frequently updated.
+3. Improve vacuum operations in reclaiming space
+
+Reference: https://www.postgresql.org/docs/14/release.html
+
+## RDS Proxy and Progresql upgrade
+The latest major version of Postgreql which RDS proxy supports is [version 13](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html#rds-proxy.support).  So we have two options:
+
+1. Upgrade to Postgresql 14 without RDS proxy 
+2. Upgrade to Postgresql 13 with RDS proxy
+
+The major enhancements of postgresl 14 which are relevant to our system are feature improvement but they are not critical to our DB tuning work.  Moreover, our previous performance test suggests that RDS proxy can help with the performance, probably because it manages a lot of short-lived database connections from harvester functions and move the workload away from the database instance.  So I recommend upgrading to Postgresql 13.  We always have the option of upgrading again from Postgresql 13 to 14.
+
+## Performance test with Postgresql 13
+
+## Upgrade procedure
+In addition to upgrading the database engine, we are going to execute the following operations:
+1. Back up existing PROD
+2. Change the instance class from `t3` to `t4g`
+3. Re-generate optimizer statistics (step 14 in [user guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion.Process)) as the upgrade process does not transfer the optimizer statistics
+4. Re-indexing so that the existing indexes can use new features provided by the upgraded database engine (for example, check E.8.3.1.2. Indexes in this [release note](https://www.postgresql.org/docs/13/release-13.html#id-1.11.6.12.5))
+
+I came up with the following options to perform the major version ugprade.
+
+### Option 1: Use AWS RDS in-place upgrade
+
+We just go ahead with modifying the DB engine via AWS console.
+
+```mermaid
+gantt
+    title Approach 1 - In-place upgrade
+    dateFormat  HH:mm:ss
+    axisFormat  %H:%M:%S
+    section Operation
+    Upgrade to postgres13             :crit,active, a1, 00:00:00, 30min
+    Change instance class             :crit,active, a2, after a1, 20min
+    Reindexing and optimizer stats    :crit,active, a3, after a2, 10min
+    Service restored                  :milestone, after a3, 0min
+    section Impact 
+    No registration                   :crit, c1a, 00:00:00, 60min
+    No notification                   :crit, c1b, 00:00:00, 60min
+```
+
+Rollback:
+1. Restore the latest snapshot
+Pro:
+1. Simplest way
+Con:
+1. Service downtime throughout the upgrade
+
+
+### Option 2: Create a new instance for Postgres13 database
+
+We create a new instance from the latest snapshot from registrations database and make changes to it.
+
+```mermaid
+gantt
+    title Approach 2 - Create new Postgres13 database
+    dateFormat  HH:mm:ss
+    axisFormat  %H:%M:%S
+    section PROD DB
+    Backup                            :a1, 00:00:00, 5min
+    section PG13 DB
+    Restore                           :b1, after a1, 20min
+    Upgrade to postgres13             :crit,active, b2, after b1, 30min
+    Change instance class             :crit,active, b3, after b2, 20min
+    Reindexing / optimizer stats      :crit,active, b4, after b3, 10min
+    Switchover                        :b5, after b4, 5min
+    Serving notifications             :milestone, after b5, 0min
+    section Impact 
+    Registration lost       :crit, c1a, 00:00:00, 90min
+    Notification available  :done, c1b, 00:00:00, 90min
+    Normal                  :done, c2, after c1a c1b, 5min
+```
+
+Rollback:
+1. Before switchover, no action is needed
+2. After switchover, we have to switch back to roll back
+Pro:
+1. No downtime to breaking news notification
+Con:
+1. Changes to registrations database that happen during upgrade will be lost after switchover
+2. Readers may find our system unreliable (subscribing to a topic but later find that it is not on our database)
+
+### Option 3: Maintain breaking news notification service in temporary database
+
+We create a tempoarary instance from the latest snapshot from registrations database and serve the breaking news notifications there.
+
+```mermaid
+gantt
+    title Approach 3 - Create temporary database to serve breaking news
+    dateFormat  HH:mm:ss
+    axisFormat  %H:%M:%S
+    section PROD DB
+    Backup                            :a1, 00:00:00, 5min
+    Upgrade to postgres13             :crit,active, a2, after b2, 30min
+    Change instance class             :crit,active, a3, after a2, 20min
+    Reindexing / optimizer stats      :crit,active, a4, after a3, 10min
+    Switch back                       :a5, after a4, 5min
+    Serving all                       :milestone, after a5, 0min
+    section Temp DB
+    Restore                           :b1, after a1, 20min
+    Switchover lambda workers         :b2, after b1, 5min
+    Serving harvester                 :milestone, after b2, 0min
+    section Impact 
+    Normal                  :done, c1, 00:00:00, 30min
+    No registration         :crit, c2b, after c1, 60min
+    Notification available  :done, c2a, after c1, 60min
+    Normal                  :done, c3, after c2a c2b, 5min    
+```
+
+Rollback:
+1. *Promote* the temporary database to be the primary registration database
+2. Switch all services to the temporary database
+Pro:
+1. No downtime to breaking news notification
+2. Readers is not able to register for a topic (rather than able to register but later the registration is lost).  *Arguably* it is better for the system to give a predictable outcome.
+Con:
+1. Downtime to registrations API
+
+
+### Option 4: Logical replication
+
+We create an empty Postgresql 13 database and use logical replication to continuously replicate data from production database.
+
+Logical replication has some limitations, which however does not affect us in our case.
+
+```mermaid
+gantt
+    title Approach 4 - Logical replicaton
+    dateFormat  HH:mm:ss
+    axisFormat  %H:%M:%S
+    section PROD DB
+    Enable replication                :a1, 00:00:00, 5min
+    Create publication                :a2, after a1, 5min
+    Synchronise                       :a3, after b1, 30min
+    section PG13 DB
+    Create subscription               :b1, after a2, 5min
+    Synchronise                       :b2, after b1, 30min
+    Stop subscription                 :b3, after b2, 5min
+    Switchover                        :b4, after b3, 5min
+    Serving all                       :milestone, after b4, 0min
+    section Impact 
+    No registration                   :crit, c1a, 00:00:00, 5min
+    No notification                   :crit, c1b, 00:00:00, 5min
+    Normal                            :done, c2, after c1a c1b, 35min
+    Registration lost                 :crit, c3a, after b3, 5min
+    Notification available            :done, c3b, after b3, 5min
+    Normal                            :done, c4, after c3a c3b, 5min    
+```
+
+Rollback:
+1. Before switchover, no action
+2. After switchover, switch back to the original PROD DB
+Pro:
+1. Minimal downtime
+2. Prepare an empty Postgresql 13 database beforehand
+Con:
+1. More sophisticated operations
+
+Procedure: https://aws.amazon.com/blogs/database/using-logical-replication-to-replicate-managed-amazon-rds-for-postgresql-and-amazon-aurora-to-self-managed-postgresql/
+RDS Supports logical replication: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication
+Postgresql: https://www.postgresql.org/docs/10/logical-replication.html
+
+### Option 5: Manual data copy
+
+We create an empty Postgresql 13 database and use pg_dump to copy data across the database
+
+```mermaid
+gantt
+    title Approach 5 - Manual data copy
+    dateFormat  HH:mm:ss
+    axisFormat  %H:%M:%S
+    section PROD DB
+    Create database dump              :a1, 00:00:00, 15min
+    section PG13 DB
+    Restore from dump                 :b1, after a1, 15min
+    Reindexing and optimizer stats    :b2, after a1, 10min
+    Switchover                        :b3, after b2, 5min
+    Serving all                       :milestone, after b2, 0min
+    section Impact 
+    Registration lost                 :crit, c1a, 00:00:00, 45min
+    Notification available            :done, c1b, 00:00:00, 45min
+    Normal                            :done, c2, after b2, 5min
+```
+
+Reference: https://www.postgresql.org/docs/10/backup-dump.html

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -214,16 +214,16 @@ gantt
     dateFormat  HH:mm:ss
     axisFormat  %H:%M:%S
     section PROD DB
-    Create database dump              :a1, 00:00:00, 15min
+    Create database dump              :a1, 00:00:00, 25min
     section PG13 DB
-    Restore from dump                 :b1, after a1, 15min
-    Reindexing and optimizer stats    :b2, after a1, 10min
+    Restore from dump                 :b1, after a1, 25min
+    Reindexing and optimizer stats    :b2, after b1, 10min
     Switchover                        :b3, after b2, 5min
-    Serving all                       :milestone, after b2, 0min
+    Serving all                       :milestone, after b3, 0min
     section Impact 
-    Registration lost                 :crit, c1a, 00:00:00, 45min
-    Notification available            :done, c1b, 00:00:00, 45min
-    Normal                            :done, c2, after b2, 5min
+    Registration lost                 :crit, c1a, 00:00:00, 65min
+    Notification available            :done, c1b, 00:00:00, 65min
+    Normal                            :done, c2, after b3, 5min
 ```
 
 Reference: https://www.postgresql.org/docs/10/backup-dump.html

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -53,6 +53,8 @@ The latest major version of Postgreql which RDS proxy supports is [version 13](h
 
 The major enhancements of postgresl 14 which are relevant to our system are feature improvement but they are not critical to our DB tuning work.  Moreover, our previous performance test suggests that RDS proxy can help with the performance, probably because it manages a lot of short-lived database connections from harvester functions and move the workload away from the database instance.  So I recommend upgrading to Postgresql 13.  We always have the option of upgrading again from Postgresql 13 to 14.
 
+At this moment, if we use AWS in-place upgrade, the registrations database (version 10.18) can be upgraded to [version 13.4](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion).  The database will be automatically upgraded to the latest "automatic upgrade version", which is version 13.6 at the moment, during maintenance window.
+
 ## Performance test with Postgresql 13
 The test result can be found in this [document](../testing/06-postgresql-upgrade.md).  Apparently it does not have direct impact on the performance.  However, Postgresql 13 improves the way the index is maintained and the way it does the vacuum and index rebuilding operations, which are useful to our database in the long run.  In addition, it provides a much better support in table partitioning which potentailly helps us to fine tune the registrations table further.
 
@@ -173,7 +175,7 @@ Disadvantages:
 
 We create an empty Postgresql 13 database and use logical replication to continuously replicate data from production database.
 
-Logical replication has some limitations, which however does not affect us in our case.
+Logical replication has [some restrictions](https://www.postgresql.org/docs/10/logical-replication-restrictions.html), but they do not affect the registrations database as the restricted features are not used.
 
 ```mermaid
 gantt
@@ -205,8 +207,9 @@ Rollback:
 
 Advantages:
 1. Minimal downtime
-2. Prepare an empty Postgresql 13 database beforehand
+2. Prepare an empty Postgresql 13.6 database beforehand
 3. The initial 5-min downtime on notification can be avoided by setting up a temporary database to serve breaking news tool
+4. Use Postgresql 13.6 directly (rather than 13.4)
 
 Disadvantages:
 1. More sophisticated operations
@@ -244,7 +247,8 @@ Rollback:
 2. After switchover, switch back to the original PROD DB
 
 Advantages:
-1. Prepare an empty Postgresql 13 database beforehand
+1. Prepare an empty Postgresql 13.6 database beforehand
+2. Use Postgresql 13.6 directly (rather than 13.4)
 
 Disadvantages:
 1. Changes to registrations database that happen during upgrade will be lost after switchover

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -216,13 +216,13 @@ gantt
     section PROD DB
     Create database dump              :a1, 00:00:00, 25min
     section PG13 DB
-    Restore from dump                 :b1, after a1, 25min
-    Reindexing and optimizer stats    :b2, after b1, 10min
+    Restore from dump                 :b1, after a1, 20min
+    Reindexing and optimizer stats    :b2, after b1, 5min
     Switchover                        :b3, after b2, 5min
     Serving all                       :milestone, after b3, 0min
     section Impact 
-    Registration lost                 :crit, c1a, 00:00:00, 65min
-    Notification available            :done, c1b, 00:00:00, 65min
+    Registration lost                 :crit, c1a, 00:00:00, 55min
+    Notification available            :done, c1b, 00:00:00, 55min
     Normal                            :done, c2, after b3, 5min
 ```
 

--- a/docs/architecture/03-postgresql-upgrade.md
+++ b/docs/architecture/03-postgresql-upgrade.md
@@ -206,6 +206,7 @@ Rollback:
 Advantages:
 1. Minimal downtime
 2. Prepare an empty Postgresql 13 database beforehand
+3. The initial 5-min downtime on notification can be avoided by setting up a temporary database to serve breaking news tool
 
 Disadvantages:
 1. More sophisticated operations

--- a/docs/architecture/03-postresql-upgrade-procedure.md
+++ b/docs/architecture/03-postresql-upgrade-procedure.md
@@ -1,0 +1,121 @@
+# Detailed Database Upgrade Procedure
+
+## Setup up a temporary database to serve breaking news notifications
+1. In AWS console, start `Take DB snapshot` action on the current PROD database
+- Name: registrations-PROD-upgrade-temp
+
+2. Run `Restore snapshot` from the created snapshot
+
+- DB instance identifier: `notifications-registrations-db-private-prod-temp`
+- Multi-AZ
+- VPC: notifications (vpc-5dddcb3f)
+- Subnet group: notifications-registrations-db-subnet-group-private-prod
+- VPC security groups: registrations-db-PROD, NO default
+- Instance class: db.t3.medium
+- Storage type: SSD (gp2)
+- Password authentication
+- Disable auto minor version upgrade
+
+3. Run some SQLs to mitigate the effects of [lazy loading](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RestoreFromSnapshot.html)
+- At terminal 1, set up a SSH tunnel to the database with `eval $(ssm ssh --tags registration,mobile-notifications,PROD -p mobile --raw --newest) -L 5432:notifications-registrations-db-private-prod-temp.crwidilr2ofx.eu-west-1.rds.amazonaws.com:5432`
+- At terminal 2, get the password with `aws --profile=mobile --region=eu-west-1 ssm get-parameter --with-decryption --name /notifications/PROD/registrations-db-password | jq -r .Parameter.Value`
+- At terminal 3, open psql with `psql -h localhost -U root registrationsPROD`
+- Run the queries `SELECT COUNT(1) FROM registrations.registrations;`
+- Run the queries `SELECT platform, COUNT(1) FROM registrations.registrations GROUP BY platform;`
+
+4. Switch the worker lambda functions over to the temporary database by 
+- changing the target group of the proxy `registrations-db-proxy-cdk-prod` to `notifications-registrations-db-private-prod-temp`
+
+5. Trigger the lambda [mobile-notifications-fakebreakingnews-PROD](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/mobile-notifications-fakebreakingnews-PROD?tab=code) to check if the service is available
+
+## Enable logical replication
+1. in AWS console, modify the DB `notifications-registrations-db-private-prod` to use the parameter group `logical-replication-publisher`
+- The parameter group has the following specific parameter values
+- `rds.logical_replication` to 1 (which causes AWS to set `wal_level` to `logical`)
+- `max_wal_senders` to 15
+
+2. Reboot the database to make parameters come into effect
+
+3. Switch back from the temporary database
+- Change the target group of the proxy `registrations-db-proxy-cdk-prod` to `notifications-registrations-db-private-prod`
+- Trigger the lambda [mobile-notifications-fakebreakingnews-PROD](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/mobile-notifications-fakebreakingnews-PROD?tab=code)
+
+## Set up publication in old PROD database
+1. Open the SQL client to the old PROD database
+- At terminal 1, set up a SSH tunnel to the database with `eval $(ssm ssh --tags registration,mobile-notifications,PROD -p mobile --raw --newest) -L 5432:notifications-registrations-db-private-prod.crwidilr2ofx.eu-west-1.rds.amazonaws.com:5432`
+- At terminal 2, get the password with `aws --profile=mobile --region=eu-west-1 ssm get-parameter --with-decryption --name /notifications/PROD/registrations-db-password | jq -r .Parameter.Value`
+- At terminal 3, open psql with `psql -h localhost -U root registrationsPROD`
+
+2. Create a publication by running `CREATE PUBLICATION alltables FOR ALL TABLES;` in the psql session
+- To check the publication, run `SELECT * FROM pg_publication;`
+
+3. After the new database makes a subscription, we can check the status of logical replication by running `SELECT * FROM pg_replication_slots;`
+- There should be an entry with the subscription name
+- The `active` column should be `t`
+- We may run `SELECT * FROM pg_stat_replication;` to get some statistics
+
+## Set up subscription in Postgresql 13 database
+1. Open the SQL client to the old PROD database
+- At terminal 1, set up a SSH tunnel to the database with `eval $(ssm ssh --tags registration,mobile-notifications,PROD -p mobile --raw --newest) -L 5432:notifications-registrations-db-private-pg13-prod.crwidilr2ofx.eu-west-1.rds.amazonaws.com:5432`
+- At terminal 2, get the password with `aws --profile=mobile --region=eu-west-1 ssm get-parameter --with-decryption --name /notifications/PROD/registrations-db-password | jq -r .Parameter.Value`
+- At terminal 3, open psql with `psql -h localhost -U root registrationsPROD`
+
+2. Create a subscription by running the following statement in the psql session.  Replace the password placeholder.
+```
+CREATE SUBSCRIPTION mysub
+         CONNECTION 'host=notifications-registrations-db-private-prod.crwidilr2ofx.eu-west-1.rds.amazonaws.com port=5432 user=root dbname=registrationsPROD password=<password>'
+        PUBLICATION alltables;
+```
+
+3. Check the status of the subscription by running `SELECT srsubid, pg_filenode_relation(0,srrelid), srsublsn, srsubstate FROM pg_subscription_rel;`
+- The `srsubstate` shows the current state:
+- `i` – Initialize,
+- `d` – Data is being copied,
+- `s` – Synchronized,
+- `r` – Ready (normal replication)
+
+4. When the state is changed to `r` (ready), make sure that the initial data copy has been completed by running `SELECT COUNT(1) FROM registrations.registrations;`
+
+5. After inital data copy, add primary constraint and an index by running:
+```
+ALTER TABLE ONLY registrations.registrations
+    ADD CONSTRAINT registrations_pkey PRIMARY KEY (token, topic);
+
+CREATE INDEX idx_registration_shard_topic ON registrations.registrations USING btree (shard, topic);   
+```
+
+6. To make sure that data are being synchronised continuously, we may run the queries in both database and compare.  (Change the timestamp)
+```
+SELECT COUNT(1) FROM registrations.registrations;
+
+SELECT token, topic, lastmodified FROM registrations.registrations
+WHERE lastmodified >= TO_TIMESTAMP('2022-08-11 13:00', 'YYYY-MM-DD HH24:MI') 
+ORDER BY lastmodified;
+```
+
+7. When we are ready to switch over, update the optimizer statistics by running `ANALYZE VERBOSE`
+
+## Switch over
+1. Stop the subscription in the new Postgresql 13 database by running `DROP SUBSCRIPTION mysub;`
+
+2. Switch the registrations API over to the new database by
+- changing the parameter in parameter store `/notifications/PROD/mobile-notifications/registration.db.url`
+- from: `jdbc:postgresql://notifications-registrations-db-private-prod.crwidilr2ofx.eu-west-1.rds.amazonaws.com/registrationsPROD?currentSchema=registrations`
+- to:   `jdbc:postgresql://notifications-registrations-db-private-pg13-prod.crwidilr2ofx.eu-west-1.rds.amazonaws.com/registrationsPROD?currentSchema=registrations`
+
+3. Restart the registrations API by redeploying the main branch of `mobile-n10n:registration` via riffraff
+
+4. Switch the worker lambda functions to the new database by
+- Change the target group of the proxy `registrations-db-proxy-cdk-prod` to `notifications-registrations-db-private-pg13-prod`
+- Trigger the lambda [mobile-notifications-fakebreakingnews-PROD](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/mobile-notifications-fakebreakingnews-PROD?tab=code)
+
+## Clean up
+1. Remove `<HOME>/.psql_history` file as it contains the password in the `CREATE SUBSCRIPTION` statement
+
+2. Stop the publication in the old PROD database by running `DROP PUBLICATION alltables`
+
+3. Delete the temporary database `notifications-registrations-db-private-prod-temp`
+
+3. When the notifications system has been running well with the new database, we may remove the old PROD database
+- Enable `create final snapshot`
+

--- a/docs/testing/05-database-tuning.md
+++ b/docs/testing/05-database-tuning.md
@@ -1,6 +1,6 @@
 # Database tuning - reducing table size
 
-This document summarises the test result and conclusiong for reducing table size.  The corresponding background and research work can be found in [the document](../architecture/02-database-tuning.md).
+This document summarises the test result and conclusion for reducing table size.  The corresponding background and research work can be found in [the document](../architecture/02-database-tuning.md).
 
 ## Results
 

--- a/docs/testing/06-postgresql-upgrade.md
+++ b/docs/testing/06-postgresql-upgrade.md
@@ -1,0 +1,50 @@
+# Postgresql Database Upgrade
+
+This document summarises the test result for database upgrade.  The corresponding background and research work can be found in [the document](../architecture/03-postgresql-upgrade.md).
+
+## Results
+
+A performance test was performed for each of the scenarios:
+1. Before upgrade from Postgresql 10
+2. Upgraded to Postgresql 14
+3. Upgraded to Postgresql 13
+
+Under each scenario, I sent four rounds of breaking news notification.
+
+### Before upgrade from Postgresql 10
+
+| # | Total harvester duration (s) | No. harvester invocations | Harvester error "marked as broken" |
+| ----------- | ----------- | ----------- | ----------- |
+| 1	| 32.41 | 159 | 0 |
+| 2	| 12.36 | 159 | 0 |
+| 3	| 11.97 | 159 | 0 |
+| 4	| 11.2 | 159 | 0 |
+| AVG | 16.985 | 159 | 0 |
+
+### Postgresql 14
+
+| # | Total harvester duration (s) | No. harvester invocations | Harvester error "marked as broken" |
+| ----------- | ----------- | ----------- | ----------- |
+| 1 | 28.85 | 162 | 0 |
+| 2 | 15.6 | 159 | 0 |
+| 3 | 10.41 | 159 | 0 |
+| 4 | 13.08 | 159 | 0 |
+| AVG | 16.985 | 159.75 | 0 |
+
+### Postgresql 13
+
+| # | Total harvester duration (s) | No. harvester invocations | Harvester error "marked as broken" |
+| ----------- | ----------- | ----------- | ----------- |
+1 | 33.41| 158 | 0 |
+2 | 14.52| 158 | 0 |
+3 | 17.94| 158 | 0 |
+4 | 24.6 | 158 | 0 |
+| AVG | 22.6175 | 158 | 0 |
+
+## Conclusion
+
+
+
+
+
+


### PR DESCRIPTION
## What does this change?

When we set up a RDS proxy in  #666 , we should manually populate the `secrets` created in Secrets Manager with the actual database passwords.  It creates a problem where we may change some parameters in the cloudformation stack `registrations-db-proxy` and as a result the AWS re-initialises the passwords in `secrets` to randomly generated strings.  Manual operations are then required to populate the secrets again.

 Newer version of AWS CDK allows us to reference the secret values stored in SSM parameter store and populates `secrets` with the actual passwords upon cloudformation creation / update.  The generated cloudformation JSON does not contain the passwords.  It just shows the path of the parameter store which is then accessed by AWS during cloudformation provisioning.

This PR bumps the GuCDK to the latest version v47 and AWS CDK v2.35 so that it uses this feature to reference SSM to set the passwords in `secrets`.

## How to test

We checked the generated cloudformation JSON and tested it on `CODE`.
