### PR TITLE
LIVE-4704: Add ec2 url parameter to apns and firebase config

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -25,12 +25,14 @@ sealed trait WorkerConfiguration {
 
 case class ApnsWorkerConfiguration(
   cleaningSqsUrl: String,
+  sqsUrl: String,
   apnsConfig: ApnsConfig,
   threadPoolSize: Int
 ) extends WorkerConfiguration
 
 case class FcmWorkerConfiguration(
   cleaningSqsUrl: String,
+  sqsUrl: String,
   fcmConfig: FcmConfig,
   threadPoolSize: Int,
   allowedTopicsForBatchSend: List[String],
@@ -85,6 +87,7 @@ object Configuration {
     val config = fetchConfiguration(confPrefixFromPlatform)
     ApnsWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
+      config.getString("sqsEc2Url"),
       ApnsConfig(
         teamId = config.getString("apns.teamId"),
         bundleId = config.getString("apns.bundleId"),
@@ -106,6 +109,7 @@ object Configuration {
 
     FcmWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
+      config.getString("sqsEc2Url"),
       FcmConfig(
         serviceAccountKey = config.getString("fcm.serviceAccountKey"),
         debug = config.getBoolean("fcm.debug"),

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -87,7 +87,7 @@ object Configuration {
     val config = fetchConfiguration(confPrefixFromPlatform)
     ApnsWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
-      config.getString("sqsEc2Url"),
+      config.getString("SqsEc2Url"),
       ApnsConfig(
         teamId = config.getString("apns.teamId"),
         bundleId = config.getString("apns.bundleId"),
@@ -109,7 +109,7 @@ object Configuration {
 
     FcmWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
-      config.getString("sqsEc2Url"),
+      config.getString("SqsEc2Url"),
       FcmConfig(
         serviceAccountKey = config.getString("fcm.serviceAccountKey"),
         debug = config.getBoolean("fcm.debug"),

--- a/senderworker/src/main/scala/com/gu/notifications/ec2worker/Configuration.scala
+++ b/senderworker/src/main/scala/com/gu/notifications/ec2worker/Configuration.scala
@@ -54,7 +54,7 @@ object Configuration {
 
     FcmWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
-      config.getString("sqsEc2Url"),
+      config.getString("SqsEc2Url"),
       FcmConfig(
         serviceAccountKey = config.getString("fcm.serviceAccountKey"),
         debug = config.getBoolean("fcm.debug"),

--- a/senderworker/src/main/scala/com/gu/notifications/ec2worker/Configuration.scala
+++ b/senderworker/src/main/scala/com/gu/notifications/ec2worker/Configuration.scala
@@ -32,7 +32,7 @@ object Configuration {
     val config = new ConfigWithPrefix(appConfig, platform.toString())
     ApnsWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
-      config.getString("sqsEc2Url"),
+      config.getString("SqsEc2Url"),
       ApnsConfig(
         teamId = config.getString("apns.teamId"),
         bundleId = config.getString("apns.bundleId"),

--- a/senderworker/src/main/scala/com/gu/notifications/ec2worker/Configuration.scala
+++ b/senderworker/src/main/scala/com/gu/notifications/ec2worker/Configuration.scala
@@ -32,6 +32,7 @@ object Configuration {
     val config = new ConfigWithPrefix(appConfig, platform.toString())
     ApnsWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
+      config.getString("sqsEc2Url"),
       ApnsConfig(
         teamId = config.getString("apns.teamId"),
         bundleId = config.getString("apns.bundleId"),
@@ -53,6 +54,7 @@ object Configuration {
 
     FcmWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
+      config.getString("sqsEc2Url"),
       FcmConfig(
         serviceAccountKey = config.getString("fcm.serviceAccountKey"),
         debug = config.getBoolean("fcm.debug"),


### PR DESCRIPTION
## What does this change?
Adds ec2 url parameter to apns and firebase config, this will be used later for polling a queue to receive messages.

## How to test
Deploy to CODE and check it loads configuration correctly