### PR TITLE
Run worker lambdas locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ dynamodb-local-schedule-lambda/
 project/.bloop/
 project/metals.sbt
 .bsp/
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -108,5 +108,40 @@ Part of [Notification Worker Lambda(s)](notificationworkerlambda). Retrieves the
 
 Tunnel to the CODE notifications database(See[Mobile Platform](https://github.com/guardian/mobile-platform/))) Run `sbt` set `project notificationworkerlambda` and `run` runs the lambda locally. 
 
-   
+### Notification Worker Local Run
 
+The notification worker lambdas can be run locally.
+
+Export the desired `Platform` env var in your terminal (e.g. `export Platform=android`). Without the Platform env var an exception is thrown during instantiation. 
+
+When running locally our identity resolves to a DevIdentity. This means that we attempt to load config locally instead of from ssm. Ensure that you have a ~/.gu/notification-worker.conf file with the following properties:
+
+````
+{
+    cleaningSqsUrl = "url"
+    dryrun = false
+    fcm {
+            debug = true
+            serviceAccountKey = """key"""
+            threadPoolSize = x
+        }
+}
+````
+
+NB: note the `"""` enclosing the serviceAccountKey, which are needed to correctly parse this string.
+
+After starting `sbt`, inside the `notificationworkerlambda` project we can execute:
+
+`run NotificationWorkerLocalRun android`
+
+The last argument in the command is the name of the worker lambda you want to run locally, eg `android`, `ios`.
+
+To control the tokens we send from the local lambda we can modify the NotificationWorkerLocalRun.scala file:
+
+```
+  val tokens = ChunkedTokens(
+    notification = notification,
+    range = ShardRange(0, 1),
+    tokens = List("<your_token _1>", "your_token_2", ...)
+  )
+```

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
@@ -1,0 +1,55 @@
+package com.gu.notifications.worker
+
+import _root_.models._
+import _root_.models.TopicTypes._
+import _root_.models.Link._
+import _root_.models.Importance._
+import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
+import com.gu.notifications.worker.tokens.ChunkedTokens
+import play.api.libs.json.Json
+
+import java.util.UUID
+import scala.jdk.CollectionConverters._
+
+object NotificationWorkerLocalRun extends App {
+  val notification = BreakingNewsNotification(
+    id = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
+    `type` = NotificationType.BreakingNews,
+    title = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"),
+    message = Some("French president Francois Hollande says killers of Normandy priest claimed to be from Islamic State"),
+    thumbnailUrl = None,
+    sender = "matt.wells@guardian.co.uk",
+    link = Internal(
+      "world/2016/jul/26/men-hostages-french-church-police-normandy-saint-etienne-du-rouvray",
+      Some("https://gu.com/p/4p7xt"),
+      GITContent,None,
+    ),
+    imageUrl = None,
+    importance = Major,
+    topic = List(Topic(Breaking, "uk"), Topic(Breaking, "us"), Topic(Breaking, "au"), Topic(Breaking, "international")),
+    dryRun = None
+  )
+
+  val tokens = ChunkedTokens(
+    notification = notification,
+    range = ShardRange(0, 1),
+    tokens = List("token")
+  )
+
+  val sqsEvent: SQSEvent = {
+    val event = new SQSEvent()
+    val sqsMessage = new SQSMessage()
+    sqsMessage.setBody(Json.stringify(Json.toJson(tokens)))
+    sqsMessage.setAttributes((Map("SentTimestamp" -> "10").asJava))
+    event.setRecords(List(sqsMessage).asJava)
+    event
+  }
+
+  args.lastOption.map(_.toLowerCase) foreach {
+    case "android" => new AndroidSender().handleChunkTokens(sqsEvent, null)
+    case "ios"     => new IOSSender().handleChunkTokens(sqsEvent, null)
+    case _         => println("invalid option")
+  }
+
+}


### PR DESCRIPTION
## What does this change?

We want to test and validate new methods for sending notifications/tokens via firebase. Having a local setup for sending notifications will enable us to quickly test new functions without needing to deploy to CODE.

This change adds the ability to execute the ios and android worker lambdas locally.

### Changes:

- create an object that allows us to run the lambda handler functions locally
- update readme with setup instructions for running the worker lambdas locally

## How to test

- export Platform env var
- create notification-worker.conf file with CODE values
- start sbt and change to project notificationworkerlambda
- `run NotificationWorkerLocalRun android`
- see valid response from firebase

## Images
<img width="1764" alt="Screenshot 2022-10-19 at 11 30 06" src="https://user-images.githubusercontent.com/45561419/196667395-4a46d7c5-370b-4bfa-bc14-5e72d1079954.png">

