### PR TITLE
Bump firebase admin version to the latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -400,7 +400,7 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
     dockerAlias := DockerAlias(registryHost = dockerRepository.value, username = None, name = (Docker / packageName).value, tag = buildNumber),
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
-      "com.google.firebase" % "firebase-admin" % "8.1.0",
+      "com.google.firebase" % "firebase-admin" % "9.0.0",
       "com.google.protobuf" % "protobuf-java" % "3.19.2",
       "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",
       "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,


### PR DESCRIPTION
This PR bumps the dependency on firebase admin to the latest version, we have recently been seeing some errors in our logs such as:

```sending failure: com.gu.notifications.worker.delivery.DeliveryException$FailedRequest: Request failed (Notification: 9694efd8-766e-36fe-b952-c4c15ed55bf4, Token: fi8bOpe4hpE:APA91bEwB0wxtYzSYwoM4DsEqfTDY8usq5zgEBbUHtN-FQtmFdgyUy7X1vzpF9ybZ9viM6_xFgchBVKIRzRqz6EHZ2TJ9sS8fzYX419sRM84GnZ6el61vZtawfNXH5-VIYurfbF2Fa2d). Cause: Internal error encountered.. ErrorCode: Some(INTERNAL)}```

and 

```Sending failure: com.gu.notifications.worker.delivery.DeliveryException$FailedRequest: Request failed (Notification: 1f8efa25-61e9-4da8-974e-7022dc6a6011, Token: fXVZX70wQPSsLnKVchApuX:APA91bHebes1c-aXXvAAwji-Gj3MWUuL62zrgdb6GjbWFEEfH0pbkhK2HGJXisXN-KZ4jerYucUEp-17NudTTdWQrgfN1LaHOEppgbmh0lKjArNCI0dxqx98mGZJ_jLA-u1IF1ubQYCt). Cause: Unknown error while making a remote service call: stream was reset: CANCEL. ErrorCode: Some(UNKNOWN)}.```

The hope is that bumping to the latest version might help with transitive dependencies. 