### PR TITLE
Apply sqs batch size changes to android worker only

### DIFF
--- a/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
+++ b/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
@@ -864,7 +864,7 @@ Object {
             "Value": "PROD",
           },
         ],
-        "Timeout": 180,
+        "Timeout": 90,
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -922,7 +922,7 @@ Object {
             "Value": "PROD",
           },
         ],
-        "VisibilityTimeout": 200,
+        "VisibilityTimeout": 100,
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
@@ -933,7 +933,7 @@ Object {
         "androidbetaSenderSqs57513D18",
       ],
       "Properties": Object {
-        "BatchSize": 20,
+        "BatchSize": 1,
         "Enabled": true,
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [
@@ -944,7 +944,7 @@ Object {
         "FunctionName": Object {
           "Ref": "androidbetaSenderLambdaCtrB3CF7FC4",
         },
-        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumBatchingWindowInSeconds": 0,
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
@@ -1334,7 +1334,7 @@ Object {
             "Value": "PROD",
           },
         ],
-        "Timeout": 180,
+        "Timeout": 90,
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -1392,7 +1392,7 @@ Object {
             "Value": "PROD",
           },
         ],
-        "VisibilityTimeout": 200,
+        "VisibilityTimeout": 100,
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
@@ -1403,7 +1403,7 @@ Object {
         "androideditionSenderSqs400C0F3A",
       ],
       "Properties": Object {
-        "BatchSize": 20,
+        "BatchSize": 1,
         "Enabled": true,
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [
@@ -1414,7 +1414,7 @@ Object {
         "FunctionName": Object {
           "Ref": "androideditionSenderLambdaCtrF0169D16",
         },
-        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumBatchingWindowInSeconds": 0,
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
@@ -1804,7 +1804,7 @@ Object {
             "Value": "PROD",
           },
         ],
-        "Timeout": 180,
+        "Timeout": 90,
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -1862,7 +1862,7 @@ Object {
             "Value": "PROD",
           },
         ],
-        "VisibilityTimeout": 200,
+        "VisibilityTimeout": 100,
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
@@ -1873,7 +1873,7 @@ Object {
         "iosSenderSqsA94CB0A0",
       ],
       "Properties": Object {
-        "BatchSize": 20,
+        "BatchSize": 1,
         "Enabled": true,
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [
@@ -1884,7 +1884,7 @@ Object {
         "FunctionName": Object {
           "Ref": "iosSenderLambdaCtr6053C1F8",
         },
-        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumBatchingWindowInSeconds": 0,
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
@@ -2274,7 +2274,7 @@ Object {
             "Value": "PROD",
           },
         ],
-        "Timeout": 180,
+        "Timeout": 90,
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -2303,7 +2303,7 @@ Object {
         "ioseditionSenderSqsFDE339AC",
       ],
       "Properties": Object {
-        "BatchSize": 20,
+        "BatchSize": 1,
         "Enabled": true,
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [
@@ -2314,7 +2314,7 @@ Object {
         "FunctionName": Object {
           "Ref": "ioseditionSenderLambdaCtr2410D4D7",
         },
-        "MaximumBatchingWindowInSeconds": 1,
+        "MaximumBatchingWindowInSeconds": 0,
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
@@ -2353,7 +2353,7 @@ Object {
             "Value": "PROD",
           },
         ],
-        "VisibilityTimeout": 200,
+        "VisibilityTimeout": 100,
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",

--- a/notificationworkerlambda/cdk/lib/senderworker.ts
+++ b/notificationworkerlambda/cdk/lib/senderworker.ts
@@ -23,7 +23,8 @@ interface SenderWorkerOpts {
   tooFewInvocationsEnabled: boolean,
   cleanerQueueArn: string,
   platform: string,
-  paramPrefix: string
+  paramPrefix: string,
+  isBatchingSqsMessages: boolean,
 }
 
 class SenderWorker extends cdkcore.Construct  {
@@ -39,7 +40,7 @@ class SenderWorker extends cdkcore.Construct  {
 
     const senderDlq = new sqs.Queue(this, 'SenderDlq')
     this.senderSqs = new sqs.Queue(this, 'SenderSqs', {
-      visibilityTimeout: cdk.Duration.seconds(200),
+      visibilityTimeout: props.isBatchingSqsMessages ? cdk.Duration.seconds(200) : cdk.Duration.seconds(100),
       retentionPeriod: cdk.Duration.hours(1),
       deadLetterQueue: {
         queue: senderDlq,
@@ -110,13 +111,13 @@ class SenderWorker extends cdkcore.Construct  {
       memorySize: 10240,
       description: `sends notifications for ${id}`,
       role: executionRole,
-      timeout: cdk.Duration.seconds(180),
+      timeout: props.isBatchingSqsMessages ? cdk.Duration.seconds(180) : cdk.Duration.seconds(90),
       reservedConcurrentExecutions: props.reservedConcurrency
     })
 
     const senderSqsEventSourceMapping = new lambda.EventSourceMapping(this, "SenderSqsEventSourceMapping", {
-      batchSize: 20,
-      maxBatchingWindow: cdk.Duration.seconds(1),
+      batchSize: props.isBatchingSqsMessages ? 20 : 1,
+      maxBatchingWindow: props.isBatchingSqsMessages ? cdk.Duration.seconds(1) : cdk.Duration.seconds(0),
       enabled: true,
       eventSourceArn: this.senderSqs.queueArn,
       target: senderLambdaCtr
@@ -216,12 +217,13 @@ export class SenderWorkerStack extends GuStack {
 
     let workerQueueArns: string[] = []
 
-    const addWorker = (workerName: string, paramPrefix: string, handler: string) => {
+    const addWorker = (workerName: string, paramPrefix: string, handler: string, isBatchingSqsMessages: boolean = false) => {
       let worker = new SenderWorker(this, workerName, {
         ...props,
         platform: workerName,
         paramPrefix: paramPrefix,
         handler: handler,
+        isBatchingSqsMessages,
         ...sharedOpts
       })
       workerQueueArns.push(worker.senderSqs.queueArn)
@@ -233,7 +235,7 @@ export class SenderWorkerStack extends GuStack {
      */
 
     addWorker("ios", "iosLive", "com.gu.notifications.worker.IOSSender::handleChunkTokens")
-    addWorker("android", "androidLive", "com.gu.notifications.worker.AndroidSender::handleChunkTokens")
+    addWorker("android", "androidLive", "com.gu.notifications.worker.AndroidSender::handleChunkTokens", true)
     addWorker("ios-edition", "iosEdition", "com.gu.notifications.worker.IOSSender::handleChunkTokens")
     addWorker("android-edition", "androidEdition", "com.gu.notifications.worker.AndroidSender::handleChunkTokens")
     addWorker("android-beta", "androidBeta", "com.gu.notifications.worker.AndroidSender::handleChunkTokens")


### PR DESCRIPTION
## What does this change?

We are testing the performance impact when concurrently handling multiple sqs messages inside a single sqs event.

Yesterday we found that performance degraded when handling 20 sqs messages and sending individual notifications (not in groups).

This change scopes the sqs batch size configuration android only, only the android worker will have:
- an sqs batch size of 20, all other workers revert to a batch size of 1
- a max batching window of 1 second
- a timeout of 180 seconds, all other workers revert to the original timeout of 90 seconds
- a visibility timeout of 200 seconds, all other workers revert to the original visibility timeout of 100 seconds

## How to test

 After deploy, confirm the lambda configuration has been updated correctly for the non-android workers.
