### PR TITLE
Resolve bucket name by SSM parameters

### DIFF
--- a/notification/conf/riff-raff.yaml
+++ b/notification/conf/riff-raff.yaml
@@ -17,6 +17,7 @@ deployments:
   notification:
     type: autoscaling
     parameters:
-      bucket: mobile-notifications-dist
+      bucketSsmLookup: true
+      bucketSsmKey: /account/services/artifact.bucket.n10n
     dependencies: [notification-cfn]
 

--- a/registration/conf/riff-raff.yaml
+++ b/registration/conf/riff-raff.yaml
@@ -12,6 +12,7 @@ deployments:
   registration:
     type: autoscaling
     parameters:
-      bucket: mobile-notifications-dist
+      bucketSsmLookup: true
+      bucketSsmKey: /account/services/artifact.bucket.n10n
     dependencies: [registration-cfn]
 

--- a/report/conf/riff-raff.yaml
+++ b/report/conf/riff-raff.yaml
@@ -12,6 +12,7 @@ deployments:
   report:
     type: autoscaling
     parameters:
-      bucket: mobile-notifications-dist
+      bucketSsmLookup: true
+      bucketSsmKey: /account/services/artifact.bucket.n10n
     dependencies: [report-cfn]
 


### PR DESCRIPTION
## What does this change?

DevX informed us that their [recommendations](https://github.com/guardian/recommendations/blob/main/github.md#repository-contents) for repository content suggests not committing S3 bucket names into public repositories. Previously the riff-raff.yaml file requires a bucket name for the autoscaling deployment type.  They are now able to provide bucketSsmLookup: true and have Riff-Raff discover the S3 bucket to copy the application artifact to via an SSM parameter.

This PR is to change the riff-raff yaml in Notification settings so that it resolves the bucket name by SSM parameter.

A SSM parameter has been created for the bucket name used by n10n. 

## How to test

We tested that registration request has been handled successfully.  A fake notification was sent successfully as well.
