### PR TITLE
LIVE-4673 Use bucket name lookup in riff-raff yaml

### DIFF
--- a/eventconsumer/riff-raff.yaml
+++ b/eventconsumer/riff-raff.yaml
@@ -5,7 +5,8 @@ deployments:
   eventconsumer:
     type: aws-lambda
     parameters:
-      bucket: mobile-notifications-dist
+      bucketSsmLookup: true
+      bucketSsmKey: /account/services/artifact.bucket.n10n
       functionNames:
       - mobile-notifications-eventconsumer-athena-
       fileName: eventconsumer.jar

--- a/football/riff-raff.yaml
+++ b/football/riff-raff.yaml
@@ -5,7 +5,7 @@ deployments:
   football:
     type: aws-lambda
     parameters:
-      bucket: mobile-dist
+      bucketSsmLookup: true
       functionNames: [-football-]
       fileName: football.jar
     dependencies: [mobile-notifications-football-cfn]

--- a/reportextractor/riff-raff.yaml
+++ b/reportextractor/riff-raff.yaml
@@ -4,7 +4,8 @@ deployments:
   reportextractor:
     type: aws-lambda
     parameters:
-      bucket: mobile-notifications-dist
+      bucketSsmLookup: true
+      bucketSsmKey: /account/services/artifact.bucket.n10n
       functionNames: [mobile-notifications-reportextractor-]
       fileName: reportextractor.jar
       prefixStack: false

--- a/schedulelambda/riff-raff.yaml
+++ b/schedulelambda/riff-raff.yaml
@@ -4,7 +4,8 @@ deployments:
   schedule:
     type: aws-lambda
     parameters:
-      bucket: mobile-notifications-dist
+      bucketSsmLookup: true
+      bucketSsmKey: /account/services/artifact.bucket.n10n
       functionNames: [mobile-notifications-schedule-]
       fileName: schedule.jar
       prefixStack: false


### PR DESCRIPTION
## What does this change?

DevX informed us that their [recommendations](https://github.com/guardian/recommendations/blob/main/github.md#repository-contents) for repository content suggests not committing S3 bucket names into public repositories. Previously the riff-raff.yaml file requires a bucket name for the autoscaling deployment type. They are now able to provide bucketSsmLookup: true and have Riff-Raff discover the S3 bucket to copy the application artifact to via an SSM parameter.

The previous PR #788 changed the riff-raff yaml for the web services (notification, registration, report).

This PR changed the riff-raff yaml for the lambdas. 

## How to test

We checked that the riff-raff deployment resolved the bucket to the correct one on `CODE` and copied the function packages to the bucket.

We also checked that the function code of the lambda was updated in AWS console.

