### PR TITLE
Upgrade cdk dependencies to the latest version

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,14 +8,14 @@
       "name": "cdk",
       "version": "0.0.0",
       "devDependencies": {
-        "@guardian/cdk": "47.3.3",
+        "@guardian/cdk": "48.5.0",
         "@guardian/eslint-config-typescript": "1.0.1",
         "@guardian/prettier": "1.0.0",
         "@types/jest": "^27.5.0",
         "@types/node": "17.0.42",
-        "aws-cdk": "2.39.1",
-        "aws-cdk-lib": "2.39.1",
-        "constructs": "10.1.17",
+        "aws-cdk": "2.50.0",
+        "aws-cdk-lib": "2.50.0",
+        "constructs": "10.1.155",
         "eslint": "^8.16.0",
         "jest": "^27.5.1",
         "prettier": "^2.7.0",
@@ -666,32 +666,32 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "47.3.3",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-47.3.3.tgz",
-      "integrity": "sha512-weA6KgnIsw/AhhoS6yUIsycnnXCJYn5B3QQqAuCc5srXuVYitc1NjLysbLwufxLCRnVotlAydewrvsHlgRzgSA==",
+      "version": "48.5.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-48.5.0.tgz",
+      "integrity": "sha512-LTSf4MbGCwz2sZEi+/RokUhtGk2O42M5Ij1XDJGTbjMH01+hw1c2RU/gtVEFiDtr1qy0y4fU1CZW2r1EXNAMrw==",
       "dev": true,
       "dependencies": {
-        "@oclif/core": "1.16.0",
-        "aws-cdk-lib": "2.39.1",
-        "aws-sdk": "^2.1209.0",
+        "@oclif/core": "1.20.4",
+        "aws-cdk-lib": "2.50.0",
+        "aws-sdk": "^2.1252.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.67.0",
-        "constructs": "10.1.91",
-        "git-url-parse": "^13.0.0",
+        "codemaker": "^1.71.0",
+        "constructs": "10.1.155",
+        "git-url-parse": "^13.1.0",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.upperfirst": "^4.3.1",
         "read-pkg-up": "7.0.1",
-        "yargs": "^17.5.1"
+        "yargs": "^17.6.2"
       },
       "bin": {
         "gu-cdk": "bin/gu-cdk"
       },
       "peerDependencies": {
-        "aws-cdk": "2.39.1",
-        "aws-cdk-lib": "2.39.1",
-        "constructs": "10.1.91"
+        "aws-cdk": "2.50.0",
+        "aws-cdk-lib": "2.50.0",
+        "constructs": "10.1.155"
       }
     },
     "node_modules/@guardian/cdk/node_modules/argparse": {
@@ -699,15 +699,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
-    },
-    "node_modules/@guardian/cdk/node_modules/constructs": {
-      "version": "10.1.91",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.91.tgz",
-      "integrity": "sha512-qf5beNs2Fv9nhlzWXk1PB1AdZfAodbgepKQCkUli/H+X8EafvqC0/2o2heAAp8IrUJxLnGfC4TCz9OHtx1eESA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
     },
     "node_modules/@guardian/cdk/node_modules/js-yaml": {
       "version": "4.1.0",
@@ -1272,13 +1263,13 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.16.0.tgz",
-      "integrity": "sha512-xtqhAbjQHBcz+xQpEHJ3eJEVfRQ4zl41Yw5gw/N+D1jgaIUrHTxCY/sfTvhw93LAQo7B++ozHzSb7DISFXsQFQ==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.20.4.tgz",
+      "integrity": "sha512-giug32M4YhSYNYKQwE1L57/+k5gp1+Bq3/0vKNQmzAY1tizFGhvBJc6GIRZasHjU+xtZLutQvrVrJo7chX3hxg==",
       "dev": true,
       "dependencies": {
         "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.2",
+        "@oclif/screen": "^3.0.3",
         "ansi-escapes": "^4.3.2",
         "ansi-styles": "^4.3.0",
         "cardinal": "^2.1.1",
@@ -1302,7 +1293,7 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.3.1",
+        "tslib": "^2.4.1",
         "widest-line": "^3.1.0",
         "wrap-ansi": "^7.0.0"
       },
@@ -1317,9 +1308,9 @@
       "dev": true
     },
     "node_modules/@oclif/screen": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.2.tgz",
-      "integrity": "sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.3.tgz",
+      "integrity": "sha512-KX8gMYA9ujBPOd1HFsV9e0iEx7Uoj8AG/3YsW4TtWQTg4lJvr82qNm7o/cFQfYRIt+jw7Ew/4oL4A22zOT+IRA==",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
@@ -1907,9 +1898,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.39.1.tgz",
-      "integrity": "sha512-HWruCkbsKJcFOKlVbcIQk/704PdPLHCkSpXNZK6BTpHB46bM49jLyQisgnbcPUc7Imk2k7kW6pe5Zvx1hFleMA==",
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.50.0.tgz",
+      "integrity": "sha512-55vmKTf2DZRqioumVfXn+S0H9oAbpRK3HFHY8EjZ5ykR5tq2+XiMWEZkYduX2HJhVAeHJJIS6h+Okk3smZjeqw==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -1922,9 +1913,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.39.1.tgz",
-      "integrity": "sha512-+KZBLBoCqq/TnC7LH8JMlQ+5IvKQtu7KHnVDiRmngtibLIXqLMVH4neKimNlSSIKhvSeOmqY2ZCaSp8v5szzrg==",
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.50.0.tgz",
+      "integrity": "sha512-deDbZTI7oyu3rqUyqjwhP6tnUO8MD70lE98yR65xiYty4yXBpsWKbeH3s1wNLpLAWS3hWJYyMtjZ4ZfC35NtVg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1945,7 +1936,7 @@
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.1.1",
-        "semver": "^7.3.7",
+        "semver": "^7.3.8",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -2086,7 +2077,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.7",
+      "version": "7.3.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2125,9 +2116,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1218.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1218.0.tgz",
-      "integrity": "sha512-oreF2jKfUZ8VKnIKh8TrOOOsdSfv87jHGtWQNAHdvfeyrYK5FrnvGkHUZ3bu6g6u1gHwu5FhTPiRMbgS8Re+NA==",
+      "version": "2.1257.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1257.0.tgz",
+      "integrity": "sha512-SNfKIVlJdLyBbUSGgvsBOuV4iOE1modoKOhnV/bIi2F7DJkq4SCPmrN1nwLNBnOQQvZRlPwFbHPVrJ3clTXLDQ==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -2518,9 +2509,9 @@
       }
     },
     "node_modules/codemaker": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.67.0.tgz",
-      "integrity": "sha512-ChqnwbXIDIq8EAju+OMOnuzJ5MQWXvFaf4PMZo2RLbLiqUfx4+ATv/i1y0rY5uZ7nvKC8lRfwmbRsgsbWQHAhA==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.71.0.tgz",
+      "integrity": "sha512-kjpPxr5TRMYr2BG0EP9IEjQAeE6lTT9fybnCBxQdw3ebVoG8pvMshsQmoMwreL7IaloV8EYIkA+cfr/UpQ6CCg==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -2588,9 +2579,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.17",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.17.tgz",
-      "integrity": "sha512-MxICX5kvtqpG1bX5wPLaVpPaI5tyEo5zTK3TfJMrOLP7l2inuHOG+Xq5wZZKaeBicuXB8ei2TAogUg/Hr2EhaA==",
+      "version": "10.1.155",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.155.tgz",
+      "integrity": "sha512-AM8HdZ1GQbOLBmnIU5ybyerNeNn9iEZSZZra+2BWuAhyaA+zJb9oxwxD3isM2uxZviB5NHGhZI83plmhOuh29A==",
       "dev": true,
       "engines": {
         "node": ">= 14.17.0"
@@ -3761,9 +3752,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -3907,6 +3898,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -4443,15 +4446,15 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
-      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
       "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
       },
       "engines": {
@@ -7037,9 +7040,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -7194,16 +7197,15 @@
       "dev": true
     },
     "node_modules/util": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
       }
     },
@@ -7361,17 +7363,17 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
-      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
       "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
+        "is-typed-array": "^1.1.10"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7504,18 +7506,18 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
       "dev": true,
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -7530,10 +7532,24 @@
         "node": ">=10"
       }
     },
+    "node_modules/yargs/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -8048,36 +8064,30 @@
       }
     },
     "@guardian/cdk": {
-      "version": "47.3.3",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-47.3.3.tgz",
-      "integrity": "sha512-weA6KgnIsw/AhhoS6yUIsycnnXCJYn5B3QQqAuCc5srXuVYitc1NjLysbLwufxLCRnVotlAydewrvsHlgRzgSA==",
+      "version": "48.5.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-48.5.0.tgz",
+      "integrity": "sha512-LTSf4MbGCwz2sZEi+/RokUhtGk2O42M5Ij1XDJGTbjMH01+hw1c2RU/gtVEFiDtr1qy0y4fU1CZW2r1EXNAMrw==",
       "dev": true,
       "requires": {
-        "@oclif/core": "1.16.0",
-        "aws-cdk-lib": "2.39.1",
-        "aws-sdk": "^2.1209.0",
+        "@oclif/core": "1.20.4",
+        "aws-cdk-lib": "2.50.0",
+        "aws-sdk": "^2.1252.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.67.0",
-        "constructs": "10.1.91",
-        "git-url-parse": "^13.0.0",
+        "codemaker": "^1.71.0",
+        "constructs": "10.1.155",
+        "git-url-parse": "^13.1.0",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.upperfirst": "^4.3.1",
         "read-pkg-up": "7.0.1",
-        "yargs": "^17.5.1"
+        "yargs": "^17.6.2"
       },
       "dependencies": {
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "constructs": {
-          "version": "10.1.91",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.91.tgz",
-          "integrity": "sha512-qf5beNs2Fv9nhlzWXk1PB1AdZfAodbgepKQCkUli/H+X8EafvqC0/2o2heAAp8IrUJxLnGfC4TCz9OHtx1eESA==",
           "dev": true
         },
         "js-yaml": {
@@ -8525,13 +8535,13 @@
       }
     },
     "@oclif/core": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.16.0.tgz",
-      "integrity": "sha512-xtqhAbjQHBcz+xQpEHJ3eJEVfRQ4zl41Yw5gw/N+D1jgaIUrHTxCY/sfTvhw93LAQo7B++ozHzSb7DISFXsQFQ==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.20.4.tgz",
+      "integrity": "sha512-giug32M4YhSYNYKQwE1L57/+k5gp1+Bq3/0vKNQmzAY1tizFGhvBJc6GIRZasHjU+xtZLutQvrVrJo7chX3hxg==",
       "dev": true,
       "requires": {
         "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.2",
+        "@oclif/screen": "^3.0.3",
         "ansi-escapes": "^4.3.2",
         "ansi-styles": "^4.3.0",
         "cardinal": "^2.1.1",
@@ -8555,7 +8565,7 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.3.1",
+        "tslib": "^2.4.1",
         "widest-line": "^3.1.0",
         "wrap-ansi": "^7.0.0"
       }
@@ -8567,9 +8577,9 @@
       "dev": true
     },
     "@oclif/screen": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.2.tgz",
-      "integrity": "sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.3.tgz",
+      "integrity": "sha512-KX8gMYA9ujBPOd1HFsV9e0iEx7Uoj8AG/3YsW4TtWQTg4lJvr82qNm7o/cFQfYRIt+jw7Ew/4oL4A22zOT+IRA==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -9013,18 +9023,18 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.39.1.tgz",
-      "integrity": "sha512-HWruCkbsKJcFOKlVbcIQk/704PdPLHCkSpXNZK6BTpHB46bM49jLyQisgnbcPUc7Imk2k7kW6pe5Zvx1hFleMA==",
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.50.0.tgz",
+      "integrity": "sha512-55vmKTf2DZRqioumVfXn+S0H9oAbpRK3HFHY8EjZ5ykR5tq2+XiMWEZkYduX2HJhVAeHJJIS6h+Okk3smZjeqw==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.39.1.tgz",
-      "integrity": "sha512-+KZBLBoCqq/TnC7LH8JMlQ+5IvKQtu7KHnVDiRmngtibLIXqLMVH4neKimNlSSIKhvSeOmqY2ZCaSp8v5szzrg==",
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.50.0.tgz",
+      "integrity": "sha512-deDbZTI7oyu3rqUyqjwhP6tnUO8MD70lE98yR65xiYty4yXBpsWKbeH3s1wNLpLAWS3hWJYyMtjZ4ZfC35NtVg==",
       "dev": true,
       "requires": {
         "@balena/dockerignore": "^1.0.2",
@@ -9034,7 +9044,7 @@
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.1.1",
-        "semver": "^7.3.7",
+        "semver": "^7.3.8",
         "yaml": "1.10.2"
       },
       "dependencies": {
@@ -9129,7 +9139,7 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.7",
+          "version": "7.3.8",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -9154,9 +9164,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1218.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1218.0.tgz",
-      "integrity": "sha512-oreF2jKfUZ8VKnIKh8TrOOOsdSfv87jHGtWQNAHdvfeyrYK5FrnvGkHUZ3bu6g6u1gHwu5FhTPiRMbgS8Re+NA==",
+      "version": "2.1257.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1257.0.tgz",
+      "integrity": "sha512-SNfKIVlJdLyBbUSGgvsBOuV4iOE1modoKOhnV/bIi2F7DJkq4SCPmrN1nwLNBnOQQvZRlPwFbHPVrJ3clTXLDQ==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -9439,9 +9449,9 @@
       "dev": true
     },
     "codemaker": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.67.0.tgz",
-      "integrity": "sha512-ChqnwbXIDIq8EAju+OMOnuzJ5MQWXvFaf4PMZo2RLbLiqUfx4+ATv/i1y0rY5uZ7nvKC8lRfwmbRsgsbWQHAhA==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.71.0.tgz",
+      "integrity": "sha512-kjpPxr5TRMYr2BG0EP9IEjQAeE6lTT9fybnCBxQdw3ebVoG8pvMshsQmoMwreL7IaloV8EYIkA+cfr/UpQ6CCg==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -9499,9 +9509,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.17",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.17.tgz",
-      "integrity": "sha512-MxICX5kvtqpG1bX5wPLaVpPaI5tyEo5zTK3TfJMrOLP7l2inuHOG+Xq5wZZKaeBicuXB8ei2TAogUg/Hr2EhaA==",
+      "version": "10.1.155",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.155.tgz",
+      "integrity": "sha512-AM8HdZ1GQbOLBmnIU5ybyerNeNn9iEZSZZra+2BWuAhyaA+zJb9oxwxD3isM2uxZviB5NHGhZI83plmhOuh29A==",
       "dev": true
     },
     "convert-source-map": {
@@ -10406,9 +10416,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -10509,6 +10519,15 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "graceful-fs": {
@@ -10877,15 +10896,15 @@
       }
     },
     "is-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
-      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
       "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
       }
     },
@@ -12838,9 +12857,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "tsutils": {
@@ -12952,16 +12971,15 @@
       }
     },
     "util": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
       }
     },
@@ -13094,17 +13112,17 @@
       }
     },
     "which-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
-      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
       "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
+        "is-typed-array": "^1.1.10"
       }
     },
     "widest-line": {
@@ -13199,24 +13217,35 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
       "dev": true,
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "dependencies": {
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
         "yargs-parser": {
-          "version": "21.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "dev": true
         }
       }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -11,14 +11,14 @@
     "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "47.3.3",
+    "@guardian/cdk": "48.5.0",
     "@guardian/eslint-config-typescript": "1.0.1",
     "@guardian/prettier": "1.0.0",
     "@types/jest": "^27.5.0",
     "@types/node": "17.0.42",
-    "aws-cdk": "2.39.1",
-    "aws-cdk-lib": "2.39.1",
-    "constructs": "10.1.17",
+    "aws-cdk": "2.50.0",
+    "aws-cdk-lib": "2.50.0",
+    "constructs": "10.1.155",
     "eslint": "^8.16.0",
     "jest": "^27.5.1",
     "prettier": "^2.7.0",

--- a/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
+++ b/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
@@ -4,7 +4,7 @@ exports[`The MobileAppsRendering stack matches the snapshot 1`] = `
 Object {
   "Metadata": Object {
     "gu:cdk:constructs": Array [],
-    "gu:cdk:version": "47.3.3",
+    "gu:cdk:version": "48.5.0",
   },
   "Outputs": Object {
     "NotificationSenderWorkerQueueArns": Object {
@@ -214,7 +214,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -242,7 +242,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -379,7 +379,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -406,7 +406,7 @@ Object {
           "App": "android",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "47.3.3",
+          "gu:cdk:version": "48.5.0",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -437,7 +437,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -684,7 +684,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -712,7 +712,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -849,7 +849,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -876,7 +876,7 @@ Object {
           "App": "android-beta",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "47.3.3",
+          "gu:cdk:version": "48.5.0",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -907,7 +907,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -1154,7 +1154,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -1182,7 +1182,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -1319,7 +1319,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -1346,7 +1346,7 @@ Object {
           "App": "android-edition",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "47.3.3",
+          "gu:cdk:version": "48.5.0",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -1377,7 +1377,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -1624,7 +1624,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -1652,7 +1652,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -1789,7 +1789,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -1816,7 +1816,7 @@ Object {
           "App": "ios",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "47.3.3",
+          "gu:cdk:version": "48.5.0",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -1847,7 +1847,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -2094,7 +2094,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -2122,7 +2122,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -2259,7 +2259,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",
@@ -2286,7 +2286,7 @@ Object {
           "App": "ios-edition",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "47.3.3",
+          "gu:cdk:version": "48.5.0",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -2338,7 +2338,7 @@ Object {
           },
           Object {
             "Key": "gu:cdk:version",
-            "Value": "47.3.3",
+            "Value": "48.5.0",
           },
           Object {
             "Key": "gu:repo",

--- a/notificationworkerlambda/cdk/package.json
+++ b/notificationworkerlambda/cdk/package.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "aws-cdk-lib": "2.39.1",
-    "@guardian/cdk": "47.3.3",
+    "aws-cdk-lib": "2.50.0",
+    "@guardian/cdk": "48.5.0",
     "@types/jest": "^27.4.1",
-    "aws-cdk": "2.39.1",
+    "aws-cdk": "2.50.0",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
     "typescript": "^4.8.3"

--- a/notificationworkerlambda/cdk/yarn.lock
+++ b/notificationworkerlambda/cdk/yarn.lock
@@ -319,24 +319,24 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@guardian/cdk@47.3.3":
-  version "47.3.3"
-  resolved "https://registry.npmjs.org/@guardian/cdk/-/cdk-47.3.3.tgz"
-  integrity sha512-weA6KgnIsw/AhhoS6yUIsycnnXCJYn5B3QQqAuCc5srXuVYitc1NjLysbLwufxLCRnVotlAydewrvsHlgRzgSA==
+"@guardian/cdk@48.5.0":
+  version "48.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-48.5.0.tgz#f77b67ae100365d11c4bb3150febcfe1c420e2bd"
+  integrity sha512-LTSf4MbGCwz2sZEi+/RokUhtGk2O42M5Ij1XDJGTbjMH01+hw1c2RU/gtVEFiDtr1qy0y4fU1CZW2r1EXNAMrw==
   dependencies:
-    "@oclif/core" "1.16.0"
-    aws-cdk-lib "2.39.1"
-    aws-sdk "^2.1209.0"
+    "@oclif/core" "1.20.4"
+    aws-cdk-lib "2.50.0"
+    aws-sdk "^2.1252.0"
     chalk "^4.1.2"
-    codemaker "^1.67.0"
-    constructs "10.1.91"
-    git-url-parse "^13.0.0"
+    codemaker "^1.71.0"
+    constructs "10.1.155"
+    git-url-parse "^13.1.0"
     js-yaml "^4.1.0"
     lodash.camelcase "^4.3.0"
     lodash.kebabcase "^4.1.1"
     lodash.upperfirst "^4.3.1"
     read-pkg-up "7.0.1"
-    yargs "^17.5.1"
+    yargs "^17.6.2"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -562,13 +562,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oclif/core@1.16.0":
-  version "1.16.0"
-  resolved "https://registry.npmjs.org/@oclif/core/-/core-1.16.0.tgz"
-  integrity sha512-xtqhAbjQHBcz+xQpEHJ3eJEVfRQ4zl41Yw5gw/N+D1jgaIUrHTxCY/sfTvhw93LAQo7B++ozHzSb7DISFXsQFQ==
+"@oclif/core@1.20.4":
+  version "1.20.4"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.20.4.tgz#7378b52e1f1b502e383ffb07f95dffc9fd8588ff"
+  integrity sha512-giug32M4YhSYNYKQwE1L57/+k5gp1+Bq3/0vKNQmzAY1tizFGhvBJc6GIRZasHjU+xtZLutQvrVrJo7chX3hxg==
   dependencies:
     "@oclif/linewrap" "^1.0.0"
-    "@oclif/screen" "^3.0.2"
+    "@oclif/screen" "^3.0.3"
     ansi-escapes "^4.3.2"
     ansi-styles "^4.3.0"
     cardinal "^2.1.1"
@@ -592,7 +592,7 @@
     strip-ansi "^6.0.1"
     supports-color "^8.1.1"
     supports-hyperlinks "^2.2.0"
-    tslib "^2.3.1"
+    tslib "^2.4.1"
     widest-line "^3.1.0"
     wrap-ansi "^7.0.0"
 
@@ -601,10 +601,10 @@
   resolved "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz"
   integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
 
-"@oclif/screen@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.2.tgz"
-  integrity sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==
+"@oclif/screen@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-3.0.3.tgz#e679ad10535e31d333f809f7a71335cc9aef1e55"
+  integrity sha512-KX8gMYA9ujBPOd1HFsV9e0iEx7Uoj8AG/3YsW4TtWQTg4lJvr82qNm7o/cFQfYRIt+jw7Ew/4oL4A22zOT+IRA==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -845,10 +845,10 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.39.1:
-  version "2.39.1"
-  resolved "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.39.1.tgz"
-  integrity sha512-+KZBLBoCqq/TnC7LH8JMlQ+5IvKQtu7KHnVDiRmngtibLIXqLMVH4neKimNlSSIKhvSeOmqY2ZCaSp8v5szzrg==
+aws-cdk-lib@2.50.0:
+  version "2.50.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.50.0.tgz#2b3a9ba4c1c4c56fd32e3e4f57eea8bf9fa3dbba"
+  integrity sha512-deDbZTI7oyu3rqUyqjwhP6tnUO8MD70lE98yR65xiYty4yXBpsWKbeH3s1wNLpLAWS3hWJYyMtjZ4ZfC35NtVg==
   dependencies:
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
@@ -857,20 +857,20 @@ aws-cdk-lib@2.39.1:
     jsonschema "^1.4.1"
     minimatch "^3.1.2"
     punycode "^2.1.1"
-    semver "^7.3.7"
+    semver "^7.3.8"
     yaml "1.10.2"
 
-aws-cdk@2.39.1:
-  version "2.39.1"
-  resolved "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.39.1.tgz"
-  integrity sha512-HWruCkbsKJcFOKlVbcIQk/704PdPLHCkSpXNZK6BTpHB46bM49jLyQisgnbcPUc7Imk2k7kW6pe5Zvx1hFleMA==
+aws-cdk@2.50.0:
+  version "2.50.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.50.0.tgz#6c6d723ba66b24245f58c363071ce20a17eabbed"
+  integrity sha512-55vmKTf2DZRqioumVfXn+S0H9oAbpRK3HFHY8EjZ5ykR5tq2+XiMWEZkYduX2HJhVAeHJJIS6h+Okk3smZjeqw==
   optionalDependencies:
     fsevents "2.3.2"
 
-aws-sdk@^2.1209.0:
-  version "2.1218.0"
-  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1218.0.tgz"
-  integrity sha512-oreF2jKfUZ8VKnIKh8TrOOOsdSfv87jHGtWQNAHdvfeyrYK5FrnvGkHUZ3bu6g6u1gHwu5FhTPiRMbgS8Re+NA==
+aws-sdk@^2.1252.0:
+  version "2.1257.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1257.0.tgz#8ed8ca99f97dc642fce98dac7d5eb18e94ae9833"
+  integrity sha512-SNfKIVlJdLyBbUSGgvsBOuV4iOE1modoKOhnV/bIi2F7DJkq4SCPmrN1nwLNBnOQQvZRlPwFbHPVrJ3clTXLDQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -1116,15 +1116,24 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
-codemaker@^1.67.0:
-  version "1.67.0"
-  resolved "https://registry.npmjs.org/codemaker/-/codemaker-1.67.0.tgz"
-  integrity sha512-ChqnwbXIDIq8EAju+OMOnuzJ5MQWXvFaf4PMZo2RLbLiqUfx4+ATv/i1y0rY5uZ7nvKC8lRfwmbRsgsbWQHAhA==
+codemaker@^1.71.0:
+  version "1.71.0"
+  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.71.0.tgz#f065b290f33e730c877642d9456671470d3e5c38"
+  integrity sha512-kjpPxr5TRMYr2BG0EP9IEjQAeE6lTT9fybnCBxQdw3ebVoG8pvMshsQmoMwreL7IaloV8EYIkA+cfr/UpQ6CCg==
   dependencies:
     camelcase "^6.3.0"
     decamelize "^5.0.1"
@@ -1171,10 +1180,10 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-constructs@10.1.91:
-  version "10.1.91"
-  resolved "https://registry.npmjs.org/constructs/-/constructs-10.1.91.tgz"
-  integrity sha512-qf5beNs2Fv9nhlzWXk1PB1AdZfAodbgepKQCkUli/H+X8EafvqC0/2o2heAAp8IrUJxLnGfC4TCz9OHtx1eESA==
+constructs@10.1.155:
+  version "10.1.155"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.1.155.tgz#dcef1545f3fd6ec379702ee0d52aa27c9cffccaa"
+  integrity sha512-AM8HdZ1GQbOLBmnIU5ybyerNeNn9iEZSZZra+2BWuAhyaA+zJb9oxwxD3isM2uxZviB5NHGhZI83plmhOuh29A==
 
 convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"
@@ -1614,9 +1623,9 @@ git-up@^7.0.0:
     is-ssh "^1.4.0"
     parse-url "^8.1.0"
 
-git-url-parse@^13.0.0:
+git-url-parse@^13.1.0:
   version "13.1.0"
-  resolved "https://registry.npmjs.org/git-url-parse/-/git-url-parse-13.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-13.1.0.tgz#07e136b5baa08d59fabdf0e33170de425adf07b4"
   integrity sha512-5FvPJP/70WkIprlUZ33bm4UAaFdjcLkJLpWft1BeZKqwR0uhhNGoKwlUaPtVb4LxCSQ++erHapRak9kWGj+FCA==
   dependencies:
     git-up "^7.0.0"
@@ -3074,6 +3083,13 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz"
@@ -3353,10 +3369,10 @@ ts-jest@^27.1.4:
     semver "7.x"
     yargs-parser "20.x"
 
-tslib@^2.3.1:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+tslib@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -3632,9 +3648,9 @@ yargs-parser@20.x, yargs-parser@^20.2.2:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-parser@^21.0.0:
+yargs-parser@^21.1.1:
   version "21.1.1"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^16.2.0:
@@ -3650,15 +3666,15 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.5.1:
-  version "17.5.1"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz"
-  integrity sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==
+yargs@^17.6.2:
+  version "17.6.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
+  integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
   dependencies:
-    cliui "^7.0.2"
+    cliui "^8.0.1"
     escalade "^3.1.1"
     get-caller-file "^2.0.5"
     require-directory "^2.1.1"
     string-width "^4.2.3"
     y18n "^5.0.5"
-    yargs-parser "^21.0.0"
+    yargs-parser "^21.1.1"


### PR DESCRIPTION
## What does this change?

We need to be on a very recent GuCDK version in order to use the new constructs for error budget alerting (https://github.com/guardian/cdk/pull/1576). Consequently, this PR upgrades GuCDK to the latest version. We also update the AWS cdk dependencies to match the versions that GuCDK needs.

## How to test

The snapshot tests indicate that the `gu:cdk:version` tag is the only thing that's changing. I have also deployed the relevant projects to `CODE`[^1] to confirm that the deployments work and that no resources are deleted.

## How can we measure success?

Everything should continue working as before, but we'll be able to make use of `GuErrorBudgetAlarmExperimental` in a future PR.

## Have we considered potential risks?

Yes, this should be pretty low risk as the only changes caused by this upgrade are related to tagging.

Although there is a major version bump here [the associated breaking change](https://github.com/guardian/cdk/pull/1504) does not seem to be relevant to this AWS account (as the Mobile VPCs were not created via GuCDK).

[^1]: [`mobile-n10n:sender-worker`](https://riffraff.gutools.co.uk/deployment/view/99f7866e-53d6-419c-89c0-583ff98ee0f3), [`mobile-n10n:notificationworkerlambda`](https://riffraff.gutools.co.uk/deployment/view/854e696e-d37e-42f5-b2e4-ae541a58a9d9), [`mobile-n10n:slomonitor`](https://riffraff.gutools.co.uk/deployment/view/e4e3632a-6488-4329-976a-68b22527ae15).