### PR TITLE
Create metric for worker lambda processing rate

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
@@ -11,7 +11,7 @@ import play.api.libs.json.Json
 
 import java.util.UUID
 import scala.jdk.CollectionConverters._
-
+import java.time.Instant
 object NotificationWorkerLocalRun extends App {
   val notification = BreakingNewsNotification(
     id = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
@@ -41,7 +41,7 @@ object NotificationWorkerLocalRun extends App {
     val event = new SQSEvent()
     val sqsMessage = new SQSMessage()
     sqsMessage.setBody(Json.stringify(Json.toJson(tokens)))
-    sqsMessage.setAttributes((Map("SentTimestamp" -> "10").asJava))
+    sqsMessage.setAttributes((Map("SentTimestamp" -> s"${Instant.now.toEpochMilli}").asJava))
     event.setRecords(List(sqsMessage).asJava)
     event
   }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
@@ -1,10 +1,13 @@
 package com.gu.notifications.worker.utils
 
 import cats.effect.IO
+import com.gu.notifications.worker.Env
+import models.{Notification, NotificationType, Platform}
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers.appendEntries
 import org.slf4j.Logger
 
+import java.time.{Duration, Instant}
 import scala.jdk.CollectionConverters.MapHasAsJava
 
 trait Logging {
@@ -13,10 +16,56 @@ trait Logging {
   implicit def mapToContext(c: Map[String, _]): LogstashMarker = appendEntries(c.asJava)
 
   private def log[A](prefix: String, logging: String => Unit): A => IO[Unit] = a => IO.delay(logging(s"$prefix: ${a.toString}"))
-  private def logWithFields[A](fields: Map[String, _], prefix: String, logging: (LogstashMarker, String) => Unit): A => IO[Unit] = a =>
-    IO.delay(logging(fields, s"$prefix: ${a.toString}"))
+  private def logWithFields[A](fields: Instant => Map[String, _], prefix: String, logging: (LogstashMarker, String) => Unit): A => IO[Unit] = a => {
+    val end = Instant.now
+    IO.delay(logging(fields(end), s"$prefix: ${a.toString}"))
+  }
+
   def logInfo[A](prefix: String = ""): A => IO[Unit] = log(prefix, logger.info)
-  def logInfoWithFields[A](fields: Map[String, _], prefix: String = ""): A => IO[Unit] = logWithFields(fields, prefix, logger.info)
+  def logInfoWithFields[A](fields: Instant => Map[String, _], prefix: String = ""): A => IO[Unit] = logWithFields(fields, prefix, logger.info)
   def logWarn[A](prefix: String = ""): A => IO[Unit] = log(prefix, logger.warn)
   def logError[A](prefix: String = ""): A => IO[Unit] = log(prefix, logger.error)
+
+  def logFields(
+     env: Env,
+     notification: Notification,
+     numberOfTokens: Int,
+     sentTime: Long,
+     functionStartTime: Instant,
+     maybePlatform: Option[Platform]
+   )(end: Instant): Map[String, Any] = {
+    val processingRate = numberOfTokens.toDouble / Duration.between(functionStartTime, end).toMillis * 1000
+    val start = Instant.ofEpochMilli(sentTime)
+    Map(
+      "_aws" -> Map(
+        "Timestamp" -> end.toEpochMilli,
+        "CloudWatchMetrics" -> List(Map(
+          "Namespace" -> s"Notifications/${env.stage}/workers",
+          "Dimensions" -> List(List("platform", "type")),
+          "Metrics" -> List(
+            Map(
+              "Name" -> "worker.notificationProcessingTime",
+              "Unit" -> "Milliseconds"
+            ),
+            Map(
+              "Name" -> "worker.functionProcessingRate",
+              "Unit" -> "Count/Second"
+            )
+          )
+        ))
+      ),
+      "notificationId" -> notification.id,
+      "platform" -> maybePlatform.map(_.toString).getOrElse("unknown"),
+      "type" -> {
+        notification.`type` match {
+          case NotificationType.BreakingNews => "breakingNews"
+          case _                             => "other"
+        }
+      },
+      "worker.functionProcessingRate" -> f"$processingRate%1.4f",
+      "worker.notificationProcessingTime" -> Duration.between(start, end).toMillis,
+      "worker.notificationProcessingStartTime.millis" -> sentTime,
+      "worker.notificationProcessingEndTime.millis" -> end.toEpochMilli,
+    )
+  }
 }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
@@ -35,7 +35,7 @@ trait Logging {
      maybePlatform: Option[Platform]
    )(end: Instant): Map[String, Any] = {
     val processingTime = Duration.between(functionStartTime, end).toMillis
-    val processingRate = numberOfTokens.toDouble / processingTime
+    val processingRate = numberOfTokens.toDouble / processingTime * 1000
     val start = Instant.ofEpochMilli(sentTime)
     Map(
       "_aws" -> Map(
@@ -62,7 +62,7 @@ trait Logging {
           case _                             => "other"
         }
       },
-      "worker.functionProcessingRate" -> f"$processingRate%1.4f",
+      "worker.functionProcessingRate" -> processingRate,
       "worker.functionProcessingTime" -> processingTime,
       "worker.notificationProcessingTime" -> Duration.between(start, end).toMillis,
       "worker.notificationProcessingStartTime.millis" -> sentTime,

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
@@ -34,7 +34,8 @@ trait Logging {
      functionStartTime: Instant,
      maybePlatform: Option[Platform]
    )(end: Instant): Map[String, Any] = {
-    val processingRate = numberOfTokens.toDouble / Duration.between(functionStartTime, end).toMillis * 1000
+    val processingTime = Duration.between(functionStartTime, end).toMillis
+    val processingRate = numberOfTokens.toDouble / processingTime * 1000
     val start = Instant.ofEpochMilli(sentTime)
     Map(
       "_aws" -> Map(
@@ -63,6 +64,7 @@ trait Logging {
         }
       },
       "worker.functionProcessingRate" -> f"$processingRate%1.4f",
+      "worker.functionProcessingTime" -> processingTime,
       "worker.notificationProcessingTime" -> Duration.between(start, end).toMillis,
       "worker.notificationProcessingStartTime.millis" -> sentTime,
       "worker.notificationProcessingEndTime.millis" -> end.toEpochMilli,

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
@@ -35,7 +35,7 @@ trait Logging {
      maybePlatform: Option[Platform]
    )(end: Instant): Map[String, Any] = {
     val processingTime = Duration.between(functionStartTime, end).toMillis
-    val processingRate = numberOfTokens.toDouble / processingTime * 1000
+    val processingRate = numberOfTokens.toDouble / processingTime
     val start = Instant.ofEpochMilli(sentTime)
     Map(
       "_aws" -> Map(

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
@@ -49,8 +49,7 @@ trait Logging {
               "Unit" -> "Milliseconds"
             ),
             Map(
-              "Name" -> "worker.functionProcessingRate",
-              "Unit" -> "Count/Second"
+              "Name" -> "worker.functionProcessingRate"
             )
           )
         ))


### PR DESCRIPTION
## What does this change?

We currently use metrics to see the performance of the whole system. For worker lambdas we have a metric for the processing time, which includes the length of time a message sits on a queue. This is great for determining the impact of changes to the overall performance.

In future PRs we are going to test using batch api calls. This PR adds a new metric to enable us to evaluate improvements to the lambda function.

The `functionProcessingRate` is a metric for how quickly we process tokens. The rate is calculated by:

`number of tokens processed by a particular function invocation / function processing time in seconds`

The result is that we get a metric representing the number of tokens being processed per second.

To capture this metric there were a number of changes required:
- Refactor the sender request handler to abstract logging code into Logger class
- Capture the start time of the function (we actively didn't want to use the `sentTime`, i.e. when the message landed on the queue, instead capturing when the function starts)
- Refactor when we determine the function has completed. Through local testing we could see we create ("compile") our stream before executing it. We changed where we capture the end time to ensure this happened when a chunk of tokens had actually completed sending.
- Calculate the function processing rate using the function start time, end time and number of tokens
- Extend cloudwatch embedded metrics to include new metric for function processing rate
- Update local run to facilitate testing of embedded metrics

## How to test

Locally we can test to ensure the lambda compiles and runs successfully. We can see in the log messages that the relevant data was being created.

To test the new embedded metric the lambda logs needed to be parsed by AWS. I deployed to CODE and checked that we could see the lambda metric being recorded via the AWS console.

