### PR TITLE
LIVE-4729 Separate AWS metric namespaces for sender lambda and EC2 sender

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -15,14 +15,14 @@ import java.util.UUID
 import java.util.concurrent.Executors
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
-class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Option[String]) extends SenderRequestHandler[FcmClient] {
+class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Option[String], val metricNs: String) extends SenderRequestHandler[FcmClient] {
 
   def this() = {
-    this(Configuration.fetchFirebase(), None)
+    this(Configuration.fetchFirebase(), None, "workers")
   }
 
   val cleaningClient = new CleaningClientImpl(config.cleaningSqsUrl)
-  val cloudwatch: Cloudwatch = new CloudwatchImpl
+  val cloudwatch: Cloudwatch = new CloudwatchImpl(metricNs)
 
   override implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(config.threadPoolSize))
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -197,7 +197,7 @@ class Harvester extends HarvesterRequestHandler {
 
   override val jdbcConfig: JdbcConfig = config.jdbcConfig
 
-  override val cloudwatch: Cloudwatch = new CloudwatchImpl
+  override val cloudwatch: Cloudwatch = new CloudwatchImpl("workers")
 
   override val lambdaServiceSet = SqsDeliveryStack(
    iosLiveDeliveryService = new SqsDeliveryServiceImpl[IO](config.iosLiveSqsUrl),

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/IOSSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/IOSSender.scala
@@ -8,14 +8,14 @@ import com.gu.notifications.worker.utils.{Cloudwatch, CloudwatchImpl}
 import java.util.concurrent.Executors
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
-class IOSSender(val config: ApnsWorkerConfiguration) extends SenderRequestHandler[ApnsClient] {
+class IOSSender(val config: ApnsWorkerConfiguration, val metricNs: String) extends SenderRequestHandler[ApnsClient] {
 
   def this() = {
-    this(Configuration.fetchApns())
+    this(Configuration.fetchApns(), "workers")
   }
 
   val cleaningClient = new CleaningClientImpl(config.cleaningSqsUrl)
-  val cloudwatch: Cloudwatch = new CloudwatchImpl
+  val cloudwatch: Cloudwatch = new CloudwatchImpl(metricNs)
 
   override implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(config.threadPoolSize))
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Cloudwatch.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Cloudwatch.scala
@@ -21,7 +21,7 @@ trait Cloudwatch {
   def sendFailures(stage: String, platform: Platform): Pipe[IO, Throwable, Unit]
 }
 
-class CloudwatchImpl extends Cloudwatch {
+class CloudwatchImpl(val senderMetricNs: String) extends Cloudwatch {
 
   lazy val cloudwatchClient: AmazonCloudWatch = AmazonCloudWatchClientBuilder
     .standard()
@@ -52,7 +52,7 @@ class CloudwatchImpl extends Cloudwatch {
         countDatum("total", results.total, dimension)
       )
       val req = new PutMetricDataRequest()
-        .withNamespace(s"Notifications/$stage/workers")
+        .withNamespace(s"Notifications/$stage/$senderMetricNs")
         .withMetricData(metrics.asJava)
       cloudwatchClient.putMetricData(req)
       ()
@@ -68,7 +68,7 @@ class CloudwatchImpl extends Cloudwatch {
           perfMetricDatum("worker.functionProcessingRate", StandardUnit.None, performanceData.functionProcessingRate).withDimensions(dimension1, dimension2),
         )
         val req = new PutMetricDataRequest()
-          .withNamespace(s"Notifications/$stage/workers")
+          .withNamespace(s"Notifications/$stage/$senderMetricNs")
           .withMetricData(perfMetrics.asJava)
         cloudwatchClient.putMetricData(req)
         ()

--- a/senderworker/src/main/scala/com/gu/notifications/ec2worker/SenderWorker.scala
+++ b/senderworker/src/main/scala/com/gu/notifications/ec2worker/SenderWorker.scala
@@ -63,23 +63,23 @@ object SenderWorker extends App {
   val config = Configuration.fetchConfiguration()
 
   logger.info("Sender worker - Ios started")
-  val iosSender = new IOSSender(Configuration.fetchApns(config, Ios))
+  val iosSender = new IOSSender(Configuration.fetchApns(config, Ios), "ec2workers")
   pollQueue(iosSender.config.sqsUrl, "ios", iosSender.handleChunkTokens)
 
   logger.info("Sender worker - Android started")
-  val androidSender = new AndroidSender(Configuration.fetchFirebase(config, Android), Some(Android.toString()))
+  val androidSender = new AndroidSender(Configuration.fetchFirebase(config, Android), Some(Android.toString()), "ec2workers")
   pollQueue(androidSender.config.sqsUrl, "android", androidSender.handleChunkTokens)
 
   logger.info("Sender worker - IosEdition started")
-  val iosEditionSender = new IOSSender(Configuration.fetchApns(config, IosEdition))
+  val iosEditionSender = new IOSSender(Configuration.fetchApns(config, IosEdition), "ec2workers")
   pollQueue(iosEditionSender.config.sqsUrl, "ios-edition", iosEditionSender.handleChunkTokens)
 
   logger.info("Sender worker - AndroidBeta started")
-  val androidBetaSender = new AndroidSender(Configuration.fetchFirebase(config, AndroidBeta), Some(AndroidBeta.toString()))
+  val androidBetaSender = new AndroidSender(Configuration.fetchFirebase(config, AndroidBeta), Some(AndroidBeta.toString()), "ec2workers")
   pollQueue(androidBetaSender.config.sqsUrl,"android-beta", androidBetaSender.handleChunkTokens)
 
   logger.info("Sender worker - AndroidEdition started")
-  val androidEditionSender = new AndroidSender(Configuration.fetchFirebase(config, AndroidEdition), Some(AndroidEdition.toString()))
+  val androidEditionSender = new AndroidSender(Configuration.fetchFirebase(config, AndroidEdition), Some(AndroidEdition.toString()), "ec2workers")
   pollQueue(androidEditionSender.config.sqsUrl, "android-edition", androidEditionSender.handleChunkTokens)
 
   logger.info("Sender worker all started")


### PR DESCRIPTION
## What does this change?

This PR is part of the work to create metrics and alarms to monitor EC2 stack after it is rolled out.

It enables the sender function to create AWS metrics under different namespaces so that we will be able to differentiate between metrics from worker lambda and EC2 sender.

It also adds a _start_ log before processing a SQS message.  This log is needed to create the concurrency level graph as proposed in #825 (the 6th item). 

## How to test

I deployed the worker lambda to CODE and verified that the AWS metrics were created under the correct namespace `Notifications/$stage/workers` and the `start` logs were created.  I also updated the sample Kibana dashboard ( https://logs.gutools.co.uk/s/mobile/app/dashboards#/view/75c0d220-6447-11ed-be34-2d379af36700?_g=(filters:!()) ) with the created logs.
