### PR TITLE
Fix failing slomonitor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -357,7 +357,9 @@ lazy val sloMonitor = lambda("slomonitor", "slomonitor", Some("com.gu.notificati
         "io.netty" % "netty-codec" % nettyVersion,
       ),
       riffRaffArtifactResources +=(file("cdk/cdk.out/SloMonitor-CODE.template.json"), s"mobile-notifications-slo-monitor-cfn/SloMonitor-CODE.template.json"),
-      riffRaffArtifactResources += (file("cdk/cdk.out/SloMonitor-PROD.template.json"), s"mobile-notifications-slo-monitor-cfn/SloMonitor-PROD.template.json")
+      riffRaffArtifactResources += (file("cdk/cdk.out/SloMonitor-PROD.template.json"), s"mobile-notifications-slo-monitor-cfn/SloMonitor-PROD.template.json"),
+      Test / fork := true,
+      Test / envVars := Map("STAGE" -> "TEST")
     )
   })
 

--- a/slomonitor/src/main/scala/com.gu.notifications.slos/SloMonitor.scala
+++ b/slomonitor/src/main/scala/com.gu.notifications.slos/SloMonitor.scala
@@ -15,14 +15,14 @@ import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
 import scala.concurrent.{Await, ExecutionContext, duration}
 import scala.jdk.CollectionConverters.MapHasAsJava
 
-trait SloMonitor {
+object SloMonitor {
 
   import ExecutionContext.Implicits.global
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
   implicit def mapToContext(c: Map[String, _]): LogstashMarker = appendEntries(c.asJava)
 
-  val stage: String
+  val stage: String = System.getenv("STAGE")
 
   val credentials = new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider("mobile"),
@@ -85,8 +85,4 @@ trait SloMonitor {
     Await.result(result, duration.Duration(4, TimeUnit.MINUTES))
   }
 
-}
-
-object SloMonitor extends SloMonitor {
-  val stage: String = System.getenv("STAGE")
 }

--- a/slomonitor/src/test/scala/com/gu/notifications/slos/SloMonitorSpec.scala
+++ b/slomonitor/src/test/scala/com/gu/notifications/slos/SloMonitorSpec.scala
@@ -10,7 +10,7 @@ class SloMonitorSpec extends Specification {
     "include a single partitionDate if before midnight" in new Scope {
       val notificationId = "1234-ASDF"
       val sentTime = LocalDateTime.of(2022, 9, 28, 9, 30, 0)
-      val queryString = TestSloMonitor.generateQueryString(notificationId, sentTime)
+      val queryString = SloMonitor.generateQueryString(notificationId, sentTime)
 
       queryString shouldEqual s"""
          |SELECT COUNT(*)
@@ -24,7 +24,7 @@ class SloMonitorSpec extends Specification {
     "include a two partitionDates if just before midnight" in new Scope {
       val notificationId = "1234-ASDF"
       val sentTime = LocalDateTime.of(2022, 9, 28, 23, 58, 0)
-      val queryString = TestSloMonitor.generateQueryString(notificationId, sentTime)
+      val queryString = SloMonitor.generateQueryString(notificationId, sentTime)
 
       queryString shouldEqual
         s"""
@@ -36,8 +36,4 @@ class SloMonitorSpec extends Specification {
       """.stripMargin
     }
   }
-}
-
-object TestSloMonitor extends SloMonitor {
-  val stage: String = "TEST"
 }


### PR DESCRIPTION
## What does this change?

slomonitor was failing to execute in aws because of missing class constructor, we believe it's caused by recent refactoring of trait/object in #771. Refactoring the tests and trait/object to fix this error.

![Screenshot 2022-09-29 at 09 27 21](https://user-images.githubusercontent.com/45561419/192980845-c1991f73-a1a7-46d9-bc26-79359254d50a.png)


## How to test

Deployed to CODE, sent a breaking news notification, validated slomonitor executed correctly.

![Screenshot 2022-09-29 at 09 29 31](https://user-images.githubusercontent.com/45561419/192981324-ce0964d7-5d73-4a88-95bb-f5fb0482b344.png)


