### PR TITLE
Notification app metrics

### DIFF
--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -22,7 +22,6 @@ import tracking.SentNotificationReportRepository
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 import scala.jdk.CollectionConverters.MapHasAsJava
-import scala.util.{Failure, Success}
 
 final class Main(
   configuration: Configuration,
@@ -93,8 +92,7 @@ final class Main(
           case _ => {}
         }
         send
-      }
-      )
+      })
     }) recoverWith {
       case NonFatal(exception) => {
         logger.warn(s"Pushing notification failed: $notification", exception)

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -5,6 +5,7 @@ import java.time.{Duration, Instant}
 import authentication.AuthAction
 import com.amazonaws.services.cloudwatch.model.StandardUnit
 import metrics.{CloudWatchMetrics, MetricDataPoint}
+import models.NotificationType.BreakingNews
 import models.{TopicTypes, _}
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers.appendEntries
@@ -21,6 +22,7 @@ import tracking.SentNotificationReportRepository
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 import scala.jdk.CollectionConverters.MapHasAsJava
+import scala.util.{Failure, Success}
 
 final class Main(
   configuration: Configuration,
@@ -73,10 +75,9 @@ final class Main(
       case a: Int if a > MaxTopics => Future.successful(BadRequest(s"Too many topics, maximum: $MaxTopics"))
       case _ if !topics.forall{topic => request.isPermittedTopicType(topic.`type`)} =>
         Future.successful(Unauthorized(s"This API key is not valid for ${topics.filterNot(topic => request.isPermittedTopicType(topic.`type`))}."))
-      case _ =>
-        val result = pushWithDuplicateProtection(notification)
+      case _ => pushWithDuplicateProtection(notification).map(send => {
         val durationMillis = Duration.between(notificationReceivedTime, Instant.now).toMillis
-        result.foreach(_ => logger.info(
+        logger.info(
           Map(
             "notificationId" -> notification.id,
             "notificationType" -> notification.`type`.toString,
@@ -85,8 +86,14 @@ final class Main(
             "notificationApp.notificationReceivedTime.millis" -> notificationReceivedTime.toEpochMilli,
             "notificationApp.notificationReceivedTime.string" -> notificationReceivedTime.toString,
           ),
-        s"Spent $durationMillis milliseconds processing notification ${notification.id}"))
-        result
+          s"Spent $durationMillis milliseconds processing notification ${notification.id}")
+        metrics.send(MetricDataPoint(name = "NotificationProcessingTime", value = durationMillis.toDouble, unit = StandardUnit.Milliseconds))
+        notification.`type` match {
+          case BreakingNews => metrics.send(MetricDataPoint(name = "BreakingNewsNotificationCount", value = 1, unit = StandardUnit.Count))
+        }
+        send
+      }
+      )
     }) recoverWith {
       case NonFatal(exception) => {
         logger.warn(s"Pushing notification failed: $notification", exception)

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -90,6 +90,7 @@ final class Main(
         metrics.send(MetricDataPoint(name = "NotificationProcessingTime", value = durationMillis.toDouble, unit = StandardUnit.Milliseconds))
         notification.`type` match {
           case BreakingNews => metrics.send(MetricDataPoint(name = "BreakingNewsNotificationCount", value = 1, unit = StandardUnit.Count))
+          case _ => {}
         }
         send
       }

--- a/notification/app/notification/controllers/Main.scala
+++ b/notification/app/notification/controllers/Main.scala
@@ -87,7 +87,7 @@ final class Main(
             "notificationApp.notificationReceivedTime.string" -> notificationReceivedTime.toString,
           ),
           s"Spent $durationMillis milliseconds processing notification ${notification.id}")
-        metrics.send(MetricDataPoint(name = "NotificationProcessingTime", value = durationMillis.toDouble, unit = StandardUnit.Milliseconds))
+        metrics.send(MetricDataPoint(name = "NotificationAppProcessingTime", value = durationMillis.toDouble, unit = StandardUnit.Milliseconds))
         notification.`type` match {
           case BreakingNews => metrics.send(MetricDataPoint(name = "BreakingNewsNotificationCount", value = 1, unit = StandardUnit.Count))
           case _ => {}


### PR DESCRIPTION
## What does this change?

The reliability team has provided a very useful [doc](https://docs.google.com/document/d/10AnOZ4MLjuTO7mXaySoVO2SwmroLmns4gGmsfY7egmw/edit?usp=sharing) about how to incorporate metrics into our notification platform. 

This PR adds metrics to the notification app only:
- notification app processing time
- count of breaking news notifications

This PR also changes the logic for how duration is calculated: previously the duration didn't account for the Future completing so the duration looked to always be ~0ms. Now I'm seeing more realistic durations (600-1700ms).

I can see that the metrics are being pushed to cloudwatch as expected:
<img width="1548" alt="Screenshot 2022-08-19 at 15 06 04" src="https://user-images.githubusercontent.com/45561419/185636482-2467d9ea-16f7-4eae-b70c-ddd9e69d0e24.png">

## How to test

I pushed to CODE, sent a couple of test notifications and checked:
- logs
- kibana dashboard
- cloudwatch metrics

## How can we measure success?

Given we publish these metrics I think we'll have the observability we need to monitor the notification app.

## Have we considered potential risks?

We're pushing custom metrics which incurs additional cost, but I'm not using additional dimensions which hopefully controls this additional cost ($0.30 per month, $0.01 per 1,000 requests).
