### PR TITLE
Process multiple sqs event records concurrently

### DIFF
--- a/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
+++ b/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
@@ -474,6 +474,7 @@ Object {
         "FunctionName": Object {
           "Ref": "androidSenderLambdaCtr85CB623B",
         },
+        "MaximumBatchingWindowInSeconds": 1,
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
@@ -943,6 +944,7 @@ Object {
         "FunctionName": Object {
           "Ref": "androidbetaSenderLambdaCtrB3CF7FC4",
         },
+        "MaximumBatchingWindowInSeconds": 1,
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
@@ -1412,6 +1414,7 @@ Object {
         "FunctionName": Object {
           "Ref": "androideditionSenderLambdaCtrF0169D16",
         },
+        "MaximumBatchingWindowInSeconds": 1,
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
@@ -1881,6 +1884,7 @@ Object {
         "FunctionName": Object {
           "Ref": "iosSenderLambdaCtr6053C1F8",
         },
+        "MaximumBatchingWindowInSeconds": 1,
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
@@ -2310,6 +2314,7 @@ Object {
         "FunctionName": Object {
           "Ref": "ioseditionSenderLambdaCtr2410D4D7",
         },
+        "MaximumBatchingWindowInSeconds": 1,
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },

--- a/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
+++ b/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
@@ -463,7 +463,7 @@ Object {
         "androidSenderSqsCF269D3F",
       ],
       "Properties": Object {
-        "BatchSize": 1,
+        "BatchSize": 20,
         "Enabled": true,
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [
@@ -932,7 +932,7 @@ Object {
         "androidbetaSenderSqs57513D18",
       ],
       "Properties": Object {
-        "BatchSize": 1,
+        "BatchSize": 20,
         "Enabled": true,
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [
@@ -1401,7 +1401,7 @@ Object {
         "androideditionSenderSqs400C0F3A",
       ],
       "Properties": Object {
-        "BatchSize": 1,
+        "BatchSize": 20,
         "Enabled": true,
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [
@@ -1870,7 +1870,7 @@ Object {
         "iosSenderSqsA94CB0A0",
       ],
       "Properties": Object {
-        "BatchSize": 1,
+        "BatchSize": 20,
         "Enabled": true,
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [
@@ -2299,7 +2299,7 @@ Object {
         "ioseditionSenderSqsFDE339AC",
       ],
       "Properties": Object {
-        "BatchSize": 1,
+        "BatchSize": 20,
         "Enabled": true,
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [

--- a/notificationworkerlambda/cdk/lib/senderworker.ts
+++ b/notificationworkerlambda/cdk/lib/senderworker.ts
@@ -115,7 +115,7 @@ class SenderWorker extends cdkcore.Construct  {
     })
 
     const senderSqsEventSourceMapping = new lambda.EventSourceMapping(this, "SenderSqsEventSourceMapping", {
-      batchSize: 1,
+      batchSize: 20,
       enabled: true,
       eventSourceArn: this.senderSqs.queueArn,
       target: senderLambdaCtr

--- a/notificationworkerlambda/cdk/lib/senderworker.ts
+++ b/notificationworkerlambda/cdk/lib/senderworker.ts
@@ -116,6 +116,7 @@ class SenderWorker extends cdkcore.Construct  {
 
     const senderSqsEventSourceMapping = new lambda.EventSourceMapping(this, "SenderSqsEventSourceMapping", {
       batchSize: 20,
+      maxBatchingWindow: cdk.Duration.seconds(1),
       enabled: true,
       eventSourceArn: this.senderSqs.queueArn,
       target: senderLambdaCtr

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -36,22 +36,22 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
   override val maxConcurrency = 100
 
   //override the deliverChunkedTokens method to validate the success of sending batch notifications to the FCM client. This implementation could be refactored in the future to make it more streamlined with APNs
-  override def deliverChunkedTokens(chunkedTokenStream: Stream[IO, (ChunkedTokens, Long, Instant)]): Stream[IO, Unit] = {
+  override def deliverChunkedTokens(chunkedTokenStream: Stream[IO, (ChunkedTokens, Long, Instant, Int)]): Stream[IO, Unit] = {
     chunkedTokenStream.map {
-      case (chunkedTokens, sentTime, functionStartTime) =>
+      case (chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize) =>
         val isAllowedToSendBatch = chunkedTokens.notification.topic.forall(topic => config.allowedTopicsForBatchSend.contains(topic.toString))
 
         if (isAllowedToSendBatch) {
           logger.info(s"Allowed to send notification ${chunkedTokens.notification.id} to topics ${chunkedTokens.notification.topic} in batches")
           deliverBatchNotificationStream(Stream.emits(chunkedTokens.toBatchNotificationToSends).covary[IO])
             .broadcastTo(
-              reportBatchSuccesses(chunkedTokens, sentTime, functionStartTime),
+              reportBatchSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
               cleanupBatchFailures(chunkedTokens.notification.id),
               trackBatchProgress(chunkedTokens.notification.id))
         } else
           deliverIndividualNotificationStream(Stream.emits(chunkedTokens.toNotificationToSends).covary[IO])
             .broadcastTo(
-              reportSuccesses(chunkedTokens, sentTime, functionStartTime),
+              reportSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
               cleanupFailures,
               trackProgress(chunkedTokens.notification.id))
     }.parJoin(maxConcurrency)
@@ -64,11 +64,11 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
       .evalTap(Reporting.logBatch(s"Sending failure: "))
   } yield resp
 
-  def reportBatchSuccesses[C <: DeliveryClient](chunkedTokens: ChunkedTokens, sentTime: Long, functionStartTime: Instant): Pipe[IO, Either[DeliveryException, BatchDeliverySuccess], Unit] = { input =>
+  def reportBatchSuccesses[C <: DeliveryClient](chunkedTokens: ChunkedTokens, sentTime: Long, functionStartTime: Instant, sqsMessageBatchSize: Int): Pipe[IO, Either[DeliveryException, BatchDeliverySuccess], Unit] = { input =>
     val notificationLog = s"(notification: ${chunkedTokens.notification.id} ${chunkedTokens.range})"
     input
       .fold(SendingResults.empty) { case (acc, resp) => SendingResults.aggregateBatch(acc, chunkedTokens.tokens.size, resp) }
-      .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform, isIndividualNotificationSend = false), prefix = s"Results $notificationLog: "))
+      .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform, isIndividualNotificationSend = false, sqsMessageBatchSize), prefix = s"Results $notificationLog: "))
       .through(cloudwatch.sendMetrics(env.stage, Configuration.platform))
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
@@ -14,7 +14,7 @@ import com.gu.notifications.worker.utils.{Cloudwatch, Logging, NotificationParse
 import fs2.{Pipe, Stream}
 import org.slf4j.{Logger, LoggerFactory}
 
-import java.time.Instant
+import java.time.{Duration, Instant}
 import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
@@ -34,7 +34,7 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
   implicit val timer: Timer[IO] = IO.timer(ec)
   implicit val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  def reportSuccesses[C <: DeliveryClient](chunkedTokens: ChunkedTokens, sentTime: Long, functionStartTime: Instant): Pipe[IO, Either[DeliveryException, DeliverySuccess], Unit] = { input =>
+  def reportSuccesses[C <: DeliveryClient](chunkedTokens: ChunkedTokens, sentTime: Long, functionStartTime: Instant, sqsMessageBatchSize: Int): Pipe[IO, Either[DeliveryException, DeliverySuccess], Unit] = { input =>
     val notificationLog = s"(notification: ${chunkedTokens.notification.id} ${chunkedTokens.range})"
     val enableAwsMetric = chunkedTokens.notification.dryRun match {
       case Some(true) => false
@@ -42,7 +42,7 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
     }
 
     input.fold(SendingResults.empty) { case (acc, resp) => SendingResults.aggregate(acc, resp) }
-      .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform), prefix = s"Results $notificationLog: ").andThen(_.map(cloudwatch.sendPerformanceMetrics(env.stage, enableAwsMetric))))
+      .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform, sqsMessageBatchSize = sqsMessageBatchSize), prefix = s"Results $notificationLog: ").andThen(_.map(cloudwatch.sendPerformanceMetrics(env.stage, enableAwsMetric))))
       .through(cloudwatch.sendMetrics(env.stage, Configuration.platform))
   }
 
@@ -68,26 +68,35 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
       .evalTap(Reporting.log(s"Sending failure: "))
   } yield resp
 
-  def deliverChunkedTokens(chunkedTokenStream: Stream[IO, (ChunkedTokens, Long, Instant)]): Stream[IO, Unit] = {
+  def deliverChunkedTokens(chunkedTokenStream: Stream[IO, (ChunkedTokens, Long, Instant, Int)]): Stream[IO, Unit] = {
     chunkedTokenStream.map {
-      case (chunkedTokens, sentTime, functionStartTime) =>
+      case (chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize) =>
         val individualNotifications = Stream.emits(chunkedTokens.toNotificationToSends).covary[IO]
         deliverIndividualNotificationStream(individualNotifications)
           .broadcastTo(
-            reportSuccesses(chunkedTokens, sentTime, functionStartTime),
+            reportSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
             cleanupFailures,
             trackProgress(chunkedTokens.notification.id))
       }.parJoin(maxConcurrency)
   }
 
   def handleChunkTokens(event: SQSEvent, context: Context): Unit = {
-    val chunkedTokenStream: Stream[IO, (ChunkedTokens, Long, Instant)] = Stream.emits(event.getRecords.asScala)
+    val sqsMessageBatchSize = event.getRecords.size
+    val startTime = Instant.now
+    val totalTokensProcessed: Int = event.getRecords.asScala.map(event => NotificationParser.parseChunkedTokenEvent(event.getBody)).foldLeft(0)((acc, r) => acc + r.tokens.size)
+    val chunkedTokenStream: Stream[IO, (ChunkedTokens, Long, Instant, Int)] = Stream.emits(event.getRecords.asScala)
       .map(r => (r.getBody, r.getAttributes.getOrDefault("SentTimestamp", "0").toLong))
-      .map { case (body, sentTimestamp) => (NotificationParser.parseChunkedTokenEvent(body), sentTimestamp, Instant.now) }
+      .map { case (body, sentTimestamp) => (NotificationParser.parseChunkedTokenEvent(body), sentTimestamp, startTime, sqsMessageBatchSize) }
 
     deliverChunkedTokens(chunkedTokenStream)
       .compile
       .drain
       .unsafeRunSync()
+
+    logger.info(Map(
+      "sqsMessageBatchSize" -> sqsMessageBatchSize,
+      "totalTokensProcessed" -> totalTokensProcessed,
+      "invocation.functionProcessingRate" -> { totalTokensProcessed.toDouble / Duration.between(startTime, Instant.now).toMillis * 1000 },
+    ), "Processed all sqs messages from sqs event")
   }
 }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
@@ -36,6 +36,8 @@ case class PerformanceMetrics(
   functionProcessingTime: Long,
   notificationProcessingTime: Long,
   notificationProcessingStartTime: Long,
-  notificationProcessingEndTime: Long
+  notificationProcessingEndTime: Long,
+  sqsMessageBatchSize: Int,
+  chunkTokenSize: Int,
 )
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
@@ -31,6 +31,8 @@ trait Logging {
         notificationProcessingTime = metricsField.get("worker.notificationProcessingTime").get.asInstanceOf[Long],
         notificationProcessingStartTime = metricsField.get("worker.notificationProcessingStartTime.millis").get.asInstanceOf[Long],
         notificationProcessingEndTime = metricsField.get("worker.notificationProcessingEndTime.millis").get.asInstanceOf[Long],
+        sqsMessageBatchSize = metricsField("sqsMessageBatchSize").asInstanceOf[Int],
+        chunkTokenSize = metricsField("worker.chunkTokenSize").asInstanceOf[Int]
       )
     }
   }
@@ -47,7 +49,8 @@ trait Logging {
     sentTime: Long,
     functionStartTime: Instant,
     maybePlatform: Option[Platform],
-    isIndividualNotificationSend: Boolean = true
+    isIndividualNotificationSend: Boolean = true,
+    sqsMessageBatchSize: Int,
   )(end: Instant): Map[String, Any] = {
     val processingTime = Duration.between(functionStartTime, end).toMillis
     val processingRate = numberOfTokens.toDouble / processingTime * 1000
@@ -67,7 +70,9 @@ trait Logging {
       "worker.notificationProcessingTime" -> Duration.between(start, end).toMillis,
       "worker.notificationProcessingStartTime.millis" -> sentTime,
       "worker.notificationProcessingEndTime.millis" -> end.toEpochMilli,
-      "worker.notificationSendMethod" -> { if (isIndividualNotificationSend) "individual" else "batch" }
+      "worker.notificationSendMethod" -> { if (isIndividualNotificationSend) "individual" else "batch" },
+      "sqsMessageBatchSize" -> sqsMessageBatchSize,
+      "worker.chunkTokenSize" -> numberOfTokens,
     )
   }
 }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/NotificationParser.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/NotificationParser.scala
@@ -39,13 +39,7 @@ object NotificationParser extends Logging {
 
   private def parseChunkedTokens(json: JsValue): ChunkedTokens = {
     json.validate[ChunkedTokens] match {
-      case JsSuccess(chunkedTokens, _) => {
-        logger.info(Map(
-          "worker.chunkTokenSize" -> chunkedTokens.tokens.size,
-          "notificationId" -> chunkedTokens.notification.id
-        ), "Parsed chunk tokens")
-        chunkedTokens
-      }
+      case JsSuccess(chunkedTokens, _) => chunkedTokens
       case JsError(errors) => throw new RuntimeException(s"Unable to parse message $errors")
     }
   }


### PR DESCRIPTION
## What does this change?

This PR is intended to test the performance improvement of multicast message sending by enabling more multicast message http requests to take place concurrently. The theory is that we have the ability to parallelise within our lambda, but it is currently under-used when sending groups of tokens to firebase.

We want to increase the function processing rate of our worker lambdas because they are the bottleneck for achieving our 90in2 SLO. We recently tried [testing](https://github.com/guardian/mobile-n10n/pull/747) the impact of multicast message sending our tokens to firebase. We observed the following results:
- the latency of a multicast message request was higher than the latency of a request to send an individual token (2600ms vs 70ms, respectively)
- the latency for sending 500 tokens is only ~38 times greater than sending for an individual token, so there is a potential efficiency gain by sending in batches, however:
- tokens were sent in groups of 500, meaning each lambda invocation would make, at most, only 2 http requests in parallel
- given the parallelism we already achieve, the overall result meant that making many shorter requests concurrently was quicker than making fewer longer requests (verified because the average lambda duration is typically smaller than the latency of a single average multicast message request).

NB: thinking about the parallelism we already achieve when sending individual notifications, we could estimate this as:
- ( average latency of a request * average number of requests made) / average total duration of lambda execution
- ( 70 ms * 1000 ) / 2400 ms
- ~29

There are some options to increase the number of parallel batch notification http requests:
- increase the number of tokens each sqs event contains: we cannot significantly increase the number of tokens in each single sqs message due to the sqs message limit (256kb, but we already send about 140kb of data)
- increase the batch size (the number of messages each lambda invocation processes): this is a good option but when testing we could see a linear relationship between duration and batch size, indicating that batches of sqs messages were being processed sequentially, not concurrently. 

A change to the `deliverChunkTokens` functions has been made to ensure multiple sqs events are processed concurrently. This was confirmed via local testing. A test sqs event was configured to included 3 sqs messages (where each message contained only 1 token). The below are extracts from the logs showing the sequence before and after this change:

| Before change                                                                                                              | After change                                                                                                                 |
|----------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
| Parsed chunk tokens                                                                                                        | "Parsed chunk tokens"                                                                                                        |
| Parsed chunk tokens                                                                                                        | "Parsed chunk tokens"                                                                                                        |
| Parsed chunk tokens                                                                                                        | "Parsed chunk tokens"                                                                                                        |
| Sending batch notification                                                                                                 | "Sending batch notification"                                                                                                 |
| Batch send request completed                                                                                               | "Sending batch notification"                                                                                                 |
| Processed 1 individual notification(s)                                                                                     | "Sending batch notification"                                                                                                 |
| Results (notification: 1145fad9-4825-4b95-9696-233ea1cdefaa ShardRange(0,1)): : Success: 0, Failure: 1, DryRun: 0 Total: 1 | "Batch send request completed"                                                                                               |
| Sent 0 tokens for deletion via SQS                                                                                         | "Processed 1 individual notification(s)"                                                                                     |
| Sending batch notification                                                                                                 | "Results (notification: ebe9a525-431f-4333-8277-b6f31b818439 ShardRange(0,1)): : Success: 0, Failure: 1, DryRun: 0 Total: 1" |
| Batch send request completed                                                                                               | "Sent 0 tokens for deletion via SQS"                                                                                         |
| Processed 1 individual notification(s)                                                                                     | "Batch send request completed"                                                                                               |
| Results (notification: d4953d04-58e3-42e3-b057-d5a2ced68641 ShardRange(0,1)): : Success: 0, Failure: 1, DryRun: 0 Total: 1 | "Processed 1 individual notification(s)"                                                                                     |
| Sent 0 tokens for deletion via SQS                                                                                         | "Results (notification: ed9e7175-8d7d-4586-a499-a4d3038251aa ShardRange(0,1)): : Success: 0, Failure: 1, DryRun: 0 Total: 1" |
| Sending batch notification                                                                                                 | "Sent 0 tokens for deletion via SQS"                                                                                         |
| Batch send request completed                                                                                               | "Batch send request completed"                                                                                               |
| Processed 1 individual notification(s)                                                                                     | "Processed 1 individual notification(s)"                                                                                     |
| Results (notification: 8b726f8c-989c-4e9e-a24b-8e05dc1701f3 ShardRange(0,1)): : Success: 0, Failure: 1, DryRun: 0 Total: 1 | "Results (notification: c861d37b-659d-46fe-9201-14b4ae6bf307 ShardRange(0,1)): : Success: 0, Failure: 1, DryRun: 0 Total: 1" |
| Sent 0 tokens for deletion via SQS                                                                                         | "Sent 0 tokens for deletion via SQS"                                                                                         |

^ here we can see that before the change we waited for the the request(s) associated with a single sqs message to return before attempting to process any subsequent sqs messages. After the change we can see all associated requests being made concurrently at the beginning of the process.

Based on the levels of parallelism we have for individual notification sends we believe that a single lambda invocation could easily parallelise 20 sqs messages. This significantly increases our token processing rate (estimated at 7400 tokens/s if all multicast messages were initiated concurrently and took the average expected time).

## How to test
 
I've tested locally and the change does what's intended (processes multiple messages concurrently).

We will also confirm the changes work as anticipated in the CODE environment.

## How can we measure success?

We should expect to see an improvement in the performance of batch notification sends - we already have metrics in place to monitor this (including function processing rate, overall duration, etc).

## Have we considered potential risks?

We are increasing the work each lambda invocation has to do which will (likely) increase the total lambda execution time (although hopefully less than a factor of 20). Our current lambda timeout is currently unchanged but open to opinions about whether this timeout should be increased. For ref:
- current timeout = 90s
- 99% of lambda invocations complete within 20s
- average lambda duration tends to be about 2.4s

