### PR TITLE
Reduce SQS batch size for android worker

### DIFF
--- a/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
+++ b/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
@@ -463,7 +463,7 @@ Object {
         "androidSenderSqsCF269D3F",
       ],
       "Properties": Object {
-        "BatchSize": 20,
+        "BatchSize": 10,
         "Enabled": true,
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [

--- a/notificationworkerlambda/cdk/lib/senderworker.ts
+++ b/notificationworkerlambda/cdk/lib/senderworker.ts
@@ -116,7 +116,7 @@ class SenderWorker extends cdkcore.Construct  {
     })
 
     const senderSqsEventSourceMapping = new lambda.EventSourceMapping(this, "SenderSqsEventSourceMapping", {
-      batchSize: props.isBatchingSqsMessages ? 20 : 1,
+      batchSize: props.isBatchingSqsMessages ? 10 : 1,
       maxBatchingWindow: props.isBatchingSqsMessages ? cdk.Duration.seconds(1) : cdk.Duration.seconds(0),
       enabled: true,
       eventSourceArn: this.senderSqs.queueArn,


### PR DESCRIPTION
## What does this change?

We deployed a [change](https://github.com/guardian/mobile-n10n/pull/823) that enabled the android worker lambda to concurrently process batches of SQS messages.

Since that deploy we have observed the following:
- increased number of errors received
- new error types being returned to us, including api client timeout errors
- android lambdas failing to process entire batches of tokens, and then having to retry

Given the SQS batching is the most recent change, this PR reduces the SQS batch size to try and reduce the errors that we're receiving.

## How to test

Given the change is deployed, confirm that the android worker lambda has an SQS batch size of 10.

## How can we measure success?

Reduction is errors received when sending breaking news notifications.
