### PR TITLE
Revert "reduce reserved concurrency for registration cleaning worker"

### DIFF
--- a/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
+++ b/notificationworkerlambda/registration-cleaning-worker-cfn.yaml
@@ -149,7 +149,7 @@ Resources:
       MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
       Timeout: 300
-      ReservedConcurrentExecutions: 1
+      ReservedConcurrentExecutions: 100
       VpcConfig:
         SecurityGroupIds:
           - !GetAtt LambdaSecurityGroup.GroupId


### PR DESCRIPTION
Reverts guardian/mobile-n10n#745

Now that we’ve successfully deployed #739  we can revert the concurrency restriction we put on the cleaning worker #745 