### PR TITLE
Set the netty version for slomonitor to fix snyk vulnerabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -354,6 +354,7 @@ lazy val sloMonitor = lambda("slomonitor", "slomonitor", Some("com.gu.notificati
       description := "Monitors SLO performance for breaking news notifications",
       libraryDependencies ++= Seq(
         "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
+        "io.netty" % "netty-codec" % nettyVersion,
       ),
       riffRaffArtifactResources +=(file("cdk/cdk.out/SloMonitor-CODE.template.json"), s"mobile-notifications-slo-monitor-cfn/SloMonitor-CODE.template.json"),
       riffRaffArtifactResources += (file("cdk/cdk.out/SloMonitor-PROD.template.json"), s"mobile-notifications-slo-monitor-cfn/SloMonitor-PROD.template.json")


### PR DESCRIPTION
## What does this change?

This PR sets the version of netty-codec library for the new subproject `slomonitor` to fix snyk vulnerabilities.

## How to test

We executed the snyk scan locally to confirm that the vulnerabilities were fixed.
Teamcity build executed the unit tests automatically.

