### PR TITLE
reduce reserved concurrency for registration cleaning worker

### DIFF
--- a/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
+++ b/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
@@ -149,7 +149,7 @@ Resources:
       MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
       Timeout: 300
-      ReservedConcurrentExecutions: 100
+      ReservedConcurrentExecutions: 1
       VpcConfig:
         SecurityGroupIds:
           - !GetAtt LambdaSecurityGroup.GroupId


### PR DESCRIPTION
## What does this change?

We would like to deploy https://github.com/guardian/mobile-n10n/pull/739 which will temporarily put increased load on the db due to a large volume of invalid tokens that we expect to parse.

Previously when we processed a large number of messages from the cleaning queue it resulted in poor performance when delivering notifications: https://docs.google.com/document/d/1svFwqn2MBVue-gSQvkS5u2MAQsOO8aOyPJeMcj26i88/edit?usp=sharing

We would like to temporarily slow down the cleaner lambda by reducing the number of parallel executions. The intention is that this would control any additional load on the db, preventing delivery of notifications to be noticeably slowed down.

This reduces the cleaning lambda's reserved concurrency to 1. As a result, we may expect to see throttle alerts for this lambda after deploying #739.

When we reach a steady state of android invalid tokens we should revert this change.

## How to test

After deploying confirm that lambda `mobile-notifications-registration-cleaning-worker-ctr-PROD` has a reserved concurrency of 1.

## How can we measure success?

Reduced reserved concurrency meaning only 1 cleaner lambda will run at any given time.

