### PR TITLE
LIVE-4704: Add ec2 worker sender queue url parameter

### DIFF
--- a/cdk/lib/__snapshots__/sender-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/sender-stack.test.ts.snap
@@ -807,6 +807,96 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
+    "SenderQueueEc2SSMParameterandroid8AD45FE3": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/ec2workers/android/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroidDCF78A7C",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderQueueEc2SSMParameterandroidbeta256C5776": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/ec2workers/android-beta/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroidbetaD9344C34",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderQueueEc2SSMParameterandroidedition3340B661": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/ec2workers/android-edition/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroideditionE70A53F0",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderQueueEc2SSMParameterios96EF48F2": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/ec2workers/ios/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsios636F1B52",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderQueueEc2SSMParameteriosedition3FC08215": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/ec2workers/ios-edition/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsioseditionF8A67CD0",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "SenderQueueSSMParameterandroidF97720E3": Object {
       "Properties": Object {
         "DataType": "text",
@@ -1930,6 +2020,96 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
+    },
+    "SenderQueueEc2SSMParameterandroid8AD45FE3": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/ec2workers/android/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroidDCF78A7C",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderQueueEc2SSMParameterandroidbeta256C5776": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/ec2workers/android-beta/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroidbetaD9344C34",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderQueueEc2SSMParameterandroidedition3340B661": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/ec2workers/android-edition/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroideditionE70A53F0",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderQueueEc2SSMParameterios96EF48F2": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/ec2workers/ios/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsios636F1B52",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderQueueEc2SSMParameteriosedition3FC08215": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/ec2workers/ios-edition/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsioseditionF8A67CD0",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
     },
     "SenderQueueSSMParameterandroidF97720E3": Object {
       "Properties": Object {

--- a/cdk/lib/sender-stack.ts
+++ b/cdk/lib/sender-stack.ts
@@ -137,6 +137,15 @@ dpkg -i /tmp/${props.appName}_1.0-latest_all.deb
 				dataType: ParameterDataType.TEXT,
 			});
 
+			//this advertises the name of the ec2 worker queue
+			new StringParameter(this, `SenderQueueEc2SSMParameter-${platformName}`, {
+				parameterName: `/notifications/${this.stage}/ec2workers/${platformName}/SqsEc2Url`,
+				simpleName: false,
+				stringValue: senderSqs.queueUrl,
+				tier: ParameterTier.STANDARD,
+				dataType: ParameterDataType.TEXT,
+			});
+
 			return senderSqs;
 		};
 


### PR DESCRIPTION
## What does this change?
Adds a new parameter to store the EC2 Workers SQS Queues URLs. This is so we can use the parameter to retrieve messages from the SQS queues. We know the parameter already exists for the harvester, the neatest way is to duplicate that parameter and modify the name for the ec2 worker namespace.

## How to test
Deploy to CODE and see if the parameter is generated