### PR TITLE
Update parsing logic for multicast message response

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -70,7 +70,7 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
     val notificationLog = s"(notification: ${chunkedTokens.notification.id} ${chunkedTokens.range})"
     input
       .fold(SendingResults.empty) { case (acc, resp) => SendingResults.aggregateBatch(acc, chunkedTokens.tokens.size, resp) }
-      .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform), prefix = s"Results $notificationLog: "))
+      .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform, isIndividualNotificationSend = false), prefix = s"Results $notificationLog: "))
       .through(cloudwatch.sendMetrics(env.stage, Configuration.platform))
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -1,20 +1,19 @@
 package com.gu.notifications.worker
 
 import cats.effect.{ContextShift, IO, Timer}
-import com.amazonaws.services.lambda.runtime.Context
-import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.gu.notifications.worker.cleaning.CleaningClientImpl
-import com.gu.notifications.worker.delivery.DeliveryException
+import com.gu.notifications.worker.delivery.DeliveryException.InvalidToken
+import com.gu.notifications.worker.delivery.{BatchDeliverySuccess, DeliveryClient, DeliveryException}
 import com.gu.notifications.worker.delivery.fcm.{Fcm, FcmClient}
+import com.gu.notifications.worker.models.SendingResults
 import com.gu.notifications.worker.tokens.{BatchNotification, ChunkedTokens}
-import com.gu.notifications.worker.utils.{Cloudwatch, CloudwatchImpl, NotificationParser, Reporting}
-import fs2.Stream
+import com.gu.notifications.worker.utils.{Cloudwatch, CloudwatchImpl, Reporting}
+import fs2.{Pipe, Stream}
 
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.Executors
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
-import scala.jdk.CollectionConverters._
-
 
 class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Option[String]) extends SenderRequestHandler[FcmClient] {
 
@@ -42,26 +41,59 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
       (chunkedTokens, sentTime, functionStartTime) <- chunkedTokenStream
       isAllowedToSendBatch = chunkedTokens.notification.topic.forall(topic => config.allowedTopicsForBatchSend.contains(topic.toString))
       resp <- {
-        val resultStream = if (isAllowedToSendBatch) {
+        if (isAllowedToSendBatch) {
           logger.info(s"Allowed to send notification ${chunkedTokens.notification.id} to topics ${chunkedTokens.notification.topic} in batches")
           deliverBatchNotificationStream(Stream.emits(chunkedTokens.toBatchNotificationToSends).covary[IO])
+            .broadcastTo(
+              reportBatchSuccesses(chunkedTokens, sentTime, functionStartTime),
+              cleanupBatchFailures(chunkedTokens.notification.id),
+              trackBatchProgress(chunkedTokens.notification.id))
         }
         else
           deliverIndividualNotificationStream(Stream.emits(chunkedTokens.toNotificationToSends).covary[IO])
-
-        resultStream
-          .broadcastTo(
-            reportSuccesses(chunkedTokens, sentTime, functionStartTime),
-            cleanupFailures,
-            trackProgress(chunkedTokens.notification.id))
+            .broadcastTo(
+              reportSuccesses(chunkedTokens, sentTime, functionStartTime),
+              cleanupFailures,
+              trackProgress(chunkedTokens.notification.id))
       }
     } yield resp
   }
 
-  def deliverBatchNotificationStream[C <: FcmClient](batchNotificationStream: Stream[IO, BatchNotification]): Stream[IO, Either[DeliveryException, C#Success]] = for {
+  def deliverBatchNotificationStream[C <: FcmClient](batchNotificationStream: Stream[IO, BatchNotification]): Stream[IO, Either[DeliveryException, C#BatchSuccess]] = for {
     deliveryService <- Stream.eval(deliveryService)
     resp <- batchNotificationStream.map(batchNotification => deliveryService.sendBatch(batchNotification.notification, batchNotification.token))
       .parJoin(maxConcurrency)
-      .evalTap(Reporting.log(s"Sending failure: "))
+      .evalTap(Reporting.logBatch(s"Sending failure: "))
   } yield resp
+
+  def reportBatchSuccesses[C <: DeliveryClient](chunkedTokens: ChunkedTokens, sentTime: Long, functionStartTime: Instant): Pipe[IO, Either[DeliveryException, BatchDeliverySuccess], Unit] = { input =>
+    val notificationLog = s"(notification: ${chunkedTokens.notification.id} ${chunkedTokens.range})"
+    input
+      .fold(SendingResults.empty) { case (acc, resp) => SendingResults.aggregateBatch(acc, chunkedTokens.tokens.size, resp) }
+      .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform), prefix = s"Results $notificationLog: "))
+      .through(cloudwatch.sendMetrics(env.stage, Configuration.platform))
+  }
+
+  def cleanupBatchFailures[C <: DeliveryClient](notificationId: UUID): Pipe[IO, Either[Throwable, BatchDeliverySuccess], Unit] = { input =>
+    input
+      .collect {
+        case Right(batchSuccess) =>
+          batchSuccess.responses.foldLeft(List[String]())((acc, res) => res match {
+            case Left(InvalidToken(_, token, _, _)) =>
+              logger.debug(Map("notificationId" -> notificationId), s"Invalid token $token")
+              token :: acc
+            case Left(_) => acc
+            case Right(_) => acc
+          })
+      }
+      .chunkN(1000)
+      .through(cleaningClient.sendInvalidBatchTokensToCleaning)
+  }
+
+  def trackBatchProgress[C <: DeliveryClient](notificationId: UUID): Pipe[IO, Either[Throwable, BatchDeliverySuccess], Unit] = {
+    input => input.evalMap(chunk => IO.delay(chunk match {
+      case Left(_) => () // we log in other places if there's a catastrophic batch error
+      case Right(batchSuccess) => logger.info(Map("notificationId" -> notificationId), s"Processed ${batchSuccess.responses.size} individual notification(s)")
+    }))
+  }
 }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryClient.scala
@@ -10,13 +10,14 @@ trait DeliveryClient {
 
   type Success <: DeliverySuccess
   type Payload <: DeliveryPayload
+  type BatchSuccess <: BatchDeliverySuccess
 
   def close(): Unit
   def sendNotification(notificationId: UUID, token: String, payload: Payload, dryRun: Boolean)
-    (onComplete: Either[Throwable, Success] => Unit)
+    (onComplete: Either[DeliveryException, Success] => Unit)
     (implicit ece: ExecutionContextExecutor): Unit
   def sendBatchNotification(notificationId: UUID, token: List[String], payload: Payload, dryRun: Boolean)
-    (onComplete: Either[Throwable, Success] => Unit)
+    (onComplete: Either[DeliveryException, BatchSuccess] => Unit)
     (implicit ece: ExecutionContextExecutor): Unit
   def payloadBuilder: Notification => Option[Payload]
   val dryRun: Boolean

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryService.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryService.scala
@@ -22,7 +22,7 @@ trait DeliveryService[F[_], C <: DeliveryClient] {
   def sendBatch(
     notification: Notification,
     tokens: List[String]
-  ): Stream[F, Either[DeliveryException, C#Success]]
+  ): Stream[F, Either[DeliveryException, C#BatchSuccess]]
 }
 
 class DeliveryServiceImpl[F[_], C <: DeliveryClient] (
@@ -90,11 +90,11 @@ class DeliveryServiceImpl[F[_], C <: DeliveryClient] (
     } yield res
   }
 
-  def sendBatch(notification: Notification, tokens: List[String]): Stream[F, Either[DeliveryException, C#Success]] = {
+  def sendBatch(notification: Notification, tokens: List[String]): Stream[F, Either[DeliveryException, C#BatchSuccess]] = {
 
-    def sendBatchAsync(client: C)(token: List[String], payload: client.Payload): F[C#Success] = {
+    def sendBatchAsync(client: C)(token: List[String], payload: client.Payload): F[C#BatchSuccess] = {
       logger.info("Sending batch notification")
-      Async[F].async { (cb: Either[Throwable, C#Success] => Unit) =>
+      Async[F].async { (cb: Either[Throwable, C#BatchSuccess] => Unit) =>
         client.sendBatchNotification(
           notification.id,
           token,
@@ -104,7 +104,7 @@ class DeliveryServiceImpl[F[_], C <: DeliveryClient] (
       }
     }
 
-    def sending(client: C)(token: List[String], payload: client.Payload): Stream[F, Either[DeliveryException, C#Success]] = {
+    def sending(client: C)(token: List[String], payload: client.Payload): Stream[F, Either[DeliveryException, C#BatchSuccess]] = {
 
       val delayInMs = {
         val rangeInMs = Range(1000, 3000)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliverySuccess.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliverySuccess.scala
@@ -6,9 +6,12 @@ sealed trait DeliverySuccess {
 }
 
 sealed trait BatchDeliverySuccess {
-  def tokens: List[String]
-  def dryRun: Boolean
+  def responses: List[Either[DeliveryException, DeliverySuccess]]
 }
 case class ApnsDeliverySuccess(token: String, dryRun: Boolean = false) extends DeliverySuccess
 case class FcmDeliverySuccess(token: String, messageId: String, dryRun: Boolean = false) extends DeliverySuccess
-case class FcmBatchDeliverySuccess(tokens: List[String], messageId: String, dryRun: Boolean = false) extends BatchDeliverySuccess
+case class FcmBatchDeliverySuccess(responses: List[Either[DeliveryException, FcmDeliverySuccess]], notificationId: String) extends BatchDeliverySuccess
+
+case class ApnsBatchDeliverySuccess(responses: List[Either[DeliveryException, ApnsDeliverySuccess]], notificationId: String) extends BatchDeliverySuccess
+
+

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
@@ -25,6 +25,7 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
 
   type Success = ApnsDeliverySuccess
   type Payload = ApnsPayload
+  type BatchSuccess = ApnsBatchDeliverySuccess
   val dryRun = config.dryRun
   implicit val logger: Logger = LoggerFactory.getLogger(this.getClass)
   private val timer = new Timer("ios-worker-timeout", true)
@@ -42,7 +43,7 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
   def payloadBuilder: Notification => Option[ApnsPayload] = apnsPayloadBuilder.apply _
 
   def sendNotification(notificationId: UUID, token: String, payload: Payload, dryRun: Boolean)
-    (onComplete: Either[Throwable, Success] => Unit)
+    (onComplete: Either[DeliveryException, Success] => Unit)
     (implicit ece: ExecutionContextExecutor): Unit = {
 
     val pushNotification = new SimpleApnsPushNotification(
@@ -103,7 +104,7 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
   }
 
   def sendBatchNotification(notificationId: UUID, token: List[String], payload: Payload, dryRun: Boolean)
-    (onComplete: Either[Throwable, Success] => Unit)
+    (onComplete: Either[DeliveryException, BatchSuccess] => Unit)
     (implicit executionContext: ExecutionContextExecutor): Unit = {
       logger.info("not implemented")
     }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -9,17 +9,14 @@ import com.gu.notifications.worker.delivery.DeliveryException.{BatchCallFailedRe
 import com.gu.notifications.worker.delivery.fcm.models.FcmConfig
 import com.gu.notifications.worker.delivery.fcm.models.payload.FcmPayloadBuilder
 import com.gu.notifications.worker.delivery.fcm.oktransport.OkGoogleHttpTransport
-import com.gu.notifications.worker.delivery.{DeliveryClient, FcmBatchDeliverySuccess, FcmDeliverySuccess, FcmPayload}
+import com.gu.notifications.worker.delivery.{DeliveryClient, DeliveryException, FcmBatchDeliverySuccess, FcmDeliverySuccess, FcmPayload}
 import com.gu.notifications.worker.utils.Logging
 import org.slf4j.LoggerFactory
-import com.gu.notifications.worker.delivery.{DeliveryClient, DeliveryException, FcmBatchDeliverySuccess, FcmDeliverySuccess, FcmPayload}
-import com.gu.notifications.worker.utils.NotificationParser.logger
 import com.gu.notifications.worker.utils.UnwrappingExecutionException
 
 import java.io.ByteArrayInputStream
 import java.time.{Duration, Instant}
 import java.util.UUID
-import java.util.concurrent.Executor
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future, Promise}
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
@@ -24,7 +24,7 @@ object SendingResults {
   def aggregateBatch(previous: SendingResults, batchSize: Int, res: Either[Throwable, BatchDeliverySuccess]): SendingResults = res match {
     case Right(batchSuccess) =>
       batchSuccess.responses.foldLeft(previous)((acc, resp) => SendingResults.aggregate(acc, resp))
-    case Left(_) => SendingResults(0, batchSize, 0)
+    case Left(_) => SendingResults(previous.successCount, previous.failureCount + batchSize, previous.dryRunCount)
   }
 }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
@@ -32,7 +32,8 @@ trait Logging {
     numberOfTokens: Int,
     sentTime: Long,
     functionStartTime: Instant,
-    maybePlatform: Option[Platform]
+    maybePlatform: Option[Platform],
+    isIndividualNotificationSend: Boolean = true
   )(end: Instant): Map[String, Any] = {
     val processingTime = Duration.between(functionStartTime, end).toMillis
     val processingRate = numberOfTokens.toDouble / processingTime * 1000
@@ -73,6 +74,7 @@ trait Logging {
       "worker.notificationProcessingTime" -> Duration.between(start, end).toMillis,
       "worker.notificationProcessingStartTime.millis" -> sentTime,
       "worker.notificationProcessingEndTime.millis" -> end.toEpochMilli,
+      "worker.notificationSendMethod" -> { if (isIndividualNotificationSend) "individual" else "batch" }
     ) ++ maybeAwsMetric
   }
 }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Reporting.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Reporting.scala
@@ -2,18 +2,30 @@ package com.gu.notifications.worker.utils
 
 import cats.effect.IO
 import com.gu.notifications.worker.delivery.DeliveryException.{FailedRequest, InvalidToken}
-import com.gu.notifications.worker.delivery.{DeliveryClient, DeliveryException, DeliverySuccess}
+import com.gu.notifications.worker.delivery.{BatchDeliverySuccess, DeliveryClient, DeliveryException, DeliverySuccess}
 import org.slf4j.Logger
 
 object Reporting {
 
+  private def logMatchCase(response: Either[DeliveryException, DeliverySuccess], prefix: String)(implicit logger: Logger): Unit = response match {
+    case Left(e: InvalidToken) => logger.warn(s"$prefix $e")
+    case Left(e: FailedRequest) => logger.warn(s"$prefix $e", e.cause)
+    case Left(e) => logger.error(prefix, e)
+    case Right(_) => () // doing nothing when success
+  }
+
+
   def log[C <: DeliveryClient](prefix: String)(implicit logger: Logger): Either[DeliveryException, DeliverySuccess] => IO[Unit] = { resp =>
     IO.delay {
+      logMatchCase(resp, prefix)
+    }
+  }
+
+  def logBatch[C <: DeliveryClient](prefix: String)(implicit logger: Logger): Either[DeliveryException, BatchDeliverySuccess] => IO[Unit] = { resp =>
+    IO.delay {
       resp match {
-        case Left(e: InvalidToken) => logger.warn(s"$prefix $e")
-        case Left(e: FailedRequest) => logger.warn(s"$prefix $e", e.cause)
         case Left(e) => logger.error(prefix, e)
-        case Right(_) => () // doing nothing when success
+        case Right(batchSuccess) => batchSuccess.responses.foreach(resp => logMatchCase(resp, prefix))
       }
     }
   }

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -10,7 +10,7 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
 import com.gu.notifications.worker.cleaning.CleaningClient
 import com.gu.notifications.worker.delivery.DeliveryException.InvalidToken
 import com.gu.notifications.worker.delivery.apns.ApnsClient
-import com.gu.notifications.worker.delivery.{ApnsDeliverySuccess, DeliveryException, DeliveryService}
+import com.gu.notifications.worker.delivery.{ApnsBatchDeliverySuccess, ApnsDeliverySuccess, BatchDeliverySuccess, DeliveryException, DeliveryService}
 import com.gu.notifications.worker.models.SendingResults
 import com.gu.notifications.worker.tokens.ChunkedTokens
 import com.gu.notifications.worker.utils.Cloudwatch
@@ -120,9 +120,8 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
           deliveries
         }
 
-        override def sendBatch(notification: Notification, tokens: List[String]): Stream[IO, Either[DeliveryException, ApnsDeliverySuccess]] = {
-          deliveryCallsCount += 1
-          deliveries
+        override def sendBatch(notification: Notification, tokens: List[String]): Stream[IO, Either[DeliveryException, ApnsBatchDeliverySuccess]] = {
+          Stream(Right(ApnsBatchDeliverySuccess(List(), notification.id.toString)))
         }
       })
 


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/mobile-n10n/pull/747 we enabled multicast messaging for specific topics. The multicast message endpoint allows us to send up to 500 tokens in a single http request (as opposed to a single token per http request in our pre-existing implementation). The intention was to test whether batching tokens would increase the rate at which lambdas could process tokens.

Batch sending has been limited to topics `breaking/international` and `breaking/international-sport`. Since deploying the previous change some notifications have been sent using the multicast message endpoint. The general results show:
- the 90in2 metric has not changed (but we don't expect it to because ios is excluded from this test).
- the number of android users receiving notifications for these two topics is as expected (indicating the sending of the notification via multicast messaging is taking place successfully).

However, the logs made validating the flow a little hard to follow, eg:

<img width="1494" alt="Screenshot 2022-11-01 at 14 09 40" src="https://user-images.githubusercontent.com/45561419/199253373-067c1b05-95b6-4f5b-86ac-d75094e9f0b8.png">

We can see the logs report that only 2 notifications were successfully sent by the given lambda invocation. However, for the notification above, id `0e1280bb-62d7-41f6-b131-9d9e3beb0139`, we can see:
- sent to `breaking/international` topic
- there were 392 function invocations
- each function invocation processed an average of 867 tokens

Given we send to the multicast messaging endpoint in groups of 500 tokens, we'd expect most of the lambda invocations to make 2 http requests.

It appeared that the logging events handled only 1 response per batch. This PR addresses the parsing logic to ensure that every response from a multicast message is handled successfully - this is important because it affects not just the logging but also the cleaning of invalid tokens.

### Explanation

Looking at the sending flow, we currently write log events from this block of code:

```scala
        resultStream
          .broadcastTo(
            reportSuccesses(chunkedTokens, sentTime, functionStartTime),
            cleanupFailures,
            trackProgress(chunkedTokens.notification.id))
```

where `resultStream` is the stream of responses resulting from sending the push notification.

The `broadcastTo` function defines a series of pipes which accept the source stream (== `resultStream`). Each of these pipes accept the input type (`Stream[IO, Either[DeliveryException, DeliverySuccess]]`) and just execute side effects (reporting, logging, sending tokens for cleaning). It feels logical that there will only be elements to pull from the results stream when we start to receive http responses. 

We use [DeliveryService](https://github.com/guardian/mobile-n10n/blob/f85f3542112eed085a42315f2e2af98a99b2be71/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryService.scala#L97) as a wrapper for making the http calls to firebase and apns. The [Async](https://typelevel.org/cats-effect/docs/typeclasses/async) wrapper is a cats-effect component and according to the docs it "creates a simple, non-cancelable ... instance that executes an asynchronous process on evaluation. The given function is being injected with a side-effectful callback for signalling the final result of an asynchronous operation".

This is important because cats-effect is providing us with a way of managing callbacks to the asynchronous process, the definition states that the callback signature should be `Either[Throwable, A] => ()`.

We use [FcmClient](https://github.com/guardian/mobile-n10n/blob/main/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala#L71) to send the batch notification to firebase and we can see that we invoke the callback function when the future has completed, e.g:

```scala
  def parseBatchSendResponse(
    notificationId: UUID, tokens: List[String], triedResponse: Try[BatchResponse]
  )(cb: Either[Throwable, Success] => Unit): Unit = triedResponse match {
    case Success(batchResponse) =>
      // From firebase sdk docs: the order of the response list corresponds to the order of the input tokens
      batchResponse.getResponses.asScala.toList.zip(tokens).foreach { el => {
        val (r, token) = el
        if (!r.isSuccessful) {
          parseSendResponse(notificationId, token, Failure(r.getException))(cb)
        } else {
          cb(Right(FcmDeliverySuccess(s"Token in batch response succeeded", token)))
        }
      }
    }
```

The parsed response has type `Either[Throwable, DeliverySuccess]` which matches the expected type for the inputs to our callback functions (the functions defined inside `broadcastTo`).

What I believe happens is:
- we make asynchronous call to firebase
- we define a callback that can be invoked when the response is received
- the responses are streamed onto a response stream
- the callbacks are equivalent to the "pipes" or functions defined inside `broadcastTo`

This is significant when considering the `parseSendResponse` function because we currently invoke the callback function for each response included in the batch:

```scala
  def parseSendResponse(
    notificationId: UUID, token: String, response: Try[String]
  )(cb: Either[Throwable, Success] => Unit): Unit = cb(response match {
    case Success(messageId) =>
      Right(FcmDeliverySuccess(token, messageId))
    ....
```

In the multicast message response our response stream is for a batch of individual responses, not just a single individual response (as it was previously).

What I think has happened is the callback has been invoked only once per batch, when the first token has been parsed.

In order to rectify this we could (as implemented in this PR), for multicast messages:
- invoke the callback after successfully parsing all the responses from the batch response
- update the logic for the callbacks to handle a List of parsed responses, instead of just a single parsed response


## How to test

### Test locally

I did some testing locally:

Single batch
74 tokens included in fake sqs message (expected 1 http request to be made)
Only 2 were valid tokens
I could see expected result log
```
{
    "@timestamp": "2022-11-01T12:34:52.384Z",
    "message": "Processed 74 individual notification(s)",
    "notificationId": "068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"
},
{
    "@timestamp": "2022-11-01T12:34:52.389Z",
    "message": "Results (notification: 068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7 ShardRange(0,1)): : Success: 2, Failure: 72, DryRun: 0 Total: 74",
    "notificationId": "068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7",
}
```

Multiple batches:
74 tokens included in fake sqs message
Changed batch size to be 50 (expected 2 http requests to be made)

```
{
    "@timestamp": "2022-11-01T15:15:52.571Z",
    "message": "Processed 24 individual notification(s)",
    "notificationId": "068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"
}
{
    "@timestamp": "2022-11-01T15:15:52.648Z",
    "message": "Processed 50 individual notification(s)",
    "notificationId": "068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"
}
{
    "@timestamp": "2022-11-01T15:15:52.653Z",
    "message": "Results (notification: 068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7 ShardRange(0,1)): : Success: 2, Failure: 72, DryRun: 0 Total: 74",
    "notificationId": "068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7",
}
```

### Test in CODE 

For a dryRun notification (pointing to `testRig` db) the logs appear as expected:

<img width="1497" alt="Screenshot 2022-11-01 at 15 38 00" src="https://user-images.githubusercontent.com/45561419/199274209-6e32d2ee-26ab-4288-ab62-10b6fef3b629.png">

^ we can see that the tokens have been correctly grouped and the parsing logic for the response has been corrected.

For a real notification send (pointing to `code` db) we expect `breaking/international` topic to send to 8 devices, 6 of which are android.

From the logs we can see that, due to the sharding, we invoke 6 lambda functions, each with their own set of expected results:

<img width="1486" alt="Screenshot 2022-11-01 at 16 01 08" src="https://user-images.githubusercontent.com/45561419/199279592-8f4379b1-86c7-4907-9c20-a4dab03c7ed6.png">


^ although this doesn't help validate successful batch parsing like the prior test, it does confirm that the multicast message still correctly sends the notification.

## How can we measure success?

Given this change is deployed we expect to see:
- log messages revealing the expected number of tokens (not batches) processed by each lambda invocation
- log messages revealing that _some_ tokens were invalid and processed accordingly
