### PR TITLE
Set up GuCDK stack for Registration and deploy stage-specific templates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -151,7 +151,8 @@ lazy val registration = project
       "org.tpolecat" %% "doobie-h2"        % doobieVersion % Test
     ),
     riffRaffPackageType := (Debian / packageBin).value,
-    riffRaffArtifactResources += (file(s"registration/conf/${name.value}.yaml"), s"${name.value}-cfn/cfn.yaml"),
+    riffRaffArtifactResources += (file(s"cdk/cdk.out/Registration-CODE.template.json"), s"registration-cfn/Registration-CODE.template.json"),
+    riffRaffArtifactResources += (file(s"cdk/cdk.out/Registration-PROD.template.json"), s"registration-cfn/Registration-PROD.template.json"),
     Debian / packageName := name.value,
     version := projectVersion
   )

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,11 +1,26 @@
 import 'source-map-support/register';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { App } from 'aws-cdk-lib';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
+import { Registration } from '../lib/registration';
 import { RegistrationsDbProxy } from '../lib/registrations-db-proxy';
 import { SenderWorkerStack } from '../lib/sender-stack';
 import { SloMonitoring } from '../lib/slo-monitoring';
 
 const app = new App();
+
+export const registrationCodeProps: GuStackProps = {
+	stack: 'mobile-notifications',
+	stage: 'CODE',
+};
+
+export const registrationProdProps: GuStackProps = {
+	stack: 'mobile-notifications',
+	stage: 'PROD',
+};
+
+new Registration(app, 'Registration-CODE', registrationCodeProps);
+new Registration(app, 'Registration-PROD', registrationProdProps);
 
 export const dbProxyCodeProps = {
 	stack: 'mobile-notifications',

--- a/cdk/lib/__snapshots__/registration.test.ts.snap
+++ b/cdk/lib/__snapshots__/registration.test.ts.snap
@@ -1,0 +1,1595 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The Registration stack matches the snapshot for CODE 1`] = `
+Object {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Registration for mobile notifications",
+  "Mappings": Object {
+    "Constants": Object {
+      "App": Object {
+        "Value": "registration",
+      },
+      "Stack": Object {
+        "Value": "mobile-notifications",
+      },
+    },
+    "StageVariables": Object {
+      "CODE": Object {
+        "CPUAlarmPeriodLower": 300,
+        "CPUAlarmPeriodUpper": 1200,
+        "CPUAlarmThresholdLower": 20,
+        "CPUAlarmThresholdUpper": 50,
+        "InstanceType": "t4g.micro",
+        "NotificationAlarmPeriod": 1200,
+      },
+      "PROD": Object {
+        "CPUAlarmPeriodLower": 300,
+        "CPUAlarmPeriodUpper": 60,
+        "CPUAlarmThresholdLower": 20,
+        "CPUAlarmThresholdUpper": 50,
+        "InstanceType": "t4g.micro",
+        "NotificationAlarmPeriod": 1200,
+      },
+    },
+  },
+  "Metadata": Object {
+    "gu:cdk:constructs": Array [],
+    "gu:cdk:version": "TEST",
+  },
+  "Outputs": Object {
+    "LoadBalancerUrl": Object {
+      "Value": Object {
+        "Fn::GetAtt": "LoadBalancerToPrivateASG.DNSName",
+      },
+    },
+  },
+  "Parameters": Object {
+    "AMI": Object {
+      "Description": "AMI used by the instances",
+      "Type": "AWS::EC2::Image::Id",
+    },
+    "ASGMaxSize": Object {
+      "Description": "Maximum size of the autoscaling group",
+      "Type": "Number",
+    },
+    "ASGMinSize": Object {
+      "Description": "Minimum size of the autoscaling group",
+      "Type": "Number",
+    },
+    "AlarmTopic": Object {
+      "Description": "The ARN of the SNS topic to send all the cloudwatch alarms to",
+      "Type": "String",
+    },
+    "CertArn": Object {
+      "Description": "ACM Certificate for app use",
+      "Type": "String",
+    },
+    "DistBucket": Object {
+      "Description": "The name of the s3 bucket containing the server artifact",
+      "Type": "String",
+    },
+    "DomainName": Object {
+      "Description": "The domain name of the ELB, should contain the trailing dot stuff.zone.example.com.",
+      "Type": "String",
+    },
+    "HostedZone": Object {
+      "Description": "The HostedZone, should contain the trailing dot zone.example.com.",
+      "Type": "String",
+    },
+    "NotEnough200sPerDayThreshold": Object {
+      "Description": "Alarm if less than too many 200s. This value was based on just below 2 standard deviations from the mean over 6 weeks of data.",
+      "Type": "Number",
+    },
+    "NotEnough200sThreshold": Object {
+      "Description": "Alarm if less than this many 200s in half an hour",
+      "Type": "Number",
+    },
+    "PrivateSubnets": Object {
+      "Description": "The private subnets of the VPC for the autoscaling group",
+      "Type": "List<AWS::EC2::Subnet::Id>",
+    },
+    "PublicSubnets": Object {
+      "Description": "The public subnets of the VPC for the loadbalancer",
+      "Type": "List<AWS::EC2::Subnet::Id>",
+    },
+    "RunbookCopy": Object {
+      "Default": "<<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+      "Type": "String",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Description": "Environment name",
+      "Type": "String",
+    },
+    "VPCSecurityGroup": Object {
+      "Description": "The default security group of the VPC",
+      "Type": "AWS::EC2::SecurityGroup::Id",
+    },
+    "VpcId": Object {
+      "Description": "The VPC",
+      "Type": "AWS::EC2::VPC::Id",
+    },
+  },
+  "Resources": Object {
+    "DistributionInstanceProfile": Object {
+      "Properties": Object {
+        "Path": "/",
+        "Roles": Array [
+          Object {
+            "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "DistributionRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Sub": "arn:aws:iam::\${AWS::AccountId}:policy/ssm-scala-v1",
+          },
+        ],
+        "Path": "/",
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": "s3:GetObject",
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Sub": "arn:aws:s3:::\${DistBucket}/*",
+                  },
+                },
+                Object {
+                  "Action": "ec2:DescribeTags",
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                Object {
+                  "Action": Array [
+                    "cloudwatch:*",
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                Object {
+                  "Action": Array [
+                    "autoscaling:DescribeAutoScalingInstances",
+                    "autoscaling:DescribeAutoScalingGroups",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                Object {
+                  "Action": Array [
+                    "kinesis:PutRecord",
+                    "kinesis:PutRecords",
+                    "kinesis:DescribeStream",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Sub": "arn:aws:kinesis:\${AWS::Region}:\${AWS::AccountId}:stream/mobile-log-aggregation-\${Stage}",
+                  },
+                },
+              ],
+            },
+            "PolicyName": "root",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": "ssm:GetParametersByPath",
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Sub": Array [
+                      "arn:aws:ssm:\${AWS::Region}:\${AWS::AccountId}:parameter/notifications/\${Stage}/\${Stack}",
+                      Object {
+                        "Stack": Object {
+                          "Fn::FindInMap": Array [
+                            "Constants",
+                            "Stack",
+                            "Value",
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": "conf",
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DnsRecord": Object {
+      "Properties": Object {
+        "HostedZoneName": Object {
+          "Ref": "HostedZone",
+        },
+        "Name": Object {
+          "Ref": "DomainName",
+        },
+        "ResourceRecords": Array [
+          Object {
+            "Fn::GetAtt": "LoadBalancerToPrivateASG.DNSName",
+          },
+        ],
+        "TTL": "60",
+        "Type": "CNAME",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "GuardianAccessSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "SSH and management server access from Guardian network",
+        "SecurityGroupIngress": Array [
+          Object {
+            "FromPort": 22,
+            "IpProtocol": "tcp",
+            "SourceSecurityGroupId": Object {
+              "Ref": "VPCSecurityGroup",
+            },
+            "ToPort": 22,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "HighCPUAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "ScaleUpPolicy",
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Sub": Array [
+            "Scale-Up if CPU is greater than \${CPUAlarmThresholdUpper} % over last \${CPUAlarmPeriodUpper} seconds",
+            Object {
+              "CPUAlarmPeriodUpper": Object {
+                "Fn::FindInMap": Array [
+                  "StageVariables",
+                  Object {
+                    "Ref": "Stage",
+                  },
+                  "CPUAlarmThresholdUpper",
+                ],
+              },
+              "CPUAlarmThresholdUpper": Object {
+                "Fn::FindInMap": Array [
+                  "StageVariables",
+                  Object {
+                    "Ref": "Stage",
+                  },
+                  "CPUAlarmThresholdUpper",
+                ],
+              },
+            },
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "AutoScalingGroupName",
+            "Value": Object {
+              "Ref": "PrivateRegistrationAutoscalingGroup",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "CPUUtilization",
+        "Namespace": "AWS/EC2",
+        "Period": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "CPUAlarmPeriodUpper",
+          ],
+        },
+        "Statistic": "Average",
+        "Threshold": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "CPUAlarmThresholdUpper",
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "InstanceSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Open up HTTP access to load balancer",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 80,
+            "IpProtocol": "tcp",
+            "ToPort": 80,
+          },
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "FromPort": 9000,
+            "IpProtocol": "tcp",
+            "SourceSecurityGroupId": Object {
+              "Ref": "LoadBalancerSecurityGroup",
+            },
+            "ToPort": 9000,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Open up HTTP access to load balancer",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 9000,
+            "IpProtocol": "tcp",
+            "ToPort": 9000,
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerToPrivateASG": Object {
+      "Properties": Object {
+        "CrossZone": true,
+        "HealthCheck": Object {
+          "HealthyThreshold": "2",
+          "Interval": "30",
+          "Target": "HTTP:9000/healthcheck",
+          "Timeout": "10",
+          "UnhealthyThreshold": "10",
+        },
+        "Listeners": Array [
+          Object {
+            "InstancePort": "9000",
+            "LoadBalancerPort": "443",
+            "Protocol": "HTTPS",
+            "SSLCertificateId": Object {
+              "Fn::Sub": "\${CertArn}",
+            },
+          },
+        ],
+        "SecurityGroups": Array [
+          Object {
+            "Ref": "LoadBalancerSecurityGroup",
+          },
+        ],
+        "Subnets": Object {
+          "Ref": "PublicSubnets",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+    },
+    "LowCPUAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "ScaleDownPolicy",
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Sub": Array [
+            "Scale-Down if CPU is less than \${CPUAlarmThresholdLower} % over last \${CPUAlarmPeriodLower} seconds",
+            Object {
+              "CPUAlarmPeriodLower": Object {
+                "Fn::FindInMap": Array [
+                  "StageVariables",
+                  Object {
+                    "Ref": "Stage",
+                  },
+                  "CPUAlarmPeriodLower",
+                ],
+              },
+              "CPUAlarmThresholdLower": Object {
+                "Fn::FindInMap": Array [
+                  "StageVariables",
+                  Object {
+                    "Ref": "Stage",
+                  },
+                  "CPUAlarmThresholdLower",
+                ],
+              },
+            },
+          ],
+        },
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "AutoScalingGroupName",
+            "Value": Object {
+              "Ref": "PrivateRegistrationAutoscalingGroup",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "CPUUtilization",
+        "Namespace": "AWS/EC2",
+        "Period": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "CPUAlarmPeriodLower",
+          ],
+        },
+        "Statistic": "Average",
+        "Threshold": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "CPUAlarmThresholdLower",
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NotEnoughHttpCode200sAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "AlarmTopic",
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Sub": "Triggers if load balancer in \${Stage} does not have enough 200s in half an hour. \${RunbookCopy}",
+        },
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancerName",
+            "Value": Object {
+              "Ref": "LoadBalancerToPrivateASG",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "HTTPCode_Backend_2XX",
+        "Namespace": "AWS/ELB",
+        "OKActions": Array [
+          Object {
+            "Ref": "AlarmTopic",
+          },
+        ],
+        "Period": 1800,
+        "Statistic": "Sum",
+        "Threshold": Object {
+          "Ref": "NotEnough200sThreshold",
+        },
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NotEnoughHttpCode200sPerDayAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "AlarmTopic",
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Sub": "Triggers if load balancer in \${Stage} does not have enough 200s in a whole day. \${RunbookCopy}",
+        },
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancerName",
+            "Value": Object {
+              "Ref": "LoadBalancerToPrivateASG",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "HTTPCode_Backend_2XX",
+        "Namespace": "AWS/ELB",
+        "OKActions": Array [
+          Object {
+            "Ref": "AlarmTopic",
+          },
+        ],
+        "Period": 86400,
+        "Statistic": "Sum",
+        "Threshold": Object {
+          "Ref": "NotEnough200sPerDayThreshold",
+        },
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "PrivateRegistrationAutoscalingGroup": Object {
+      "Properties": Object {
+        "AvailabilityZones": Object {
+          "Fn::GetAZs": "",
+        },
+        "HealthCheckGracePeriod": 400,
+        "HealthCheckType": "ELB",
+        "LaunchConfigurationName": Object {
+          "Ref": "RegistrationLaunchConfig",
+        },
+        "LoadBalancerNames": Array [
+          Object {
+            "Ref": "LoadBalancerToPrivateASG",
+          },
+        ],
+        "MaxSize": Object {
+          "Ref": "ASGMaxSize",
+        },
+        "MinSize": Object {
+          "Ref": "ASGMinSize",
+        },
+        "NotificationConfiguration": Object {
+          "NotificationTypes": Array [
+            "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+            "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
+          ],
+          "TopicARN": Object {
+            "Fn::Sub": "arn:aws:sns:eu-west-1:\${AWS::AccountId}:AutoscalingNotifications\${Stage}",
+          },
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": Object {
+              "Fn::FindInMap": Array [
+                "Constants",
+                "App",
+                "Value",
+              ],
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/mobile-n10n",
+          },
+          Object {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "mobile-notifications",
+          },
+          Object {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "CODE",
+          },
+        ],
+        "VPCZoneIdentifier": Object {
+          "Ref": "PrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "RegistrationLaunchConfig": Object {
+      "Properties": Object {
+        "AssociatePublicIpAddress": false,
+        "IamInstanceProfile": Object {
+          "Ref": "DistributionInstanceProfile",
+        },
+        "ImageId": Object {
+          "Ref": "AMI",
+        },
+        "InstanceType": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "InstanceType",
+          ],
+        },
+        "MetadataOptions": Object {
+          "HttpTokens": "required",
+        },
+        "SecurityGroups": Array [
+          Object {
+            "Ref": "InstanceSecurityGroup",
+          },
+          Object {
+            "Ref": "GuardianAccessSecurityGroup",
+          },
+          Object {
+            "Ref": "VPCSecurityGroup",
+          },
+        ],
+        "UserData": Object {
+          "Fn::Base64": Object {
+            "Fn::Sub": Array [
+              "#!/bin/bash -ev
+aws --region \${AWS::Region} s3 cp s3://\${DistBucket}/\${Stack}/\${Stage}/\${App}/\${App}_1.0-latest_all.deb /tmp
+dpkg -i /tmp/\${App}_1.0-latest_all.deb
+/opt/aws-kinesis-agent/configure-aws-kinesis-agent \${AWS::Region} mobile-log-aggregation-\${Stage} /var/log/\${App}/application.log
+",
+              Object {
+                "App": Object {
+                  "Fn::FindInMap": Array [
+                    "Constants",
+                    "App",
+                    "Value",
+                  ],
+                },
+                "Stack": Object {
+                  "Fn::FindInMap": Array [
+                    "Constants",
+                    "Stack",
+                    "Value",
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+    },
+    "ScaleDownPolicy": Object {
+      "Properties": Object {
+        "AdjustmentType": "ChangeInCapacity",
+        "AutoScalingGroupName": Object {
+          "Ref": "PrivateRegistrationAutoscalingGroup",
+        },
+        "Cooldown": "3600",
+        "ScalingAdjustment": -1,
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "ScaleUpPolicy": Object {
+      "Properties": Object {
+        "AdjustmentType": "PercentChangeInCapacity",
+        "AutoScalingGroupName": Object {
+          "Ref": "PrivateRegistrationAutoscalingGroup",
+        },
+        "Cooldown": "300",
+        "ScalingAdjustment": 100,
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+  },
+}
+`;
+
+exports[`The Registration stack matches the snapshot for PROD 1`] = `
+Object {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Registration for mobile notifications",
+  "Mappings": Object {
+    "Constants": Object {
+      "App": Object {
+        "Value": "registration",
+      },
+      "Stack": Object {
+        "Value": "mobile-notifications",
+      },
+    },
+    "StageVariables": Object {
+      "CODE": Object {
+        "CPUAlarmPeriodLower": 300,
+        "CPUAlarmPeriodUpper": 1200,
+        "CPUAlarmThresholdLower": 20,
+        "CPUAlarmThresholdUpper": 50,
+        "InstanceType": "t4g.micro",
+        "NotificationAlarmPeriod": 1200,
+      },
+      "PROD": Object {
+        "CPUAlarmPeriodLower": 300,
+        "CPUAlarmPeriodUpper": 60,
+        "CPUAlarmThresholdLower": 20,
+        "CPUAlarmThresholdUpper": 50,
+        "InstanceType": "t4g.micro",
+        "NotificationAlarmPeriod": 1200,
+      },
+    },
+  },
+  "Metadata": Object {
+    "gu:cdk:constructs": Array [],
+    "gu:cdk:version": "TEST",
+  },
+  "Outputs": Object {
+    "LoadBalancerUrl": Object {
+      "Value": Object {
+        "Fn::GetAtt": "LoadBalancerToPrivateASG.DNSName",
+      },
+    },
+  },
+  "Parameters": Object {
+    "AMI": Object {
+      "Description": "AMI used by the instances",
+      "Type": "AWS::EC2::Image::Id",
+    },
+    "ASGMaxSize": Object {
+      "Description": "Maximum size of the autoscaling group",
+      "Type": "Number",
+    },
+    "ASGMinSize": Object {
+      "Description": "Minimum size of the autoscaling group",
+      "Type": "Number",
+    },
+    "AlarmTopic": Object {
+      "Description": "The ARN of the SNS topic to send all the cloudwatch alarms to",
+      "Type": "String",
+    },
+    "CertArn": Object {
+      "Description": "ACM Certificate for app use",
+      "Type": "String",
+    },
+    "DistBucket": Object {
+      "Description": "The name of the s3 bucket containing the server artifact",
+      "Type": "String",
+    },
+    "DomainName": Object {
+      "Description": "The domain name of the ELB, should contain the trailing dot stuff.zone.example.com.",
+      "Type": "String",
+    },
+    "HostedZone": Object {
+      "Description": "The HostedZone, should contain the trailing dot zone.example.com.",
+      "Type": "String",
+    },
+    "NotEnough200sPerDayThreshold": Object {
+      "Description": "Alarm if less than too many 200s. This value was based on just below 2 standard deviations from the mean over 6 weeks of data.",
+      "Type": "Number",
+    },
+    "NotEnough200sThreshold": Object {
+      "Description": "Alarm if less than this many 200s in half an hour",
+      "Type": "Number",
+    },
+    "PrivateSubnets": Object {
+      "Description": "The private subnets of the VPC for the autoscaling group",
+      "Type": "List<AWS::EC2::Subnet::Id>",
+    },
+    "PublicSubnets": Object {
+      "Description": "The public subnets of the VPC for the loadbalancer",
+      "Type": "List<AWS::EC2::Subnet::Id>",
+    },
+    "RunbookCopy": Object {
+      "Default": "<<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+      "Type": "String",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Description": "Environment name",
+      "Type": "String",
+    },
+    "VPCSecurityGroup": Object {
+      "Description": "The default security group of the VPC",
+      "Type": "AWS::EC2::SecurityGroup::Id",
+    },
+    "VpcId": Object {
+      "Description": "The VPC",
+      "Type": "AWS::EC2::VPC::Id",
+    },
+  },
+  "Resources": Object {
+    "DistributionInstanceProfile": Object {
+      "Properties": Object {
+        "Path": "/",
+        "Roles": Array [
+          Object {
+            "Ref": "DistributionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "DistributionRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Sub": "arn:aws:iam::\${AWS::AccountId}:policy/ssm-scala-v1",
+          },
+        ],
+        "Path": "/",
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": "s3:GetObject",
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Sub": "arn:aws:s3:::\${DistBucket}/*",
+                  },
+                },
+                Object {
+                  "Action": "ec2:DescribeTags",
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                Object {
+                  "Action": Array [
+                    "cloudwatch:*",
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                Object {
+                  "Action": Array [
+                    "autoscaling:DescribeAutoScalingInstances",
+                    "autoscaling:DescribeAutoScalingGroups",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                Object {
+                  "Action": Array [
+                    "kinesis:PutRecord",
+                    "kinesis:PutRecords",
+                    "kinesis:DescribeStream",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Sub": "arn:aws:kinesis:\${AWS::Region}:\${AWS::AccountId}:stream/mobile-log-aggregation-\${Stage}",
+                  },
+                },
+              ],
+            },
+            "PolicyName": "root",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": "ssm:GetParametersByPath",
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Sub": Array [
+                      "arn:aws:ssm:\${AWS::Region}:\${AWS::AccountId}:parameter/notifications/\${Stage}/\${Stack}",
+                      Object {
+                        "Stack": Object {
+                          "Fn::FindInMap": Array [
+                            "Constants",
+                            "Stack",
+                            "Value",
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": "conf",
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DnsRecord": Object {
+      "Properties": Object {
+        "HostedZoneName": Object {
+          "Ref": "HostedZone",
+        },
+        "Name": Object {
+          "Ref": "DomainName",
+        },
+        "ResourceRecords": Array [
+          Object {
+            "Fn::GetAtt": "LoadBalancerToPrivateASG.DNSName",
+          },
+        ],
+        "TTL": "60",
+        "Type": "CNAME",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "GuardianAccessSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "SSH and management server access from Guardian network",
+        "SecurityGroupIngress": Array [
+          Object {
+            "FromPort": 22,
+            "IpProtocol": "tcp",
+            "SourceSecurityGroupId": Object {
+              "Ref": "VPCSecurityGroup",
+            },
+            "ToPort": 22,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "HighCPUAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "ScaleUpPolicy",
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Sub": Array [
+            "Scale-Up if CPU is greater than \${CPUAlarmThresholdUpper} % over last \${CPUAlarmPeriodUpper} seconds",
+            Object {
+              "CPUAlarmPeriodUpper": Object {
+                "Fn::FindInMap": Array [
+                  "StageVariables",
+                  Object {
+                    "Ref": "Stage",
+                  },
+                  "CPUAlarmThresholdUpper",
+                ],
+              },
+              "CPUAlarmThresholdUpper": Object {
+                "Fn::FindInMap": Array [
+                  "StageVariables",
+                  Object {
+                    "Ref": "Stage",
+                  },
+                  "CPUAlarmThresholdUpper",
+                ],
+              },
+            },
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "AutoScalingGroupName",
+            "Value": Object {
+              "Ref": "PrivateRegistrationAutoscalingGroup",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "CPUUtilization",
+        "Namespace": "AWS/EC2",
+        "Period": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "CPUAlarmPeriodUpper",
+          ],
+        },
+        "Statistic": "Average",
+        "Threshold": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "CPUAlarmThresholdUpper",
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "InstanceSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Open up HTTP access to load balancer",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 80,
+            "IpProtocol": "tcp",
+            "ToPort": 80,
+          },
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "FromPort": 9000,
+            "IpProtocol": "tcp",
+            "SourceSecurityGroupId": Object {
+              "Ref": "LoadBalancerSecurityGroup",
+            },
+            "ToPort": 9000,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Open up HTTP access to load balancer",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 9000,
+            "IpProtocol": "tcp",
+            "ToPort": 9000,
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerToPrivateASG": Object {
+      "Properties": Object {
+        "CrossZone": true,
+        "HealthCheck": Object {
+          "HealthyThreshold": "2",
+          "Interval": "30",
+          "Target": "HTTP:9000/healthcheck",
+          "Timeout": "10",
+          "UnhealthyThreshold": "10",
+        },
+        "Listeners": Array [
+          Object {
+            "InstancePort": "9000",
+            "LoadBalancerPort": "443",
+            "Protocol": "HTTPS",
+            "SSLCertificateId": Object {
+              "Fn::Sub": "\${CertArn}",
+            },
+          },
+        ],
+        "SecurityGroups": Array [
+          Object {
+            "Ref": "LoadBalancerSecurityGroup",
+          },
+        ],
+        "Subnets": Object {
+          "Ref": "PublicSubnets",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+    },
+    "LowCPUAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "ScaleDownPolicy",
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Sub": Array [
+            "Scale-Down if CPU is less than \${CPUAlarmThresholdLower} % over last \${CPUAlarmPeriodLower} seconds",
+            Object {
+              "CPUAlarmPeriodLower": Object {
+                "Fn::FindInMap": Array [
+                  "StageVariables",
+                  Object {
+                    "Ref": "Stage",
+                  },
+                  "CPUAlarmPeriodLower",
+                ],
+              },
+              "CPUAlarmThresholdLower": Object {
+                "Fn::FindInMap": Array [
+                  "StageVariables",
+                  Object {
+                    "Ref": "Stage",
+                  },
+                  "CPUAlarmThresholdLower",
+                ],
+              },
+            },
+          ],
+        },
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "AutoScalingGroupName",
+            "Value": Object {
+              "Ref": "PrivateRegistrationAutoscalingGroup",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "CPUUtilization",
+        "Namespace": "AWS/EC2",
+        "Period": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "CPUAlarmPeriodLower",
+          ],
+        },
+        "Statistic": "Average",
+        "Threshold": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "CPUAlarmThresholdLower",
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NotEnoughHttpCode200sAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "AlarmTopic",
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Sub": "Triggers if load balancer in \${Stage} does not have enough 200s in half an hour. \${RunbookCopy}",
+        },
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancerName",
+            "Value": Object {
+              "Ref": "LoadBalancerToPrivateASG",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "HTTPCode_Backend_2XX",
+        "Namespace": "AWS/ELB",
+        "OKActions": Array [
+          Object {
+            "Ref": "AlarmTopic",
+          },
+        ],
+        "Period": 1800,
+        "Statistic": "Sum",
+        "Threshold": Object {
+          "Ref": "NotEnough200sThreshold",
+        },
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "NotEnoughHttpCode200sPerDayAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "AlarmTopic",
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Sub": "Triggers if load balancer in \${Stage} does not have enough 200s in a whole day. \${RunbookCopy}",
+        },
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancerName",
+            "Value": Object {
+              "Ref": "LoadBalancerToPrivateASG",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "HTTPCode_Backend_2XX",
+        "Namespace": "AWS/ELB",
+        "OKActions": Array [
+          Object {
+            "Ref": "AlarmTopic",
+          },
+        ],
+        "Period": 86400,
+        "Statistic": "Sum",
+        "Threshold": Object {
+          "Ref": "NotEnough200sPerDayThreshold",
+        },
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "PrivateRegistrationAutoscalingGroup": Object {
+      "Properties": Object {
+        "AvailabilityZones": Object {
+          "Fn::GetAZs": "",
+        },
+        "HealthCheckGracePeriod": 400,
+        "HealthCheckType": "ELB",
+        "LaunchConfigurationName": Object {
+          "Ref": "RegistrationLaunchConfig",
+        },
+        "LoadBalancerNames": Array [
+          Object {
+            "Ref": "LoadBalancerToPrivateASG",
+          },
+        ],
+        "MaxSize": Object {
+          "Ref": "ASGMaxSize",
+        },
+        "MinSize": Object {
+          "Ref": "ASGMinSize",
+        },
+        "NotificationConfiguration": Object {
+          "NotificationTypes": Array [
+            "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+            "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
+          ],
+          "TopicARN": Object {
+            "Fn::Sub": "arn:aws:sns:eu-west-1:\${AWS::AccountId}:AutoscalingNotifications\${Stage}",
+          },
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": Object {
+              "Fn::FindInMap": Array [
+                "Constants",
+                "App",
+                "Value",
+              ],
+            },
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/mobile-n10n",
+          },
+          Object {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "mobile-notifications",
+          },
+          Object {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "PROD",
+          },
+        ],
+        "VPCZoneIdentifier": Object {
+          "Ref": "PrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "RegistrationLaunchConfig": Object {
+      "Properties": Object {
+        "AssociatePublicIpAddress": false,
+        "IamInstanceProfile": Object {
+          "Ref": "DistributionInstanceProfile",
+        },
+        "ImageId": Object {
+          "Ref": "AMI",
+        },
+        "InstanceType": Object {
+          "Fn::FindInMap": Array [
+            "StageVariables",
+            Object {
+              "Ref": "Stage",
+            },
+            "InstanceType",
+          ],
+        },
+        "MetadataOptions": Object {
+          "HttpTokens": "required",
+        },
+        "SecurityGroups": Array [
+          Object {
+            "Ref": "InstanceSecurityGroup",
+          },
+          Object {
+            "Ref": "GuardianAccessSecurityGroup",
+          },
+          Object {
+            "Ref": "VPCSecurityGroup",
+          },
+        ],
+        "UserData": Object {
+          "Fn::Base64": Object {
+            "Fn::Sub": Array [
+              "#!/bin/bash -ev
+aws --region \${AWS::Region} s3 cp s3://\${DistBucket}/\${Stack}/\${Stage}/\${App}/\${App}_1.0-latest_all.deb /tmp
+dpkg -i /tmp/\${App}_1.0-latest_all.deb
+/opt/aws-kinesis-agent/configure-aws-kinesis-agent \${AWS::Region} mobile-log-aggregation-\${Stage} /var/log/\${App}/application.log
+",
+              Object {
+                "App": Object {
+                  "Fn::FindInMap": Array [
+                    "Constants",
+                    "App",
+                    "Value",
+                  ],
+                },
+                "Stack": Object {
+                  "Fn::FindInMap": Array [
+                    "Constants",
+                    "Stack",
+                    "Value",
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+    },
+    "ScaleDownPolicy": Object {
+      "Properties": Object {
+        "AdjustmentType": "ChangeInCapacity",
+        "AutoScalingGroupName": Object {
+          "Ref": "PrivateRegistrationAutoscalingGroup",
+        },
+        "Cooldown": "3600",
+        "ScalingAdjustment": -1,
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "ScaleUpPolicy": Object {
+      "Properties": Object {
+        "AdjustmentType": "PercentChangeInCapacity",
+        "AutoScalingGroupName": Object {
+          "Ref": "PrivateRegistrationAutoscalingGroup",
+        },
+        "Cooldown": "300",
+        "ScalingAdjustment": 100,
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+  },
+}
+`;

--- a/cdk/lib/registration.test.ts
+++ b/cdk/lib/registration.test.ts
@@ -1,0 +1,27 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { registrationCodeProps, registrationProdProps } from '../bin/cdk';
+import { Registration } from './registration';
+
+describe('The Registration stack', () => {
+	it('matches the snapshot for CODE', () => {
+		const app = new App();
+		const stack = new Registration(
+			app,
+			'Registration-CODE',
+			registrationCodeProps,
+		);
+		const template = Template.fromStack(stack);
+		expect(template.toJSON()).toMatchSnapshot();
+	});
+	it('matches the snapshot for PROD', () => {
+		const app = new App();
+		const stack = new Registration(
+			app,
+			'Registration-PROD',
+			registrationProdProps,
+		);
+		const template = Template.fromStack(stack);
+		expect(template.toJSON()).toMatchSnapshot();
+	});
+});

--- a/cdk/lib/registration.ts
+++ b/cdk/lib/registration.ts
@@ -1,0 +1,21 @@
+import { join } from 'path';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import type { App } from 'aws-cdk-lib';
+import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
+
+export class Registration extends GuStack {
+	constructor(scope: App, id: string, props: GuStackProps) {
+		super(scope, id, props);
+		const yamlTemplateFilePath = join(
+			__dirname,
+			'../../registration/conf/registration.yaml',
+		);
+		// Until this project has been fully migrated to GuCDK you should update the 'old' infrastructure by modifying
+		// the YAML file and then re-running the snapshot tests to confirm that the changes are being pulled through by
+		// CDK
+		new CfnInclude(this, 'YamlTemplate', {
+			templateFile: yamlTemplateFilePath,
+		});
+	}
+}

--- a/registration/conf/registration.yaml
+++ b/registration/conf/registration.yaml
@@ -1,3 +1,6 @@
+# The infrastructure in this file is now ingested and built via CDK before deployment (i.e. this file is no longer
+# directly uploaded to Riff-Raff). You can edit this file as normal, but you must update the CDK snapshot tests in order
+# to get CI to pass.
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Registration for mobile notifications
 Mappings:

--- a/registration/conf/riff-raff.yaml
+++ b/registration/conf/riff-raff.yaml
@@ -8,7 +8,9 @@ deployments:
       amiTags:
         Recipe: bionic-mobile-ARM
         AmigoStage: PROD
-      templatePath: cfn.yaml
+      templateStagePaths:
+        CODE: Registration-CODE.template.json
+        PROD: Registration-PROD.template.json
   registration:
     type: autoscaling
     parameters:


### PR DESCRIPTION
## What does this change?

We would like to use the new constructs for error budget alerting (https://github.com/guardian/cdk/pull/1576) so that we receive warnings if we are at risk of missing SLO(s) for the Registration service.

This PR imports the Registration YAML via GuCDK in order to configure these alerts, as doing so will make it easier[^1] to reference the correct metrics in TypeScript code and also simplifies deploying the error budget alarm configuration via Riff-Raff. Finally, the work here is the [first step in migrating the Registration app to GuCDK](https://github.com/guardian/cdk/blob/main/docs/migration-guide.md#introduce-cdk-to-the-repository-with-cicd)[^2], so we will need to do it at some point anyway! 

cc @guardian/devx-reliability 

## How to test

This shouldn't change any behaviour - I've [deployed to `CODE`](https://riffraff.gutools.co.uk/deployment/view/4837ee12-d059-4ef3-855b-dab753eaf464) and can see that resources are being updated (but, crucially, not deleted/replaced!) by this change:

![image](https://user-images.githubusercontent.com/19384074/203331462-6a9ab4e1-e82c-47ad-ace4-2c0a2e5e5435.png)

The updates are just GuCDK automatically tagging resources e.g.

![image](https://user-images.githubusercontent.com/19384074/203331729-4f3a1806-f841-4561-8cf7-8324c3c0b7bf.png)

## How can we measure success?

* Everything should continue working as before, but we'll be able to make use of `GuErrorBudgetAlarmExperimental` more easily in a future PR.
* There is slightly less work to do when we decide to migrate Registration to GuCDK.

## Have we considered potential risks?

We are moving to two separate infrastructure definition files here (one for `CODE` and one for `PROD`) so there is a risk that I've made a typo and wired things up incorrectly (although I will test in `CODE` there are now some `PROD`-specific errors that would be missed via testing, so a careful review would be much appreciated!).

Lastly, operating in this partially-migrated state means that the process for updating the infrastructure for Registration could be slightly more confusing than before (you need to update the YAML and then update the snapshot tests); I've tried to mitigate this with comments to explain the new process.

[^1]: That said, it is not strictly necessary to do this now - we could just deploy a standalone alerting stack and reference the SLI metrics by hardcoding the names as strings. If you'd prefer not to import the current template let me know and I'll take a different approach.
[^2]: It's a slightly amended version of the steps described in the GuCDK migration docs, since this repo already includes the GuCDK library; the end result is the same. In other words, when you decide to fully migrate Registration to GuCDK, you'll be able to start [here](https://github.com/guardian/cdk/blob/main/docs/migration-guide-ec2.md).