### PR TITLE
Include multiple partition_dates if notification sent just before midnight

### DIFF
--- a/slomonitor/src/main/scala/com.gu.notifications.slos/SloMonitor.scala
+++ b/slomonitor/src/main/scala/com.gu.notifications.slos/SloMonitor.scala
@@ -89,5 +89,4 @@ trait SloMonitor {
 
 object SloMonitor extends SloMonitor {
   val stage: String = System.getenv("STAGE")
-
 }

--- a/slomonitor/src/main/scala/com.gu.notifications.slos/SloMonitor.scala
+++ b/slomonitor/src/main/scala/com.gu.notifications.slos/SloMonitor.scala
@@ -10,19 +10,19 @@ import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers.appendEntries
 import org.slf4j.{Logger, LoggerFactory}
 
-import java.time.{Instant, LocalDateTime, ZoneOffset}
+import java.time.{Instant, LocalDateTime, LocalTime, ZoneOffset}
 import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
 import scala.concurrent.{Await, ExecutionContext, duration}
 import scala.jdk.CollectionConverters.MapHasAsJava
 
-object SloMonitor {
+trait SloMonitor {
 
   import ExecutionContext.Implicits.global
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
   implicit def mapToContext(c: Map[String, _]): LogstashMarker = appendEntries(c.asJava)
 
-  val stage: String = System.getenv("STAGE")
+  val stage: String
 
   val credentials = new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider("mobile"),
@@ -40,6 +40,21 @@ object SloMonitor {
     (actualDeliveries / expectedDeliveries) * 100
   }
 
+  def generateQueryString(notificationId: String, sentTime: LocalDateTime): String = {
+    val partitionDate = if (sentTime.toLocalTime.isAfter(LocalTime.of(23, 57)))
+      s"(partition_date = '${sentTime.toLocalDate}' OR partition_date = '${sentTime.toLocalDate.plusDays(1)}')"
+    else
+      s"partition_date = '${sentTime.toLocalDate}'"
+
+    s"""
+         |SELECT COUNT(*)
+         |FROM notification_received_${stage.toLowerCase()}
+         |WHERE notificationid = '${notificationId}'
+         |AND $partitionDate
+         |AND DATE_DIFF('second', from_iso8601_timestamp('${sentTime}'), received_timestamp) < 120
+      """.stripMargin
+  }
+
   def handleMessage(event: SQSEvent): Unit = {
     logger.info(s"Running SLO monitor")
     val record = event.getRecords.get(0) // Batch size is defined as 1 in cdk
@@ -50,14 +65,7 @@ object SloMonitor {
     // b) Obtain it via the DynamoDB Report table
     // c) Something else...
     val expectedDeliveries: Int = 100 // FIXME
-    val query =
-      s"""
-         |SELECT COUNT(*)
-         |FROM notification_received_${stage.toLowerCase()}
-         |WHERE notificationid = '${notificationId}'
-         |AND partition_date = '${sentTime.toLocalDate}'
-         |AND DATE_DIFF('second', from_iso8601_timestamp('${sentTime}'), received_timestamp) < 120
-      """.stripMargin
+    val query = generateQueryString(notificationId, sentTime)
     logger.info(s"Starting query: $query")
     val result = Athena.startQuery(Query("notifications", query, s"s3://aws-mobile-event-logs-${this.stage.toLowerCase()}/athena/slo-monitoring"))
       .flatMap(Athena.fetchQueryResponse(_, rows => rows.head.head)
@@ -76,5 +84,10 @@ object SloMonitor {
       )
     Await.result(result, duration.Duration(4, TimeUnit.MINUTES))
   }
+
+}
+
+object SloMonitor extends SloMonitor {
+  val stage: String = System.getenv("STAGE")
 
 }

--- a/slomonitor/src/test/scala/com/gu/notifications/slos/SloMonitorSpec.scala
+++ b/slomonitor/src/test/scala/com/gu/notifications/slos/SloMonitorSpec.scala
@@ -1,13 +1,11 @@
 package com.gu.notifications.slos
 
-import org.mockito.Mockito.when
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 
 import java.time.LocalDateTime
 
-class SloMonitorSpec extends Specification with Mockito {
+class SloMonitorSpec extends Specification {
   "generateQueryString" should {
     "include a single partitionDate if before midnight" in new Scope {
       val notificationId = "1234-ASDF"

--- a/slomonitor/src/test/scala/com/gu/notifications/slos/SloMonitorSpec.scala
+++ b/slomonitor/src/test/scala/com/gu/notifications/slos/SloMonitorSpec.scala
@@ -1,0 +1,45 @@
+package com.gu.notifications.slos
+
+import org.mockito.Mockito.when
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import java.time.LocalDateTime
+
+class SloMonitorSpec extends Specification with Mockito {
+  "generateQueryString" should {
+    "include a single partitionDate if before midnight" in new Scope {
+      val notificationId = "1234-ASDF"
+      val sentTime = LocalDateTime.of(2022, 9, 28, 9, 30, 0)
+      val queryString = TestSloMonitor.generateQueryString(notificationId, sentTime)
+
+      queryString shouldEqual s"""
+         |SELECT COUNT(*)
+         |FROM notification_received_test
+         |WHERE notificationid = '$notificationId'
+         |AND partition_date = '2022-09-28'
+         |AND DATE_DIFF('second', from_iso8601_timestamp('2022-09-28T09:30'), received_timestamp) < 120
+      """.stripMargin
+    }
+
+    "include a two partitionDates if just before midnight" in new Scope {
+      val notificationId = "1234-ASDF"
+      val sentTime = LocalDateTime.of(2022, 9, 28, 23, 58, 0)
+      val queryString = TestSloMonitor.generateQueryString(notificationId, sentTime)
+
+      queryString shouldEqual
+        s"""
+           |SELECT COUNT(*)
+           |FROM notification_received_test
+           |WHERE notificationid = '$notificationId'
+           |AND (partition_date = '2022-09-28' OR partition_date = '2022-09-29')
+           |AND DATE_DIFF('second', from_iso8601_timestamp('2022-09-28T23:58'), received_timestamp) < 120
+      """.stripMargin
+    }
+  }
+}
+
+object TestSloMonitor extends SloMonitor {
+  val stage: String = "TEST"
+}


### PR DESCRIPTION
## What does this change?

We pushed the slomonitor lambda into production to collect data about the accuracy of the 90in2 count. The results revealed an edge case that severely impacted data accuracy for a specific scenario:
- A notification was sent at 23.59
- The athena query only counted results from the same day
- The majority of the notifications were received within the 2nd minute after sending, i.e. 00.01 the following day, and so were accidentally excluded from the 90in2 count

This PR attempts to handle the edge case to improve the data accuracy of slomonitor's 90in2 count:

- extract and extend the logic that generates the athena query string
- create test cases for query string generation
- refactor slomonitor object to extend from a trait allowing env vars to be overridden in tests


## How to test

We've added unit tests to cover the expected change in logic.

## How can we measure success?

After pushing the change we should continue to monitor the 90in2 accuracy, if the edge case scenario happens again we should expect to see a 90in2 count that matches that seen via bigquery.

