### PR TITLE
LIVE-4704: Add sqs url parameters to apns and firebase config

### DIFF
--- a/cdk/lib/__snapshots__/sender-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/sender-stack.test.ts.snap
@@ -807,96 +807,6 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "SenderQueueEc2SSMParameterandroid8AD45FE3": Object {
-      "Properties": Object {
-        "DataType": "text",
-        "Name": "/notifications/CODE/ec2workers/android/SqsEc2Url",
-        "Tags": Object {
-          "Stack": "mobile-notifications-workers",
-          "Stage": "CODE",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/mobile-n10n",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": Object {
-          "Ref": "SenderSqsandroidDCF78A7C",
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
-    },
-    "SenderQueueEc2SSMParameterandroidbeta256C5776": Object {
-      "Properties": Object {
-        "DataType": "text",
-        "Name": "/notifications/CODE/ec2workers/android-beta/SqsEc2Url",
-        "Tags": Object {
-          "Stack": "mobile-notifications-workers",
-          "Stage": "CODE",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/mobile-n10n",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": Object {
-          "Ref": "SenderSqsandroidbetaD9344C34",
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
-    },
-    "SenderQueueEc2SSMParameterandroidedition3340B661": Object {
-      "Properties": Object {
-        "DataType": "text",
-        "Name": "/notifications/CODE/ec2workers/android-edition/SqsEc2Url",
-        "Tags": Object {
-          "Stack": "mobile-notifications-workers",
-          "Stage": "CODE",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/mobile-n10n",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": Object {
-          "Ref": "SenderSqsandroideditionE70A53F0",
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
-    },
-    "SenderQueueEc2SSMParameterios96EF48F2": Object {
-      "Properties": Object {
-        "DataType": "text",
-        "Name": "/notifications/CODE/ec2workers/ios/SqsEc2Url",
-        "Tags": Object {
-          "Stack": "mobile-notifications-workers",
-          "Stage": "CODE",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/mobile-n10n",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": Object {
-          "Ref": "SenderSqsios636F1B52",
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
-    },
-    "SenderQueueEc2SSMParameteriosedition3FC08215": Object {
-      "Properties": Object {
-        "DataType": "text",
-        "Name": "/notifications/CODE/ec2workers/ios-edition/SqsEc2Url",
-        "Tags": Object {
-          "Stack": "mobile-notifications-workers",
-          "Stage": "CODE",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/mobile-n10n",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": Object {
-          "Ref": "SenderSqsioseditionF8A67CD0",
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
-    },
     "SenderQueueSSMParameterandroidF97720E3": Object {
       "Properties": Object {
         "DataType": "text",
@@ -1166,6 +1076,186 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
+    },
+    "SenderWorkerQueueEc2SSMParameterandroid8BD1FAA8": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/ec2workers/android/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroidDCF78A7C",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueEc2SSMParameterandroidbeta0AA5F3E8": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/ec2workers/android-beta/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroidbetaD9344C34",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueEc2SSMParameterandroidedition8F4F65D7": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/ec2workers/android-edition/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroideditionE70A53F0",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueEc2SSMParameterios0242CBA8": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/ec2workers/ios/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsios636F1B52",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueEc2SSMParameteriosedition7DE491E2": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/ec2workers/ios-edition/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsioseditionF8A67CD0",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueSSMParameterandroid4CF3EFFE": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/workers/android/SqsUrl",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroidDCF78A7C",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueSSMParameterandroidbetaF0A5DAB4": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/workers/android-beta/SqsUrl",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroidbetaD9344C34",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueSSMParameterandroidedition91708990": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/workers/android-edition/SqsUrl",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroideditionE70A53F0",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueSSMParameterios8C7D81B1": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/workers/ios/SqsUrl",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsios636F1B52",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueSSMParameteriosedition43CCA007": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/CODE/workers/ios-edition/SqsUrl",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "CODE",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsioseditionF8A67CD0",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
     },
     "WazuhSecurityGroup": Object {
       "Properties": Object {
@@ -2021,96 +2111,6 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
-    "SenderQueueEc2SSMParameterandroid8AD45FE3": Object {
-      "Properties": Object {
-        "DataType": "text",
-        "Name": "/notifications/PROD/ec2workers/android/SqsEc2Url",
-        "Tags": Object {
-          "Stack": "mobile-notifications-workers",
-          "Stage": "PROD",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/mobile-n10n",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": Object {
-          "Ref": "SenderSqsandroidDCF78A7C",
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
-    },
-    "SenderQueueEc2SSMParameterandroidbeta256C5776": Object {
-      "Properties": Object {
-        "DataType": "text",
-        "Name": "/notifications/PROD/ec2workers/android-beta/SqsEc2Url",
-        "Tags": Object {
-          "Stack": "mobile-notifications-workers",
-          "Stage": "PROD",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/mobile-n10n",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": Object {
-          "Ref": "SenderSqsandroidbetaD9344C34",
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
-    },
-    "SenderQueueEc2SSMParameterandroidedition3340B661": Object {
-      "Properties": Object {
-        "DataType": "text",
-        "Name": "/notifications/PROD/ec2workers/android-edition/SqsEc2Url",
-        "Tags": Object {
-          "Stack": "mobile-notifications-workers",
-          "Stage": "PROD",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/mobile-n10n",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": Object {
-          "Ref": "SenderSqsandroideditionE70A53F0",
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
-    },
-    "SenderQueueEc2SSMParameterios96EF48F2": Object {
-      "Properties": Object {
-        "DataType": "text",
-        "Name": "/notifications/PROD/ec2workers/ios/SqsEc2Url",
-        "Tags": Object {
-          "Stack": "mobile-notifications-workers",
-          "Stage": "PROD",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/mobile-n10n",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": Object {
-          "Ref": "SenderSqsios636F1B52",
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
-    },
-    "SenderQueueEc2SSMParameteriosedition3FC08215": Object {
-      "Properties": Object {
-        "DataType": "text",
-        "Name": "/notifications/PROD/ec2workers/ios-edition/SqsEc2Url",
-        "Tags": Object {
-          "Stack": "mobile-notifications-workers",
-          "Stage": "PROD",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/mobile-n10n",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": Object {
-          "Ref": "SenderSqsioseditionF8A67CD0",
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
-    },
     "SenderQueueSSMParameterandroidF97720E3": Object {
       "Properties": Object {
         "DataType": "text",
@@ -2380,6 +2380,186 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
+    },
+    "SenderWorkerQueueEc2SSMParameterandroid8BD1FAA8": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/ec2workers/android/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroidDCF78A7C",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueEc2SSMParameterandroidbeta0AA5F3E8": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/ec2workers/android-beta/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroidbetaD9344C34",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueEc2SSMParameterandroidedition8F4F65D7": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/ec2workers/android-edition/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroideditionE70A53F0",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueEc2SSMParameterios0242CBA8": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/ec2workers/ios/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsios636F1B52",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueEc2SSMParameteriosedition7DE491E2": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/ec2workers/ios-edition/SqsEc2Url",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsioseditionF8A67CD0",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueSSMParameterandroid4CF3EFFE": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/workers/android/SqsUrl",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroidDCF78A7C",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueSSMParameterandroidbetaF0A5DAB4": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/workers/android-beta/SqsUrl",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroidbetaD9344C34",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueSSMParameterandroidedition91708990": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/workers/android-edition/SqsUrl",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsandroideditionE70A53F0",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueSSMParameterios8C7D81B1": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/workers/ios/SqsUrl",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsios636F1B52",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "SenderWorkerQueueSSMParameteriosedition43CCA007": Object {
+      "Properties": Object {
+        "DataType": "text",
+        "Name": "/notifications/PROD/workers/ios-edition/SqsUrl",
+        "Tags": Object {
+          "Stack": "mobile-notifications-workers",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/mobile-n10n",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "SenderSqsioseditionF8A67CD0",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
     },
     "WazuhSecurityGroup": Object {
       "Properties": Object {

--- a/cdk/lib/__snapshots__/sender-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/sender-stack.test.ts.snap
@@ -1080,7 +1080,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueEc2SSMParameterandroid8BD1FAA8": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/CODE/ec2workers/android/SqsEc2Url",
+        "Name": "/notifications/CODE/ec2workers/android/sqsEc2Url",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "CODE",
@@ -1098,7 +1098,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueEc2SSMParameterandroidbeta0AA5F3E8": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/CODE/ec2workers/android-beta/SqsEc2Url",
+        "Name": "/notifications/CODE/ec2workers/android-beta/sqsEc2Url",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "CODE",
@@ -1116,7 +1116,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueEc2SSMParameterandroidedition8F4F65D7": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/CODE/ec2workers/android-edition/SqsEc2Url",
+        "Name": "/notifications/CODE/ec2workers/android-edition/sqsEc2Url",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "CODE",
@@ -1134,7 +1134,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueEc2SSMParameterios0242CBA8": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/CODE/ec2workers/ios/SqsEc2Url",
+        "Name": "/notifications/CODE/ec2workers/ios/sqsEc2Url",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "CODE",
@@ -1152,7 +1152,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueEc2SSMParameteriosedition7DE491E2": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/CODE/ec2workers/ios-edition/SqsEc2Url",
+        "Name": "/notifications/CODE/ec2workers/ios-edition/sqsEc2Url",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "CODE",
@@ -1170,7 +1170,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueSSMParameterandroid4CF3EFFE": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/CODE/workers/android/SqsUrl",
+        "Name": "/notifications/CODE/workers/android/sqsUrl",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "CODE",
@@ -1188,7 +1188,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueSSMParameterandroidbetaF0A5DAB4": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/CODE/workers/android-beta/SqsUrl",
+        "Name": "/notifications/CODE/workers/android-beta/sqsUrl",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "CODE",
@@ -1206,7 +1206,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueSSMParameterandroidedition91708990": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/CODE/workers/android-edition/SqsUrl",
+        "Name": "/notifications/CODE/workers/android-edition/sqsUrl",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "CODE",
@@ -1224,7 +1224,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueSSMParameterios8C7D81B1": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/CODE/workers/ios/SqsUrl",
+        "Name": "/notifications/CODE/workers/ios/sqsUrl",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "CODE",
@@ -1242,7 +1242,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueSSMParameteriosedition43CCA007": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/CODE/workers/ios-edition/SqsUrl",
+        "Name": "/notifications/CODE/workers/ios-edition/sqsUrl",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "CODE",
@@ -2384,7 +2384,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueEc2SSMParameterandroid8BD1FAA8": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/PROD/ec2workers/android/SqsEc2Url",
+        "Name": "/notifications/PROD/ec2workers/android/sqsEc2Url",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
@@ -2402,7 +2402,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueEc2SSMParameterandroidbeta0AA5F3E8": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/PROD/ec2workers/android-beta/SqsEc2Url",
+        "Name": "/notifications/PROD/ec2workers/android-beta/sqsEc2Url",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
@@ -2420,7 +2420,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueEc2SSMParameterandroidedition8F4F65D7": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/PROD/ec2workers/android-edition/SqsEc2Url",
+        "Name": "/notifications/PROD/ec2workers/android-edition/sqsEc2Url",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
@@ -2438,7 +2438,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueEc2SSMParameterios0242CBA8": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/PROD/ec2workers/ios/SqsEc2Url",
+        "Name": "/notifications/PROD/ec2workers/ios/sqsEc2Url",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
@@ -2456,7 +2456,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueEc2SSMParameteriosedition7DE491E2": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/PROD/ec2workers/ios-edition/SqsEc2Url",
+        "Name": "/notifications/PROD/ec2workers/ios-edition/sqsEc2Url",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
@@ -2474,7 +2474,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueSSMParameterandroid4CF3EFFE": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/PROD/workers/android/SqsUrl",
+        "Name": "/notifications/PROD/workers/android/sqsUrl",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
@@ -2492,7 +2492,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueSSMParameterandroidbetaF0A5DAB4": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/PROD/workers/android-beta/SqsUrl",
+        "Name": "/notifications/PROD/workers/android-beta/sqsUrl",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
@@ -2510,7 +2510,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueSSMParameterandroidedition91708990": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/PROD/workers/android-edition/SqsUrl",
+        "Name": "/notifications/PROD/workers/android-edition/sqsUrl",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
@@ -2528,7 +2528,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueSSMParameterios8C7D81B1": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/PROD/workers/ios/SqsUrl",
+        "Name": "/notifications/PROD/workers/ios/sqsUrl",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
@@ -2546,7 +2546,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
     "SenderWorkerQueueSSMParameteriosedition43CCA007": Object {
       "Properties": Object {
         "DataType": "text",
-        "Name": "/notifications/PROD/workers/ios-edition/SqsUrl",
+        "Name": "/notifications/PROD/workers/ios-edition/sqsUrl",
         "Tags": Object {
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",

--- a/cdk/lib/sender-stack.ts
+++ b/cdk/lib/sender-stack.ts
@@ -142,7 +142,7 @@ dpkg -i /tmp/${props.appName}_1.0-latest_all.deb
 				this,
 				`SenderWorkerQueueEc2SSMParameter-${platformName}`,
 				{
-					parameterName: `/notifications/${this.stage}/ec2workers/${platformName}/SqsEc2Url`,
+					parameterName: `/notifications/${this.stage}/ec2workers/${platformName}/sqsEc2Url`,
 					simpleName: false,
 					stringValue: senderSqs.queueUrl,
 					tier: ParameterTier.STANDARD,
@@ -155,7 +155,7 @@ dpkg -i /tmp/${props.appName}_1.0-latest_all.deb
 				this,
 				`SenderWorkerQueueSSMParameter-${platformName}`,
 				{
-					parameterName: `/notifications/${this.stage}/workers/${platformName}/SqsUrl`,
+					parameterName: `/notifications/${this.stage}/workers/${platformName}/sqsUrl`,
 					simpleName: false,
 					stringValue: senderSqs.queueUrl,
 					tier: ParameterTier.STANDARD,

--- a/cdk/lib/sender-stack.ts
+++ b/cdk/lib/sender-stack.ts
@@ -138,22 +138,30 @@ dpkg -i /tmp/${props.appName}_1.0-latest_all.deb
 			});
 
 			//this advertises the name of the ec2 worker queue
-			new StringParameter(this, `SenderWorkerQueueEc2SSMParameter-${platformName}`, {
-				parameterName: `/notifications/${this.stage}/ec2workers/${platformName}/SqsEc2Url`,
-				simpleName: false,
-				stringValue: senderSqs.queueUrl,
-				tier: ParameterTier.STANDARD,
-				dataType: ParameterDataType.TEXT,
-			});
+			new StringParameter(
+				this,
+				`SenderWorkerQueueEc2SSMParameter-${platformName}`,
+				{
+					parameterName: `/notifications/${this.stage}/ec2workers/${platformName}/SqsEc2Url`,
+					simpleName: false,
+					stringValue: senderSqs.queueUrl,
+					tier: ParameterTier.STANDARD,
+					dataType: ParameterDataType.TEXT,
+				},
+			);
 
 			//this advertises the name of the worker queue
-			new StringParameter(this, `SenderWorkerQueueSSMParameter-${platformName}`, {
-				parameterName: `/notifications/${this.stage}/workers/${platformName}/SqsUrl`,
-				simpleName: false,
-				stringValue: senderSqs.queueUrl,
-				tier: ParameterTier.STANDARD,
-				dataType: ParameterDataType.TEXT,
-			});
+			new StringParameter(
+				this,
+				`SenderWorkerQueueSSMParameter-${platformName}`,
+				{
+					parameterName: `/notifications/${this.stage}/workers/${platformName}/SqsUrl`,
+					simpleName: false,
+					stringValue: senderSqs.queueUrl,
+					tier: ParameterTier.STANDARD,
+					dataType: ParameterDataType.TEXT,
+				},
+			);
 
 			return senderSqs;
 		};

--- a/cdk/lib/sender-stack.ts
+++ b/cdk/lib/sender-stack.ts
@@ -138,8 +138,17 @@ dpkg -i /tmp/${props.appName}_1.0-latest_all.deb
 			});
 
 			//this advertises the name of the ec2 worker queue
-			new StringParameter(this, `SenderQueueEc2SSMParameter-${platformName}`, {
+			new StringParameter(this, `SenderWorkerQueueEc2SSMParameter-${platformName}`, {
 				parameterName: `/notifications/${this.stage}/ec2workers/${platformName}/SqsEc2Url`,
+				simpleName: false,
+				stringValue: senderSqs.queueUrl,
+				tier: ParameterTier.STANDARD,
+				dataType: ParameterDataType.TEXT,
+			});
+
+			//this advertises the name of the worker queue
+			new StringParameter(this, `SenderWorkerQueueSSMParameter-${platformName}`, {
+				parameterName: `/notifications/${this.stage}/workers/${platformName}/SqsUrl`,
 				simpleName: false,
 				stringValue: senderSqs.queueUrl,
 				tier: ParameterTier.STANDARD,

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -87,7 +87,7 @@ object Configuration {
     val config = fetchConfiguration(confPrefixFromPlatform)
     ApnsWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
-      config.getString("SqsUrl"),
+      config.getString("sqsUrl"),
       ApnsConfig(
         teamId = config.getString("apns.teamId"),
         bundleId = config.getString("apns.bundleId"),
@@ -109,7 +109,7 @@ object Configuration {
 
     FcmWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
-      config.getString("SqsUrl"),
+      config.getString("sqsUrl"),
       FcmConfig(
         serviceAccountKey = config.getString("fcm.serviceAccountKey"),
         debug = config.getBoolean("fcm.debug"),

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -87,7 +87,7 @@ object Configuration {
     val config = fetchConfiguration(confPrefixFromPlatform)
     ApnsWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
-      config.getString("SqsEc2Url"),
+      config.getString("SqsUrl"),
       ApnsConfig(
         teamId = config.getString("apns.teamId"),
         bundleId = config.getString("apns.bundleId"),
@@ -109,7 +109,7 @@ object Configuration {
 
     FcmWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
-      config.getString("SqsEc2Url"),
+      config.getString("SqsUrl"),
       FcmConfig(
         serviceAccountKey = config.getString("fcm.serviceAccountKey"),
         debug = config.getBoolean("fcm.debug"),

--- a/senderworker/src/main/scala/com/gu/notifications/ec2worker/Configuration.scala
+++ b/senderworker/src/main/scala/com/gu/notifications/ec2worker/Configuration.scala
@@ -32,7 +32,7 @@ object Configuration {
     val config = new ConfigWithPrefix(appConfig, platform.toString())
     ApnsWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
-      config.getString("SqsEc2Url"),
+      config.getString("sqsEc2Url"),
       ApnsConfig(
         teamId = config.getString("apns.teamId"),
         bundleId = config.getString("apns.bundleId"),
@@ -54,7 +54,7 @@ object Configuration {
 
     FcmWorkerConfiguration(
       config.getString("cleaningSqsUrl"),
-      config.getString("SqsEc2Url"),
+      config.getString("sqsEc2Url"),
       FcmConfig(
         serviceAccountKey = config.getString("fcm.serviceAccountKey"),
         debug = config.getBoolean("fcm.debug"),


### PR DESCRIPTION
## What does this change?
Adds ec2 url parameter to apns and firebase config, this will be used later for polling a queue to receive messages. Also adds an sqs url parameter to the old worker config.

## How to test
Deploy to CODE and check it loads configuration correctly, check the lambda still works as expected.