### PR TITLE
LIVE-4705 set up deployment for EC2-based sender

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -441,7 +441,7 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
     riffRaffArtifactResources += (file("cdk/cdk.out/RegistrationsDbProxy-PROD.template.json"), s"registrations-db-proxy-cfn/RegistrationsDbProxy-PROD.template.json")
 )
 
-lazy val ec2SenderWorker = Project("senderworker", file("senderworker"))
+lazy val ec2SenderWorker = Project("sender-worker", file("senderworker"))
   .dependsOn(common, notificationworkerlambda, commontest % "test->test")
   .enablePlugins(SystemdPlugin, RiffRaffArtifact, JavaServerAppPackaging)
   .settings(standardSettings: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -441,6 +441,23 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
     riffRaffArtifactResources += (file("cdk/cdk.out/RegistrationsDbProxy-PROD.template.json"), s"registrations-db-proxy-cfn/RegistrationsDbProxy-PROD.template.json")
 )
 
+lazy val ec2SenderWorker = Project("senderworker", file("senderworker"))
+  .dependsOn(common, notificationworkerlambda, commontest % "test->test")
+  .enablePlugins(SystemdPlugin, RiffRaffArtifact, JavaServerAppPackaging)
+  .settings(standardSettings: _*)
+  .settings(
+    fork := true,
+    libraryDependencies ++= Seq(
+      logback
+    ),
+    riffRaffPackageType := (Debian / packageBin).value,
+    riffRaffArtifactResources += (file(s"cdk/cdk.out/SenderWorker-CODE.template.json"), s"senderworker-cfn/SenderWorker-CODE.template.json"),
+    riffRaffArtifactResources += (file(s"cdk/cdk.out/SenderWorker-PROD.template.json"), s"senderworker-cfn/SenderWorker-PROD.template.json"),
+    Debian / packageName := name.value,
+    mainClass := Some("SenderWorker"),
+    version := projectVersion
+  )
+
 
 lazy val fakebreakingnewslambda = lambda("fakebreakingnewslambda", "fakebreakingnewslambda", Some("fakebreakingnews.LocalRun"))
   .dependsOn(common)

--- a/cdk/lib/__snapshots__/sender-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/sender-stack.test.ts.snap
@@ -200,14 +200,17 @@ Object {
               "",
               Array [
                 "#!/bin/bash -ev
-	  echo ",
+aws --region ",
                 Object {
                   "Ref": "AWS::Region",
                 },
-                "
-	  echo mobile-notifications-workers
-	  echo CODE
-	  echo sender-worker",
+                " s3 cp s3://mobile-dist/mobile-notifications-workers/CODE/sender-worker/sender-worker_1.0-latest_all.deb /tmp
+dpkg -i /tmp/sender-worker_1.0-latest_all.deb
+/opt/aws-kinesis-agent/configure-aws-kinesis-agent ",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                " mobile-log-aggregation-CODE /var/log/sender-worker/sender-worker.log",
               ],
             ],
           },
@@ -1280,14 +1283,17 @@ Object {
               "",
               Array [
                 "#!/bin/bash -ev
-	  echo ",
+aws --region ",
                 Object {
                   "Ref": "AWS::Region",
                 },
-                "
-	  echo mobile-notifications-workers
-	  echo PROD
-	  echo sender-worker",
+                " s3 cp s3://mobile-dist/mobile-notifications-workers/PROD/sender-worker/sender-worker_1.0-latest_all.deb /tmp
+dpkg -i /tmp/sender-worker_1.0-latest_all.deb
+/opt/aws-kinesis-agent/configure-aws-kinesis-agent ",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                " mobile-log-aggregation-PROD /var/log/sender-worker/sender-worker.log",
               ],
             ],
           },

--- a/cdk/lib/__snapshots__/sender-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/sender-stack.test.ts.snap
@@ -193,6 +193,7 @@ Object {
               "GroupId",
             ],
           },
+          "sg-85829de7",
         ],
         "UserData": Object {
           "Fn::Base64": Object {
@@ -1276,6 +1277,7 @@ Object {
               "GroupId",
             ],
           },
+          "sg-85829de7",
         ],
         "UserData": Object {
           "Fn::Base64": Object {

--- a/cdk/lib/sender-stack.ts
+++ b/cdk/lib/sender-stack.ts
@@ -40,7 +40,7 @@ export class SenderWorkerStack extends GuStack {
 		const sqsMessageVisibilityTimeout = Duration.seconds(100);
 		const sqsMessageRetentionPeriod = Duration.hours(1);
 		const sqsMessageRetryCount = 5;
-		const vpcSecurityGroupId = 'sg-85829de7';
+		const defaultVpcSecurityGroup = 'sg-85829de7';
 
 		const vpc = GuVpc.fromIdParameter(
 			this,
@@ -93,11 +93,10 @@ dpkg -i /tmp/${props.appName}_1.0-latest_all.deb
 				},
 			],
 			additionalSecurityGroups: [
-				// Need this security group to call CAPI
 				GuSecurityGroup.fromSecurityGroupId(
 					this,
 					'DefaultVpcSecurityGroup',
-					vpcSecurityGroupId,
+					defaultVpcSecurityGroup,
 				),
 			],
 		});

--- a/cdk/lib/sender-stack.ts
+++ b/cdk/lib/sender-stack.ts
@@ -68,10 +68,9 @@ export class SenderWorkerStack extends GuStack {
 			role: distributionRole,
 			healthCheck: HealthCheck.elb({ grace: Duration.minutes(5) }),
 			userData: `#!/bin/bash -ev
-	  echo ${this.region}
-	  echo ${this.stack}
-	  echo ${this.stage}
-	  echo ${props.appName}`,
+aws --region ${this.region} s3 cp s3://mobile-dist/${this.stack}/${props.stage}/${props.appName}/${props.appName}_1.0-latest_all.deb /tmp
+dpkg -i /tmp/${props.appName}_1.0-latest_all.deb
+/opt/aws-kinesis-agent/configure-aws-kinesis-agent ${this.region} mobile-log-aggregation-${this.stage} /var/log/${props.appName}/${props.appName}.log`,
 			vpcSubnets: {
 				subnets: GuVpc.subnetsFromParameter(this, {
 					type: SubnetType.PRIVATE,

--- a/cdk/lib/sender-stack.ts
+++ b/cdk/lib/sender-stack.ts
@@ -1,7 +1,11 @@
 import { GuAutoScalingGroup } from '@guardian/cdk/lib/constructs/autoscaling';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { AppIdentity, GuStack } from '@guardian/cdk/lib/constructs/core';
-import { GuVpc, SubnetType } from '@guardian/cdk/lib/constructs/ec2';
+import {
+	GuSecurityGroup,
+	GuVpc,
+	SubnetType,
+} from '@guardian/cdk/lib/constructs/ec2';
 import {
 	GuAllowPolicy,
 	GuInstanceRole,
@@ -36,6 +40,7 @@ export class SenderWorkerStack extends GuStack {
 		const sqsMessageVisibilityTimeout = Duration.seconds(100);
 		const sqsMessageRetentionPeriod = Duration.hours(1);
 		const sqsMessageRetryCount = 5;
+		const vpcSecurityGroupId = 'sg-85829de7';
 
 		const vpc = GuVpc.fromIdParameter(
 			this,
@@ -86,6 +91,14 @@ dpkg -i /tmp/${props.appName}_1.0-latest_all.deb
 					),
 					scalingEvents: ScalingEvents.ERRORS,
 				},
+			],
+			additionalSecurityGroups: [
+				// Need this security group to call CAPI
+				GuSecurityGroup.fromSecurityGroupId(
+					this,
+					'DefaultVpcSecurityGroup',
+					vpcSecurityGroupId,
+				),
 			],
 		});
 		autoScalingGroup.scaleOnCpuUtilization('CpuScalingPolicy', {

--- a/senderworker/riff-raff.yaml
+++ b/senderworker/riff-raff.yaml
@@ -19,6 +19,5 @@ deployments:
     type: autoscaling
     parameters:
       bucketSsmLookup: true
-      bucketSsmKey: /account/services/artifact.bucket
     dependencies: [senderworker-cfn]
 

--- a/senderworker/riff-raff.yaml
+++ b/senderworker/riff-raff.yaml
@@ -15,7 +15,7 @@ deployments:
       templateStagePaths: 
         CODE: SenderWorker-CODE.template.json
         PROD: SenderWorker-PROD.template.json
-  senderworker:
+  sender-worker:
     type: autoscaling
     parameters:
       bucketSsmLookup: true

--- a/senderworker/riff-raff.yaml
+++ b/senderworker/riff-raff.yaml
@@ -1,0 +1,24 @@
+stacks: [mobile-notifications-workers]
+regions: [eu-west-1]
+allowedStages:
+  - CODE
+  - PROD
+deployments:
+  senderworker-cfn:
+    type: cloud-formation
+    app: sender-worker
+    parameters:
+      amiParameter: AMISenderworker
+      amiTags:
+        Recipe: bionic-mobile-ARM
+        AmigoStage: PROD
+      templateStagePaths: 
+        CODE: SenderWorker-CODE.template.json
+        PROD: SenderWorker-PROD.template.json
+  senderworker:
+    type: autoscaling
+    parameters:
+      bucketSsmLookup: true
+      bucketSsmKey: /account/services/artifact.bucket
+    dependencies: [senderworker-cfn]
+

--- a/senderworker/src/main/scala/SenderWorker.scala
+++ b/senderworker/src/main/scala/SenderWorker.scala
@@ -1,3 +1,4 @@
 object SenderWorker extends App {
   println("Hello, World!")
+  Thread.sleep(60*60*1000)
 }

--- a/senderworker/src/main/scala/SenderWorker.scala
+++ b/senderworker/src/main/scala/SenderWorker.scala
@@ -1,0 +1,3 @@
+object SenderWorker extends App {
+  println("Hello, World!")
+}


### PR DESCRIPTION
## What does this change?

We are building a EC2-based sender worker to further improve the performance of the notification delivery pipeline.

The previous PR #793 created a new cloudformation stack for the sender worker we are looking to build.

This PR set up a sub-project in the repo with the corresponding riff-raff configuration for deployment.

Specifically, it contains the following changes:

1. Create a new subproject `senderworker` which is a Scala project
2. It depends on `notificationworkerlambda`.  The JAR is included in the output package of `senderworker`
3. It is packaged as Debian package and deployed as a Systemd service (just like MAPI microservice)
4. At this moment, the Scala program does nothing (except printing some messages to confirm it is executed)
5. `AWS-kinesis-agent` is set up to copy logs from log file to the `mobile-aggregate-log-$(stage)` stream
6. Associate the EC2 instance with the default security group so that we can use ssm-ssh to log in the instance

## How to test

We deployed it to `CODE` and it worked as expected.

The stack is not used by existing programs in the notification delivery pipeline yet. So no impact to production is expected.