### PR TITLE
LIVE-4701 create stack switch in harvester

### DIFF
--- a/notificationworkerlambda/harvester-cfn.yaml
+++ b/notificationworkerlambda/harvester-cfn.yaml
@@ -115,6 +115,16 @@ Resources:
                 - ","
                 - "Fn::ImportValue":
                     "Fn::Sub": 'NotificationSenderWorkerQueueArns-${Stage}'
+      - PolicyName: SQSOutputForEc2
+        PolicyDocument:
+          Statement:
+            Effect: Allow
+            Action: sqs:*
+            Resource:
+              "Fn::Split":
+                - ","
+                - "Fn::ImportValue":
+                    "Fn::Sub": 'NotificationEc2SenderWorkerQueueArns-${Stage}'
       - PolicyName: VPC
         PolicyDocument:
           Statement:

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -21,7 +21,8 @@ case class HarvesterConfiguration(
   iosEditionSqsEc2Url: String,
   androidLiveSqsEc2Url: String,
   androidEditionSqsEc2Url: String,
-  androidBetaSqsEc2Url: String
+  androidBetaSqsEc2Url: String,
+  allowedTopicsForEc2Sender: List[String]
 )
 
 sealed trait WorkerConfiguration {
@@ -87,7 +88,8 @@ object Configuration {
       iosEditionSqsEc2Url = config.getString("iosEditionSqsEc2Url"),
       androidLiveSqsEc2Url = config.getString("androidLiveSqsEc2Url"),
       androidEditionSqsEc2Url = config.getString("androidEditionSqsEc2Url"),
-      androidBetaSqsEc2Url = config.getString("androidBetaSqsEc2Url")      
+      androidBetaSqsEc2Url = config.getString("androidBetaSqsEc2Url"),
+      allowedTopicsForEc2Sender = if (config.hasPath("allowedTopicsForEc2Sender")) config.getString("allowedTopicsForEc2Sender").split(",").toList else List()
     )
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -16,7 +16,12 @@ case class HarvesterConfiguration(
   iosEditionSqsUrl: String,
   androidLiveSqsUrl: String,
   androidEditionSqsUrl: String,
-  androidBetaSqsUrl: String
+  androidBetaSqsUrl: String,
+  iosLiveSqsEc2Url: String,
+  iosEditionSqsEc2Url: String,
+  androidLiveSqsEc2Url: String,
+  androidEditionSqsEc2Url: String,
+  androidBetaSqsEc2Url: String
 )
 
 sealed trait WorkerConfiguration {
@@ -77,7 +82,12 @@ object Configuration {
       iosEditionSqsUrl = config.getString("iosEditionSqsCdkUrl"),
       androidLiveSqsUrl = config.getString("androidLiveSqsCdkUrl"),
       androidEditionSqsUrl = config.getString("androidEditionSqsCdkUrl"),
-      androidBetaSqsUrl = config.getString("androidBetaSqsCdkUrl")
+      androidBetaSqsUrl = config.getString("androidBetaSqsCdkUrl"),
+      iosLiveSqsEc2Url = config.getString("iosLiveSqsEc2Url"),
+      iosEditionSqsEc2Url = config.getString("iosEditionSqsEc2Url"),
+      androidLiveSqsEc2Url = config.getString("androidLiveSqsEc2Url"),
+      androidEditionSqsEc2Url = config.getString("androidEditionSqsEc2Url"),
+      androidBetaSqsEc2Url = config.getString("androidBetaSqsEc2Url")      
     )
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -76,10 +76,13 @@ trait HarvesterRequestHandler extends Logging {
   }
 
   def switchStack(topics: List[_root_.models.Topic]): SqsDeliveryStack = {
-    if (topics.forall(topic => allowedTopicsForEc2Sender.contains(topic.toString)))
+    if (topics.forall(topic => allowedTopicsForEc2Sender.contains(topic.toString))) {
+      logger.info("Switch to EC2-based sender"); 
       ec2ServiceSet
-    else
+    } else {
+      logger.info("Switch to lambda-based sender"); 
       lambdaServiceSet
+    }
   }
 
 
@@ -213,4 +216,6 @@ class Harvester extends HarvesterRequestHandler {
   )
 
   override val allowedTopicsForEc2Sender = config.allowedTopicsForEc2Sender
+
+  logger.info(s"Allowed topics for EC2 sender: ${config.allowedTopicsForEc2Sender}")
 }

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -105,27 +105,33 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
 
       override val jdbcConfig: JdbcConfig = null
 
-      override val iosLiveDeliveryService: SqsDeliveryService[IO] = (chunkedTokens: ChunkedTokens) => {
-        apnsSqsDeliveriesCount.incrementAndGet()
-        apnsSqsDeliveriesTotal.addAndGet(chunkedTokens.tokens.size)
-        sqsDeliveries
-      }
+      override val lambdaServiceSet: SqsDeliveryServiceSet = SqsDeliveryServiceSet(
+        iosLiveDeliveryService = (chunkedTokens: ChunkedTokens) => {
+          apnsSqsDeliveriesCount.incrementAndGet()
+          apnsSqsDeliveriesTotal.addAndGet(chunkedTokens.tokens.size)
+          sqsDeliveries
+        },
+        androidLiveDeliveryService = (chunkedTokens: ChunkedTokens) => {
+          firebaseSqsDeliveriesCount.incrementAndGet()
+          firebaseSqsDeliveriesTotal.addAndGet(chunkedTokens.tokens.size)
+          sqsDeliveries
+        },
+        androidBetaDeliveryService = (chunkedTokens: ChunkedTokens) => {
+          firebaseSqsDeliveriesCount.incrementAndGet()
+          firebaseSqsDeliveriesTotal.addAndGet(chunkedTokens.tokens.size)
+          sqsDeliveries
+        },
+        iosEditionDeliveryService = (chunkedTokens: ChunkedTokens) => sqsDeliveries,
+        androidEditionDeliveryService = (chunkedTokens: ChunkedTokens) => sqsDeliveries
+      )
 
-      override val androidLiveDeliveryService: SqsDeliveryService[IO] = (chunkedTokens: ChunkedTokens) => {
-        firebaseSqsDeliveriesCount.incrementAndGet()
-        firebaseSqsDeliveriesTotal.addAndGet(chunkedTokens.tokens.size)
-        sqsDeliveries
-      }
-
-      override val androidBetaDeliveryService: SqsDeliveryService[IO] = (chunkedTokens: ChunkedTokens) => {
-       firebaseSqsDeliveriesCount.incrementAndGet()
-       firebaseSqsDeliveriesTotal.addAndGet(chunkedTokens.tokens.size)
-       sqsDeliveries
-      }
-
-      override val iosEditionDeliveryService: SqsDeliveryService[IO] = (chunkedTokens: ChunkedTokens) => sqsDeliveries
-
-      override val androidEditionDeliveryService: SqsDeliveryService[IO] = (chunkedTokens: ChunkedTokens) => sqsDeliveries
+      override val ec2ServiceSet: SqsDeliveryServiceSet = SqsDeliveryServiceSet(
+        iosLiveDeliveryService = (chunkedTokens: ChunkedTokens) => sqsDeliveries,
+        androidLiveDeliveryService = (chunkedTokens: ChunkedTokens) => sqsDeliveries,
+        androidBetaDeliveryService = (chunkedTokens: ChunkedTokens) => sqsDeliveries,
+        iosEditionDeliveryService = (chunkedTokens: ChunkedTokens) => sqsDeliveries,
+        androidEditionDeliveryService = (chunkedTokens: ChunkedTokens) => sqsDeliveries
+      )
 
       override val cloudwatch: Cloudwatch = new Cloudwatch {
         override def sendMetrics(stage: String, platform: Option[Platform]): Pipe[IO, SendingResults, Unit] = ???

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -105,7 +105,9 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
 
       override val jdbcConfig: JdbcConfig = null
 
-      override val lambdaServiceSet: SqsDeliveryServiceSet = SqsDeliveryServiceSet(
+      override val allowedTopicsForEc2Sender: List[String] = List()
+
+      override val lambdaServiceSet: SqsDeliveryStack = SqsDeliveryStack(
         iosLiveDeliveryService = (chunkedTokens: ChunkedTokens) => {
           apnsSqsDeliveriesCount.incrementAndGet()
           apnsSqsDeliveriesTotal.addAndGet(chunkedTokens.tokens.size)
@@ -125,7 +127,7 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
         androidEditionDeliveryService = (chunkedTokens: ChunkedTokens) => sqsDeliveries
       )
 
-      override val ec2ServiceSet: SqsDeliveryServiceSet = SqsDeliveryServiceSet(
+      override val ec2ServiceSet: SqsDeliveryStack = SqsDeliveryStack(
         iosLiveDeliveryService = (chunkedTokens: ChunkedTokens) => sqsDeliveries,
         androidLiveDeliveryService = (chunkedTokens: ChunkedTokens) => sqsDeliveries,
         androidBetaDeliveryService = (chunkedTokens: ChunkedTokens) => sqsDeliveries,


### PR DESCRIPTION
## What does this change?

We are building a EC2-based sender worker to further improve the performance of the notification delivery pipeline.

In option 1, we plan to have both the lambda sender worker and EC2-based sender worker running in parallel during the migration and testing phase, and we route the notification tokens based on the topics of the notification.

This PR implements this stack switching feature in the harvester worker.

It makes the following changes
1. Read the new parameters about the URLs of the new SQSs from SSM
2. Read the new parameter `allowedTopicsForEc2Sender`
3. Instantiate two sets of `SqsDeliveryService`, for the old SQSs and for the new ones.
4. Dispatch the tokens to the set of `SqsDeliveryService` based on the topic.  If all topics of the notification are on the list, it goes to the new stack.
5. Update test cases

### Configuration

The parameters for the URLs of the new SQS were created in this PR #793 

The parameter path for allowed topics is
`/notifications/CODE/workers/harvester/allowedTopicsForEc2Sender` for `CODE` and
`/notifications/PROD/workers/harvester/allowedTopicsForEc2Sender` for `PROD`.

This parameter is optional.  If this parameter does not exist, it means no topics are allowed to use the EC2 stack.

Its type is string.  For multiple topics, it should be a comma-separated list.

## How to test

Test cases have been added to test the stack switching logics.  It has also been tested on CODE.

