### PR TITLE
Bump logging libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ val jacksonScalaModule: String = "2.13.3"
 val simpleConfigurationVersion: String = "1.5.6"
 val googleOAuthClient: String = "1.33.3"
 val nettyVersion: String = "4.1.78.Final"
-val slf4jVersion: String = "1.7.36"
+val slf4jVersion: String = "2.0.4"
 
 val standardSettings = Seq[Setting[_]](
   resolvers ++= Seq(
@@ -265,7 +265,7 @@ def lambda(projectName: String, directoryName: String, mainClassName: Option[Str
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "com.gu" %% "simple-configuration-core" % simpleConfigurationVersion,
       "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
-      "ch.qos.logback" % "logback-classic" % "1.2.11",
+      "ch.qos.logback" % "logback-classic" % "1.3.4",
       "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
       specs2 % Test
     ),


### PR DESCRIPTION
## What does this change?

After bumping the firebase lib we lost some logs in notification sender worker lambdas, it referenced this page:
https://www.slf4j.org/codes.html#ignoredBindings

Which suggests we need to bump the logback-classic version.

We also bumped:
- slf4j-api version explicitly to be the version required 
- we didn't bump logback-classic to the latest because it looks incompatible with our java version

## How to test

Ran notification worker local run and could see logs being printed successfully again to the console.