### PR TITLE
Bump version of firebase-admin to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -418,7 +418,7 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
     dockerAlias := DockerAlias(registryHost = dockerRepository.value, username = None, name = (Docker / packageName).value, tag = buildNumber),
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
-      "com.google.firebase" % "firebase-admin" % "9.0.0",
+      "com.google.firebase" % "firebase-admin" % "9.1.1",
       "com.google.protobuf" % "protobuf-java" % "3.19.2",
       "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",
       "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,


### PR DESCRIPTION
## What does this change?

Firebase recommended bumping `firebase-admin` to the [latest](https://firebase.google.com/support/release-notes/admin/java). This PR updates the version specified.

Although there appear to be no changes relevant to firebase messaging in the release notes it is probably good to migrate anyway.