### PR TITLE
Removing blocking code from the firebase client

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -1,7 +1,7 @@
 package com.gu.notifications.worker.delivery.fcm
 
 import _root_.models.Notification
-import com.google.api.core.ApiFuture
+import com.google.api.core.{ApiFuture, ApiFutureCallback, ApiFutures}
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.firebase.messaging.{FirebaseMessaging, FirebaseMessagingException, Message, MessagingErrorCode}
 import com.google.firebase.{ErrorCode, FirebaseApp, FirebaseOptions}
@@ -14,7 +14,7 @@ import com.gu.notifications.worker.utils.UnwrappingExecutionException
 
 import java.io.ByteArrayInputStream
 import java.util.UUID
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future, Promise}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
@@ -45,7 +45,7 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
   }
 
   def sendNotification(notificationId: UUID, token: String, payload: Payload, dryRun: Boolean)
-    (onComplete: Either[Throwable, Success] => Unit)
+    (onAPICallComplete: Either[Throwable, Success] => Unit)
     (implicit executionContext: ExecutionContextExecutor): Unit = {
 
     val message = Message
@@ -54,28 +54,31 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
       .setAndroidConfig(payload.androidConfig)
       .build
 
-
     if(dryRun) { // Firebase has a dry run mode but in order to get the same behavior for both APNS and Firebase we don't send the request
-      onComplete(Right(FcmDeliverySuccess(token, "dryrun", dryRun = true)))
+      onAPICallComplete(Right(FcmDeliverySuccess(token, "dryrun", dryRun = true)))
     } else {
       import FirebaseHelpers._
       firebaseMessaging
         .sendAsync(message)
         .asScala
-        .onComplete {
-          case Success(messageId) =>
-            onComplete(Right(FcmDeliverySuccess(token, messageId)))
-          case Failure(UnwrappingExecutionException(e: FirebaseMessagingException)) if invalidTokenErrorCodes.contains(e.getErrorCode) || isUnregistered(e) =>
-            onComplete(Left(InvalidToken(notificationId, token, e.getMessage)))
-          case Failure(UnwrappingExecutionException(e: FirebaseMessagingException)) =>
-            onComplete(Left(FailedRequest(notificationId, token, e, Option(e.getErrorCode.toString))))
-          case Failure(NonFatal(t)) =>
-            onComplete(Left(FailedRequest(notificationId, token, t)))
-          case Failure(_) =>
-            onComplete(Left(UnknownReasonFailedRequest(notificationId, token)))
-        }
+        .onComplete { response => parseSendResponse(notificationId, token, response)(onAPICallComplete) }
     }
   }
+
+  def parseSendResponse(
+    notificationId: UUID, token: String, response: Try[String]
+  )(cb: Either[Throwable, Success] => Unit) = cb(response match {
+    case Success(messageId) =>
+      Right(FcmDeliverySuccess(token, messageId))
+    case Failure(UnwrappingExecutionException(e: FirebaseMessagingException)) if invalidTokenErrorCodes.contains(e.getErrorCode) || isUnregistered(e) =>
+      Left(InvalidToken(notificationId, token, e.getMessage))
+    case Failure(UnwrappingExecutionException(e: FirebaseMessagingException)) =>
+      Left(FailedRequest(notificationId, token, e, Option(e.getErrorCode.toString)))
+    case Failure(NonFatal(t)) =>
+      Left(FailedRequest(notificationId, token, t))
+    case Failure(_) =>
+      Left(UnknownReasonFailedRequest(notificationId, token))
+  })
 
 }
 
@@ -95,11 +98,15 @@ object FcmClient {
 
 object FirebaseHelpers {
 
-  implicit class RichApiFuture[T](val f: ApiFuture[T]) extends AnyVal {
-    def asScala(implicit e: ExecutionContext): Future[T] =
-      Future {
-        f.get()
-      }
-  }
+  implicit class RichApiFuture[T](val af: ApiFuture[T]) extends AnyVal {
+    def asScala(implicit ec: ExecutionContext): Future[T] = {
+      val p = Promise[T]()
+      ApiFutures.addCallback(af, new ApiFutureCallback[T] {
+        def onFailure(t: Throwable): Unit = p failure t
 
+        def onSuccess(result: T): Unit = p success result
+      }, (command: Runnable) => ec.execute(command))
+      p.future
+    }
+  }
 }


### PR DESCRIPTION
## What does this change?

In #729 we increased the thread pool size as a way of increasing performance in the notification system. This probably wouldn't have been necessary if we did not have blocking code.

As discussed [here](https://github.com/guardian/mobile-n10n/pull/729#issuecomment-1284068735) the blocking code has been identified and a solution discussed.

In this PR we've refactored sendNotification() and extracted parseSendResponse() so that we can test the response parsing more easily (without having to mock all the Future-related interactions).


## How to test

We have validated that the unit tests still correctly parse the response from firebase.

We ran the lambda locally and could see the future completing.

## How can we measure success?

We should monitor the n10n [dashboard](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#dashboards:name=n10n-profiling) which shows lambda duration. After the change is released we should not expect to see a degradation in performance.

