### PR TITLE
LIVE-4729 create alarms for EC2 stack rollout

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -53,6 +53,8 @@ export const senderCodeProps = {
 	targetCpuUtilization: 20,
 	notificationSnsTopic:
 		'arn:aws:sns:eu-west-1:201359054765:AutoscalingNotificationsCODE',
+	alarmSnsTopic: 'mobile-server-side',
+	alarmEnabled: false,
 	cleanerQueueArn:
 		'arn:aws:sqs:eu-west-1:201359054765:mobile-notifications-registration-cleaning-worker-CODE-Sqs-1CFISZQCN49SR',
 };
@@ -70,6 +72,8 @@ export const senderProdProps = {
 	targetCpuUtilization: 20,
 	notificationSnsTopic:
 		'arn:aws:sns:eu-west-1:201359054765:AutoscalingNotificationsPROD',
+	alarmSnsTopic: 'mobile-server-side',
+	alarmEnabled: true,
 	cleanerQueueArn:
 		'arn:aws:sqs:eu-west-1:201359054765:mobile-notifications-registration-cleaning-worker-PROD-Sqs-12LNONCNWBRWK',
 };

--- a/cdk/lib/__snapshots__/sender-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/sender-stack.test.ts.snap
@@ -21,6 +21,26 @@ Object {
       "GuHttpsEgressSecurityGroup",
       "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -544,6 +564,321 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "MessageAgeAlarmandroidB60A67E9": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the age of the oldest message exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-CODE-MessageAge-android",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsandroidDCF78A7C",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 180,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MessageAgeAlarmandroidbetaC5859B97": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the age of the oldest message exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-CODE-MessageAge-android-beta",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsandroidbetaD9344C34",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 180,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MessageAgeAlarmandroidedition5A973330": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the age of the oldest message exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-CODE-MessageAge-android-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsandroideditionE70A53F0",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 180,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MessageAgeAlarmiosD48AE20F": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the age of the oldest message exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-CODE-MessageAge-ios",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsios636F1B52",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 180,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MessageAgeAlarmiosedition6D787D77": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the age of the oldest message exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-CODE-MessageAge-ios-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsioseditionF8A67CD0",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 180,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "ParameterStoreReadSenderworker1A48F352": Object {
       "Properties": Object {
@@ -1300,6 +1635,1366 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
+    "failureRateandroidF3480B68": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender exceeded 25% error rate",
+        "AlarmName": "sender-worker-CODE-failureRate-android",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/(m2-m3)",
+            "Id": "expr_1",
+            "Label": "Success % of EC2 Sender - android",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "failure-android",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android",
+                  },
+                ],
+                "MetricName": "failure",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "Label": "total-android",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m3",
+            "Label": "dryrun-android",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android",
+                  },
+                ],
+                "MetricName": "dryrun",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 25,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "failureRateandroidbetaCF56BB5E": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender exceeded 25% error rate",
+        "AlarmName": "sender-worker-CODE-failureRate-android-beta",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/(m2-m3)",
+            "Id": "expr_1",
+            "Label": "Success % of EC2 Sender - android-beta",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "failure-android-beta",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-beta",
+                  },
+                ],
+                "MetricName": "failure",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "Label": "total-android-beta",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-beta",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m3",
+            "Label": "dryrun-android-beta",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-beta",
+                  },
+                ],
+                "MetricName": "dryrun",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 25,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "failureRateandroidedition11756D02": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender exceeded 25% error rate",
+        "AlarmName": "sender-worker-CODE-failureRate-android-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/(m2-m3)",
+            "Id": "expr_1",
+            "Label": "Success % of EC2 Sender - android-edition",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "failure-android-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-edition",
+                  },
+                ],
+                "MetricName": "failure",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "Label": "total-android-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-edition",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m3",
+            "Label": "dryrun-android-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-edition",
+                  },
+                ],
+                "MetricName": "dryrun",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 25,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "failureRateiosA081B9CF": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender exceeded 25% error rate",
+        "AlarmName": "sender-worker-CODE-failureRate-ios",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/(m2-m3)",
+            "Id": "expr_1",
+            "Label": "Success % of EC2 Sender - ios",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "failure-ios",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios",
+                  },
+                ],
+                "MetricName": "failure",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "Label": "total-ios",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m3",
+            "Label": "dryrun-ios",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios",
+                  },
+                ],
+                "MetricName": "dryrun",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 25,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "failureRateiosedition38A87D6D": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender exceeded 25% error rate",
+        "AlarmName": "sender-worker-CODE-failureRate-ios-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/(m2-m3)",
+            "Id": "expr_1",
+            "Label": "Success % of EC2 Sender - ios-edition",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "failure-ios-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios-edition",
+                  },
+                ],
+                "MetricName": "failure",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "Label": "total-ios-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios-edition",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m3",
+            "Label": "dryrun-ios-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios-edition",
+                  },
+                ],
+                "MetricName": "dryrun",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 25,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "messagesInFlightAlarmandroid4277DD3D": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the number of messages in flight exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-CODE-MessageInFlight-android",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsandroidDCF78A7C",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 500,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "messagesInFlightAlarmandroidbeta4F8D771C": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the number of messages in flight exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-CODE-MessageInFlight-android-beta",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsandroidbetaD9344C34",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 500,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "messagesInFlightAlarmandroideditionEF38BFA2": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the number of messages in flight exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-CODE-MessageInFlight-android-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsandroideditionE70A53F0",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 500,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "messagesInFlightAlarmios1417977D": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the number of messages in flight exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-CODE-MessageInFlight-ios",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsios636F1B52",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 500,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "messagesInFlightAlarmioseditionB74B94D0": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the number of messages in flight exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-CODE-MessageInFlight-ios-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsioseditionF8A67CD0",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 500,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "processingRateandroid55B0FFB7": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender went below 75% processing rate",
+        "AlarmName": "sender-worker-CODE-processingRate-android",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "Processed % of SQS messages by EC2 Sender - android",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "total-android",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "QueueName",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "SenderSqsandroidDCF78A7C",
+                        "QueueName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "NumberOfMessagesReceived",
+                "Namespace": "AWS/SQS",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 75,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "processingRateandroidbeta877F989F": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender went below 75% processing rate",
+        "AlarmName": "sender-worker-CODE-processingRate-android-beta",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "Processed % of SQS messages by EC2 Sender - android-beta",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "total-android-beta",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-beta",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "QueueName",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "SenderSqsandroidbetaD9344C34",
+                        "QueueName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "NumberOfMessagesReceived",
+                "Namespace": "AWS/SQS",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 75,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "processingRateandroidedition416914A9": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender went below 75% processing rate",
+        "AlarmName": "sender-worker-CODE-processingRate-android-edition",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "Processed % of SQS messages by EC2 Sender - android-edition",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "total-android-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-edition",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "QueueName",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "SenderSqsandroideditionE70A53F0",
+                        "QueueName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "NumberOfMessagesReceived",
+                "Namespace": "AWS/SQS",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 75,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "processingRateios3E5DA673": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender went below 75% processing rate",
+        "AlarmName": "sender-worker-CODE-processingRate-ios",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "Processed % of SQS messages by EC2 Sender - ios",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "total-ios",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "QueueName",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "SenderSqsios636F1B52",
+                        "QueueName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "NumberOfMessagesReceived",
+                "Namespace": "AWS/SQS",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 75,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "processingRateioseditionBBDB2410": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender went below 75% processing rate",
+        "AlarmName": "sender-worker-CODE-processingRate-ios-edition",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "Processed % of SQS messages by EC2 Sender - ios-edition",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "total-ios-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios-edition",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/CODE/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "QueueName",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "SenderSqsioseditionF8A67CD0",
+                        "QueueName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "NumberOfMessagesReceived",
+                "Namespace": "AWS/SQS",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 75,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
   },
 }
 `;
@@ -1325,6 +3020,26 @@ Object {
       "GuHttpsEgressSecurityGroup",
       "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -1848,6 +3563,321 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "MessageAgeAlarmandroidB60A67E9": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the age of the oldest message exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-PROD-MessageAge-android",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsandroidDCF78A7C",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 180,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MessageAgeAlarmandroidbetaC5859B97": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the age of the oldest message exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-PROD-MessageAge-android-beta",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsandroidbetaD9344C34",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 180,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MessageAgeAlarmandroidedition5A973330": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the age of the oldest message exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-PROD-MessageAge-android-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsandroideditionE70A53F0",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 180,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MessageAgeAlarmiosD48AE20F": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the age of the oldest message exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-PROD-MessageAge-ios",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsios636F1B52",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 180,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MessageAgeAlarmiosedition6D787D77": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the age of the oldest message exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-PROD-MessageAge-ios-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsioseditionF8A67CD0",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 180,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "ParameterStoreReadSenderworker1A48F352": Object {
       "Properties": Object {
@@ -2603,6 +4633,1366 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "failureRateandroidF3480B68": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender exceeded 25% error rate",
+        "AlarmName": "sender-worker-PROD-failureRate-android",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/(m2-m3)",
+            "Id": "expr_1",
+            "Label": "Success % of EC2 Sender - android",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "failure-android",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android",
+                  },
+                ],
+                "MetricName": "failure",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "Label": "total-android",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m3",
+            "Label": "dryrun-android",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android",
+                  },
+                ],
+                "MetricName": "dryrun",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 25,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "failureRateandroidbetaCF56BB5E": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender exceeded 25% error rate",
+        "AlarmName": "sender-worker-PROD-failureRate-android-beta",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/(m2-m3)",
+            "Id": "expr_1",
+            "Label": "Success % of EC2 Sender - android-beta",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "failure-android-beta",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-beta",
+                  },
+                ],
+                "MetricName": "failure",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "Label": "total-android-beta",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-beta",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m3",
+            "Label": "dryrun-android-beta",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-beta",
+                  },
+                ],
+                "MetricName": "dryrun",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 25,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "failureRateandroidedition11756D02": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender exceeded 25% error rate",
+        "AlarmName": "sender-worker-PROD-failureRate-android-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/(m2-m3)",
+            "Id": "expr_1",
+            "Label": "Success % of EC2 Sender - android-edition",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "failure-android-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-edition",
+                  },
+                ],
+                "MetricName": "failure",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "Label": "total-android-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-edition",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m3",
+            "Label": "dryrun-android-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-edition",
+                  },
+                ],
+                "MetricName": "dryrun",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 25,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "failureRateiosA081B9CF": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender exceeded 25% error rate",
+        "AlarmName": "sender-worker-PROD-failureRate-ios",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/(m2-m3)",
+            "Id": "expr_1",
+            "Label": "Success % of EC2 Sender - ios",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "failure-ios",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios",
+                  },
+                ],
+                "MetricName": "failure",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "Label": "total-ios",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m3",
+            "Label": "dryrun-ios",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios",
+                  },
+                ],
+                "MetricName": "dryrun",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 25,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "failureRateiosedition38A87D6D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender exceeded 25% error rate",
+        "AlarmName": "sender-worker-PROD-failureRate-ios-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/(m2-m3)",
+            "Id": "expr_1",
+            "Label": "Success % of EC2 Sender - ios-edition",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "failure-ios-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios-edition",
+                  },
+                ],
+                "MetricName": "failure",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "Label": "total-ios-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios-edition",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m3",
+            "Label": "dryrun-ios-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios-edition",
+                  },
+                ],
+                "MetricName": "dryrun",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 25,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "messagesInFlightAlarmandroid4277DD3D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the number of messages in flight exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-PROD-MessageInFlight-android",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsandroidDCF78A7C",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 500,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "messagesInFlightAlarmandroidbeta4F8D771C": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the number of messages in flight exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-PROD-MessageInFlight-android-beta",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsandroidbetaD9344C34",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 500,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "messagesInFlightAlarmandroideditionEF38BFA2": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the number of messages in flight exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-PROD-MessageInFlight-android-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsandroideditionE70A53F0",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 500,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "messagesInFlightAlarmios1417977D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the number of messages in flight exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-PROD-MessageInFlight-ios",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsios636F1B52",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 500,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "messagesInFlightAlarmioseditionB74B94D0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if the number of messages in flight exceeds the threshold. <<<Runbook|https://docs.google.com/document/d/1aJMytnPGeWH8YLpD2_66doxqyr8dPvAVonYIOG-zmOA>>>",
+        "AlarmName": "sender-worker-PROD-MessageInFlight-ios-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "SenderSqsioseditionF8A67CD0",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 500,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "processingRateandroid55B0FFB7": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender went below 75% processing rate",
+        "AlarmName": "sender-worker-PROD-processingRate-android",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "Processed % of SQS messages by EC2 Sender - android",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "total-android",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "QueueName",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "SenderSqsandroidDCF78A7C",
+                        "QueueName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "NumberOfMessagesReceived",
+                "Namespace": "AWS/SQS",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 75,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "processingRateandroidbeta877F989F": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender went below 75% processing rate",
+        "AlarmName": "sender-worker-PROD-processingRate-android-beta",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "Processed % of SQS messages by EC2 Sender - android-beta",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "total-android-beta",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-beta",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "QueueName",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "SenderSqsandroidbetaD9344C34",
+                        "QueueName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "NumberOfMessagesReceived",
+                "Namespace": "AWS/SQS",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 75,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "processingRateandroidedition416914A9": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender went below 75% processing rate",
+        "AlarmName": "sender-worker-PROD-processingRate-android-edition",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "Processed % of SQS messages by EC2 Sender - android-edition",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "total-android-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "android-edition",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "QueueName",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "SenderSqsandroideditionE70A53F0",
+                        "QueueName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "NumberOfMessagesReceived",
+                "Namespace": "AWS/SQS",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 75,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "processingRateios3E5DA673": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender went below 75% processing rate",
+        "AlarmName": "sender-worker-PROD-processingRate-ios",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "Processed % of SQS messages by EC2 Sender - ios",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "total-ios",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "QueueName",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "SenderSqsios636F1B52",
+                        "QueueName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "NumberOfMessagesReceived",
+                "Namespace": "AWS/SQS",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 75,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "processingRateioseditionBBDB2410": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "EC2 sender went below 75% processing rate",
+        "AlarmName": "sender-worker-PROD-processingRate-ios-edition",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": "Processed % of SQS messages by EC2 Sender - ios-edition",
+          },
+          Object {
+            "Id": "m1",
+            "Label": "total-ios-edition",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "platform",
+                    "Value": "ios-edition",
+                  },
+                ],
+                "MetricName": "total",
+                "Namespace": "Notifications/PROD/ec2workers",
+              },
+              "Period": 300,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "QueueName",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "SenderSqsioseditionF8A67CD0",
+                        "QueueName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "NumberOfMessagesReceived",
+                "Namespace": "AWS/SQS",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 75,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
   },
 }

--- a/cdk/lib/__snapshots__/sender-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/sender-stack.test.ts.snap
@@ -1635,7 +1635,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "failureRateandroidF3480B68": Object {
+    "lowSucccessRateandroid0C5310D4": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -1656,9 +1656,9 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender exceeded 25% error rate",
-        "AlarmName": "sender-worker-CODE-failureRate-android",
-        "ComparisonOperator": "GreaterThanThreshold",
+        "AlarmDescription": "EC2 sender went below 75% success rate",
+        "AlarmName": "sender-worker-CODE-lowSuccessRate-android",
+        "ComparisonOperator": "LessThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
@@ -1668,7 +1668,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
           Object {
             "Id": "m1",
-            "Label": "failure-android",
+            "Label": "success-android",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -1677,7 +1677,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "android",
                   },
                 ],
-                "MetricName": "failure",
+                "MetricName": "success",
                 "Namespace": "Notifications/CODE/ec2workers",
               },
               "Period": 300,
@@ -1742,12 +1742,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 25,
+        "Threshold": 75,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "failureRateandroidbetaCF56BB5E": Object {
+    "lowSucccessRateandroidbeta54A27A3F": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -1768,9 +1768,9 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender exceeded 25% error rate",
-        "AlarmName": "sender-worker-CODE-failureRate-android-beta",
-        "ComparisonOperator": "GreaterThanThreshold",
+        "AlarmDescription": "EC2 sender went below 75% success rate",
+        "AlarmName": "sender-worker-CODE-lowSuccessRate-android-beta",
+        "ComparisonOperator": "LessThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
@@ -1780,7 +1780,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
           Object {
             "Id": "m1",
-            "Label": "failure-android-beta",
+            "Label": "success-android-beta",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -1789,7 +1789,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "android-beta",
                   },
                 ],
-                "MetricName": "failure",
+                "MetricName": "success",
                 "Namespace": "Notifications/CODE/ec2workers",
               },
               "Period": 300,
@@ -1854,12 +1854,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 25,
+        "Threshold": 75,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "failureRateandroidedition11756D02": Object {
+    "lowSucccessRateandroidedition5F27E836": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -1880,9 +1880,9 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender exceeded 25% error rate",
-        "AlarmName": "sender-worker-CODE-failureRate-android-edition",
-        "ComparisonOperator": "GreaterThanThreshold",
+        "AlarmDescription": "EC2 sender went below 75% success rate",
+        "AlarmName": "sender-worker-CODE-lowSuccessRate-android-edition",
+        "ComparisonOperator": "LessThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
@@ -1892,7 +1892,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
           Object {
             "Id": "m1",
-            "Label": "failure-android-edition",
+            "Label": "success-android-edition",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -1901,7 +1901,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "android-edition",
                   },
                 ],
-                "MetricName": "failure",
+                "MetricName": "success",
                 "Namespace": "Notifications/CODE/ec2workers",
               },
               "Period": 300,
@@ -1966,12 +1966,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 25,
+        "Threshold": 75,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "failureRateiosA081B9CF": Object {
+    "lowSucccessRateiosAE24AB51": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -1992,9 +1992,9 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender exceeded 25% error rate",
-        "AlarmName": "sender-worker-CODE-failureRate-ios",
-        "ComparisonOperator": "GreaterThanThreshold",
+        "AlarmDescription": "EC2 sender went below 75% success rate",
+        "AlarmName": "sender-worker-CODE-lowSuccessRate-ios",
+        "ComparisonOperator": "LessThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
@@ -2004,7 +2004,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
           Object {
             "Id": "m1",
-            "Label": "failure-ios",
+            "Label": "success-ios",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -2013,7 +2013,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "ios",
                   },
                 ],
-                "MetricName": "failure",
+                "MetricName": "success",
                 "Namespace": "Notifications/CODE/ec2workers",
               },
               "Period": 300,
@@ -2078,12 +2078,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 25,
+        "Threshold": 75,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "failureRateiosedition38A87D6D": Object {
+    "lowSucccessRateiosedition217BD2F9": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -2104,9 +2104,9 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender exceeded 25% error rate",
-        "AlarmName": "sender-worker-CODE-failureRate-ios-edition",
-        "ComparisonOperator": "GreaterThanThreshold",
+        "AlarmDescription": "EC2 sender went below 75% success rate",
+        "AlarmName": "sender-worker-CODE-lowSuccessRate-ios-edition",
+        "ComparisonOperator": "LessThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
@@ -2116,7 +2116,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
           Object {
             "Id": "m1",
-            "Label": "failure-ios-edition",
+            "Label": "success-ios-edition",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -2125,7 +2125,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "ios-edition",
                   },
                 ],
-                "MetricName": "failure",
+                "MetricName": "success",
                 "Namespace": "Notifications/CODE/ec2workers",
               },
               "Period": 300,
@@ -2190,7 +2190,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 25,
+        "Threshold": 75,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -2603,7 +2603,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
         ],
         "Threshold": 75,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -2700,7 +2700,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
         ],
         "Threshold": 75,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -2797,7 +2797,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
         ],
         "Threshold": 75,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -2894,7 +2894,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
         ],
         "Threshold": 75,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -2991,7 +2991,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
         ],
         "Threshold": 75,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -4634,7 +4634,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "failureRateandroidF3480B68": Object {
+    "lowSucccessRateandroid0C5310D4": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -4655,9 +4655,9 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender exceeded 25% error rate",
-        "AlarmName": "sender-worker-PROD-failureRate-android",
-        "ComparisonOperator": "GreaterThanThreshold",
+        "AlarmDescription": "EC2 sender went below 75% success rate",
+        "AlarmName": "sender-worker-PROD-lowSuccessRate-android",
+        "ComparisonOperator": "LessThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
@@ -4667,7 +4667,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
           Object {
             "Id": "m1",
-            "Label": "failure-android",
+            "Label": "success-android",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -4676,7 +4676,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "android",
                   },
                 ],
-                "MetricName": "failure",
+                "MetricName": "success",
                 "Namespace": "Notifications/PROD/ec2workers",
               },
               "Period": 300,
@@ -4741,12 +4741,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 25,
+        "Threshold": 75,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "failureRateandroidbetaCF56BB5E": Object {
+    "lowSucccessRateandroidbeta54A27A3F": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -4767,9 +4767,9 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender exceeded 25% error rate",
-        "AlarmName": "sender-worker-PROD-failureRate-android-beta",
-        "ComparisonOperator": "GreaterThanThreshold",
+        "AlarmDescription": "EC2 sender went below 75% success rate",
+        "AlarmName": "sender-worker-PROD-lowSuccessRate-android-beta",
+        "ComparisonOperator": "LessThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
@@ -4779,7 +4779,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
           Object {
             "Id": "m1",
-            "Label": "failure-android-beta",
+            "Label": "success-android-beta",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -4788,7 +4788,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "android-beta",
                   },
                 ],
-                "MetricName": "failure",
+                "MetricName": "success",
                 "Namespace": "Notifications/PROD/ec2workers",
               },
               "Period": 300,
@@ -4853,12 +4853,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 25,
+        "Threshold": 75,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "failureRateandroidedition11756D02": Object {
+    "lowSucccessRateandroidedition5F27E836": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -4879,9 +4879,9 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender exceeded 25% error rate",
-        "AlarmName": "sender-worker-PROD-failureRate-android-edition",
-        "ComparisonOperator": "GreaterThanThreshold",
+        "AlarmDescription": "EC2 sender went below 75% success rate",
+        "AlarmName": "sender-worker-PROD-lowSuccessRate-android-edition",
+        "ComparisonOperator": "LessThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
@@ -4891,7 +4891,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
           Object {
             "Id": "m1",
-            "Label": "failure-android-edition",
+            "Label": "success-android-edition",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -4900,7 +4900,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "android-edition",
                   },
                 ],
-                "MetricName": "failure",
+                "MetricName": "success",
                 "Namespace": "Notifications/PROD/ec2workers",
               },
               "Period": 300,
@@ -4965,12 +4965,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 25,
+        "Threshold": 75,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "failureRateiosA081B9CF": Object {
+    "lowSucccessRateiosAE24AB51": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -4991,9 +4991,9 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender exceeded 25% error rate",
-        "AlarmName": "sender-worker-PROD-failureRate-ios",
-        "ComparisonOperator": "GreaterThanThreshold",
+        "AlarmDescription": "EC2 sender went below 75% success rate",
+        "AlarmName": "sender-worker-PROD-lowSuccessRate-ios",
+        "ComparisonOperator": "LessThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
@@ -5003,7 +5003,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
           Object {
             "Id": "m1",
-            "Label": "failure-ios",
+            "Label": "success-ios",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -5012,7 +5012,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "ios",
                   },
                 ],
-                "MetricName": "failure",
+                "MetricName": "success",
                 "Namespace": "Notifications/PROD/ec2workers",
               },
               "Period": 300,
@@ -5077,12 +5077,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 25,
+        "Threshold": 75,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "failureRateiosedition38A87D6D": Object {
+    "lowSucccessRateiosedition217BD2F9": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -5103,9 +5103,9 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender exceeded 25% error rate",
-        "AlarmName": "sender-worker-PROD-failureRate-ios-edition",
-        "ComparisonOperator": "GreaterThanThreshold",
+        "AlarmDescription": "EC2 sender went below 75% success rate",
+        "AlarmName": "sender-worker-PROD-lowSuccessRate-ios-edition",
+        "ComparisonOperator": "LessThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
@@ -5115,7 +5115,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
           Object {
             "Id": "m1",
-            "Label": "failure-ios-edition",
+            "Label": "success-ios-edition",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -5124,7 +5124,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "ios-edition",
                   },
                 ],
-                "MetricName": "failure",
+                "MetricName": "success",
                 "Namespace": "Notifications/PROD/ec2workers",
               },
               "Period": 300,
@@ -5189,7 +5189,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 25,
+        "Threshold": 75,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -5602,7 +5602,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
         ],
         "Threshold": 75,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -5699,7 +5699,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
         ],
         "Threshold": 75,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -5796,7 +5796,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
         ],
         "Threshold": 75,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -5893,7 +5893,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
         ],
         "Threshold": 75,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -5990,7 +5990,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
           },
         ],
         "Threshold": 75,
-        "TreatMissingData": "breaching",
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/cdk/lib/__snapshots__/sender-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/sender-stack.test.ts.snap
@@ -600,7 +600,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateAgeOfOldestMessage",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -623,7 +623,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 180,
+        "Threshold": 700,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -663,7 +663,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateAgeOfOldestMessage",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -686,7 +686,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 180,
+        "Threshold": 700,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -726,7 +726,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateAgeOfOldestMessage",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -749,7 +749,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 180,
+        "Threshold": 700,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -789,7 +789,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateAgeOfOldestMessage",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -812,7 +812,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 180,
+        "Threshold": 700,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -852,7 +852,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateAgeOfOldestMessage",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -875,7 +875,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 180,
+        "Threshold": 700,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -1635,7 +1635,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "lowSucccessRateandroid0C5310D4": Object {
+    "failurePercentageandroidCD03357C": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -1656,19 +1656,19 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% success rate",
-        "AlarmName": "sender-worker-CODE-lowSuccessRate-android",
-        "ComparisonOperator": "LessThanThreshold",
+        "AlarmDescription": "EC2 sender exceeds 1% error percentage",
+        "AlarmName": "sender-worker-CODE-failure-android",
+        "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/(m2-m3)",
             "Id": "expr_1",
-            "Label": "Success % of EC2 Sender - android",
+            "Label": "Failure % of EC2 Sender - android",
           },
           Object {
             "Id": "m1",
-            "Label": "success-android",
+            "Label": "failure-android",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -1677,7 +1677,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "android",
                   },
                 ],
-                "MetricName": "success",
+                "MetricName": "failure",
                 "Namespace": "Notifications/CODE/ec2workers",
               },
               "Period": 300,
@@ -1742,12 +1742,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "lowSucccessRateandroidbeta54A27A3F": Object {
+    "failurePercentageandroidbeta58BBE921": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -1768,19 +1768,19 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% success rate",
-        "AlarmName": "sender-worker-CODE-lowSuccessRate-android-beta",
-        "ComparisonOperator": "LessThanThreshold",
+        "AlarmDescription": "EC2 sender exceeds 1% error percentage",
+        "AlarmName": "sender-worker-CODE-failure-android-beta",
+        "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/(m2-m3)",
             "Id": "expr_1",
-            "Label": "Success % of EC2 Sender - android-beta",
+            "Label": "Failure % of EC2 Sender - android-beta",
           },
           Object {
             "Id": "m1",
-            "Label": "success-android-beta",
+            "Label": "failure-android-beta",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -1789,7 +1789,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "android-beta",
                   },
                 ],
-                "MetricName": "success",
+                "MetricName": "failure",
                 "Namespace": "Notifications/CODE/ec2workers",
               },
               "Period": 300,
@@ -1854,12 +1854,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "lowSucccessRateandroidedition5F27E836": Object {
+    "failurePercentageandroideditionBE5D24E3": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -1880,19 +1880,19 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% success rate",
-        "AlarmName": "sender-worker-CODE-lowSuccessRate-android-edition",
-        "ComparisonOperator": "LessThanThreshold",
+        "AlarmDescription": "EC2 sender exceeds 1% error percentage",
+        "AlarmName": "sender-worker-CODE-failure-android-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/(m2-m3)",
             "Id": "expr_1",
-            "Label": "Success % of EC2 Sender - android-edition",
+            "Label": "Failure % of EC2 Sender - android-edition",
           },
           Object {
             "Id": "m1",
-            "Label": "success-android-edition",
+            "Label": "failure-android-edition",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -1901,7 +1901,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "android-edition",
                   },
                 ],
-                "MetricName": "success",
+                "MetricName": "failure",
                 "Namespace": "Notifications/CODE/ec2workers",
               },
               "Period": 300,
@@ -1966,12 +1966,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "lowSucccessRateiosAE24AB51": Object {
+    "failurePercentageios3A8FD40D": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -1992,19 +1992,19 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% success rate",
-        "AlarmName": "sender-worker-CODE-lowSuccessRate-ios",
-        "ComparisonOperator": "LessThanThreshold",
+        "AlarmDescription": "EC2 sender exceeds 1% error percentage",
+        "AlarmName": "sender-worker-CODE-failure-ios",
+        "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/(m2-m3)",
             "Id": "expr_1",
-            "Label": "Success % of EC2 Sender - ios",
+            "Label": "Failure % of EC2 Sender - ios",
           },
           Object {
             "Id": "m1",
-            "Label": "success-ios",
+            "Label": "failure-ios",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -2013,7 +2013,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "ios",
                   },
                 ],
-                "MetricName": "success",
+                "MetricName": "failure",
                 "Namespace": "Notifications/CODE/ec2workers",
               },
               "Period": 300,
@@ -2078,12 +2078,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "lowSucccessRateiosedition217BD2F9": Object {
+    "failurePercentageiosedition5E69B50F": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -2104,19 +2104,19 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% success rate",
-        "AlarmName": "sender-worker-CODE-lowSuccessRate-ios-edition",
-        "ComparisonOperator": "LessThanThreshold",
+        "AlarmDescription": "EC2 sender exceeds 1% error percentage",
+        "AlarmName": "sender-worker-CODE-failure-ios-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/(m2-m3)",
             "Id": "expr_1",
-            "Label": "Success % of EC2 Sender - ios-edition",
+            "Label": "Failure % of EC2 Sender - ios-edition",
           },
           Object {
             "Id": "m1",
-            "Label": "success-ios-edition",
+            "Label": "failure-ios-edition",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -2125,7 +2125,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "ios-edition",
                   },
                 ],
-                "MetricName": "success",
+                "MetricName": "failure",
                 "Namespace": "Notifications/CODE/ec2workers",
               },
               "Period": 300,
@@ -2190,7 +2190,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -2230,7 +2230,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateNumberOfMessagesNotVisible",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -2253,7 +2253,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 500,
+        "Threshold": 400,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -2293,7 +2293,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateNumberOfMessagesNotVisible",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -2316,7 +2316,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 500,
+        "Threshold": 400,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -2356,7 +2356,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateNumberOfMessagesNotVisible",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -2379,7 +2379,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 500,
+        "Threshold": 400,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -2419,7 +2419,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateNumberOfMessagesNotVisible",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -2442,7 +2442,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 500,
+        "Threshold": 400,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -2482,7 +2482,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateNumberOfMessagesNotVisible",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -2505,12 +2505,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 500,
+        "Threshold": 400,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "processingRateandroid55B0FFB7": Object {
+    "processedandroid4C5DB298": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -2531,10 +2531,10 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% processing rate",
-        "AlarmName": "sender-worker-CODE-processingRate-android",
+        "AlarmDescription": "EC2 sender processed less than 50% messages",
+        "AlarmName": "sender-worker-CODE-processed-android",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 3,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",
@@ -2602,12 +2602,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 50,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "processingRateandroidbeta877F989F": Object {
+    "processedandroidbetaA273AA12": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -2628,10 +2628,10 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% processing rate",
-        "AlarmName": "sender-worker-CODE-processingRate-android-beta",
+        "AlarmDescription": "EC2 sender processed less than 50% messages",
+        "AlarmName": "sender-worker-CODE-processed-android-beta",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 3,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",
@@ -2699,12 +2699,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 50,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "processingRateandroidedition416914A9": Object {
+    "processedandroideditionA36DBF89": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -2725,10 +2725,10 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% processing rate",
-        "AlarmName": "sender-worker-CODE-processingRate-android-edition",
+        "AlarmDescription": "EC2 sender processed less than 50% messages",
+        "AlarmName": "sender-worker-CODE-processed-android-edition",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 3,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",
@@ -2796,12 +2796,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 50,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "processingRateios3E5DA673": Object {
+    "processediosD1D3AE06": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -2822,10 +2822,10 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% processing rate",
-        "AlarmName": "sender-worker-CODE-processingRate-ios",
+        "AlarmDescription": "EC2 sender processed less than 50% messages",
+        "AlarmName": "sender-worker-CODE-processed-ios",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 3,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",
@@ -2893,12 +2893,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 50,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "processingRateioseditionBBDB2410": Object {
+    "processedioseditionC7509270": Object {
       "Properties": Object {
         "ActionsEnabled": false,
         "AlarmActions": Array [
@@ -2919,10 +2919,10 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% processing rate",
-        "AlarmName": "sender-worker-CODE-processingRate-ios-edition",
+        "AlarmDescription": "EC2 sender processed less than 50% messages",
+        "AlarmName": "sender-worker-CODE-processed-ios-edition",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 3,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",
@@ -2990,7 +2990,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 50,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -3599,7 +3599,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateAgeOfOldestMessage",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -3622,7 +3622,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 180,
+        "Threshold": 700,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -3662,7 +3662,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateAgeOfOldestMessage",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -3685,7 +3685,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 180,
+        "Threshold": 700,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -3725,7 +3725,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateAgeOfOldestMessage",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -3748,7 +3748,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 180,
+        "Threshold": 700,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -3788,7 +3788,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateAgeOfOldestMessage",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -3811,7 +3811,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 180,
+        "Threshold": 700,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -3851,7 +3851,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateAgeOfOldestMessage",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -3874,7 +3874,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 180,
+        "Threshold": 700,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -4634,7 +4634,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "lowSucccessRateandroid0C5310D4": Object {
+    "failurePercentageandroidCD03357C": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -4655,19 +4655,19 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% success rate",
-        "AlarmName": "sender-worker-PROD-lowSuccessRate-android",
-        "ComparisonOperator": "LessThanThreshold",
+        "AlarmDescription": "EC2 sender exceeds 1% error percentage",
+        "AlarmName": "sender-worker-PROD-failure-android",
+        "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/(m2-m3)",
             "Id": "expr_1",
-            "Label": "Success % of EC2 Sender - android",
+            "Label": "Failure % of EC2 Sender - android",
           },
           Object {
             "Id": "m1",
-            "Label": "success-android",
+            "Label": "failure-android",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -4676,7 +4676,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "android",
                   },
                 ],
-                "MetricName": "success",
+                "MetricName": "failure",
                 "Namespace": "Notifications/PROD/ec2workers",
               },
               "Period": 300,
@@ -4741,12 +4741,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "lowSucccessRateandroidbeta54A27A3F": Object {
+    "failurePercentageandroidbeta58BBE921": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -4767,19 +4767,19 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% success rate",
-        "AlarmName": "sender-worker-PROD-lowSuccessRate-android-beta",
-        "ComparisonOperator": "LessThanThreshold",
+        "AlarmDescription": "EC2 sender exceeds 1% error percentage",
+        "AlarmName": "sender-worker-PROD-failure-android-beta",
+        "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/(m2-m3)",
             "Id": "expr_1",
-            "Label": "Success % of EC2 Sender - android-beta",
+            "Label": "Failure % of EC2 Sender - android-beta",
           },
           Object {
             "Id": "m1",
-            "Label": "success-android-beta",
+            "Label": "failure-android-beta",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -4788,7 +4788,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "android-beta",
                   },
                 ],
-                "MetricName": "success",
+                "MetricName": "failure",
                 "Namespace": "Notifications/PROD/ec2workers",
               },
               "Period": 300,
@@ -4853,12 +4853,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "lowSucccessRateandroidedition5F27E836": Object {
+    "failurePercentageandroideditionBE5D24E3": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -4879,19 +4879,19 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% success rate",
-        "AlarmName": "sender-worker-PROD-lowSuccessRate-android-edition",
-        "ComparisonOperator": "LessThanThreshold",
+        "AlarmDescription": "EC2 sender exceeds 1% error percentage",
+        "AlarmName": "sender-worker-PROD-failure-android-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/(m2-m3)",
             "Id": "expr_1",
-            "Label": "Success % of EC2 Sender - android-edition",
+            "Label": "Failure % of EC2 Sender - android-edition",
           },
           Object {
             "Id": "m1",
-            "Label": "success-android-edition",
+            "Label": "failure-android-edition",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -4900,7 +4900,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "android-edition",
                   },
                 ],
-                "MetricName": "success",
+                "MetricName": "failure",
                 "Namespace": "Notifications/PROD/ec2workers",
               },
               "Period": 300,
@@ -4965,12 +4965,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "lowSucccessRateiosAE24AB51": Object {
+    "failurePercentageios3A8FD40D": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -4991,19 +4991,19 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% success rate",
-        "AlarmName": "sender-worker-PROD-lowSuccessRate-ios",
-        "ComparisonOperator": "LessThanThreshold",
+        "AlarmDescription": "EC2 sender exceeds 1% error percentage",
+        "AlarmName": "sender-worker-PROD-failure-ios",
+        "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/(m2-m3)",
             "Id": "expr_1",
-            "Label": "Success % of EC2 Sender - ios",
+            "Label": "Failure % of EC2 Sender - ios",
           },
           Object {
             "Id": "m1",
-            "Label": "success-ios",
+            "Label": "failure-ios",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -5012,7 +5012,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "ios",
                   },
                 ],
-                "MetricName": "success",
+                "MetricName": "failure",
                 "Namespace": "Notifications/PROD/ec2workers",
               },
               "Period": 300,
@@ -5077,12 +5077,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "lowSucccessRateiosedition217BD2F9": Object {
+    "failurePercentageiosedition5E69B50F": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -5103,19 +5103,19 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% success rate",
-        "AlarmName": "sender-worker-PROD-lowSuccessRate-ios-edition",
-        "ComparisonOperator": "LessThanThreshold",
+        "AlarmDescription": "EC2 sender exceeds 1% error percentage",
+        "AlarmName": "sender-worker-PROD-failure-ios-edition",
+        "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/(m2-m3)",
             "Id": "expr_1",
-            "Label": "Success % of EC2 Sender - ios-edition",
+            "Label": "Failure % of EC2 Sender - ios-edition",
           },
           Object {
             "Id": "m1",
-            "Label": "success-ios-edition",
+            "Label": "failure-ios-edition",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -5124,7 +5124,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
                     "Value": "ios-edition",
                   },
                 ],
-                "MetricName": "success",
+                "MetricName": "failure",
                 "Namespace": "Notifications/PROD/ec2workers",
               },
               "Period": 300,
@@ -5189,7 +5189,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -5229,7 +5229,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateNumberOfMessagesNotVisible",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -5252,7 +5252,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 500,
+        "Threshold": 400,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -5292,7 +5292,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateNumberOfMessagesNotVisible",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -5315,7 +5315,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 500,
+        "Threshold": 400,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -5355,7 +5355,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateNumberOfMessagesNotVisible",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -5378,7 +5378,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 500,
+        "Threshold": 400,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -5418,7 +5418,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateNumberOfMessagesNotVisible",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -5441,7 +5441,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 500,
+        "Threshold": 400,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -5481,7 +5481,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             },
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 1,
         "MetricName": "ApproximateNumberOfMessagesNotVisible",
         "Namespace": "AWS/SQS",
         "OKActions": Array [
@@ -5504,12 +5504,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
         ],
         "Period": 60,
         "Statistic": "Maximum",
-        "Threshold": 500,
+        "Threshold": 400,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "processingRateandroid55B0FFB7": Object {
+    "processedandroid4C5DB298": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -5530,10 +5530,10 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% processing rate",
-        "AlarmName": "sender-worker-PROD-processingRate-android",
+        "AlarmDescription": "EC2 sender processed less than 50% messages",
+        "AlarmName": "sender-worker-PROD-processed-android",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 3,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",
@@ -5601,12 +5601,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 50,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "processingRateandroidbeta877F989F": Object {
+    "processedandroidbetaA273AA12": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -5627,10 +5627,10 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% processing rate",
-        "AlarmName": "sender-worker-PROD-processingRate-android-beta",
+        "AlarmDescription": "EC2 sender processed less than 50% messages",
+        "AlarmName": "sender-worker-PROD-processed-android-beta",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 3,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",
@@ -5698,12 +5698,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 50,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "processingRateandroidedition416914A9": Object {
+    "processedandroideditionA36DBF89": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -5724,10 +5724,10 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% processing rate",
-        "AlarmName": "sender-worker-PROD-processingRate-android-edition",
+        "AlarmDescription": "EC2 sender processed less than 50% messages",
+        "AlarmName": "sender-worker-PROD-processed-android-edition",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 3,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",
@@ -5795,12 +5795,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 50,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "processingRateios3E5DA673": Object {
+    "processediosD1D3AE06": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -5821,10 +5821,10 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% processing rate",
-        "AlarmName": "sender-worker-PROD-processingRate-ios",
+        "AlarmDescription": "EC2 sender processed less than 50% messages",
+        "AlarmName": "sender-worker-PROD-processed-ios",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 3,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",
@@ -5892,12 +5892,12 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 50,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "processingRateioseditionBBDB2410": Object {
+    "processedioseditionC7509270": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -5918,10 +5918,10 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "AlarmDescription": "EC2 sender went below 75% processing rate",
-        "AlarmName": "sender-worker-PROD-processingRate-ios-edition",
+        "AlarmDescription": "EC2 sender processed less than 50% messages",
+        "AlarmName": "sender-worker-PROD-processed-ios-edition",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 3,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",
@@ -5989,7 +5989,7 @@ dpkg -i /tmp/sender-worker_1.0-latest_all.deb
             ],
           },
         ],
-        "Threshold": 75,
+        "Threshold": 50,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",


### PR DESCRIPTION
## What does this change?

We are building a EC2 implementation of sender worker, which is one of our experiments to further improve the performance of the notification delivery pipeline.

This PR creates alarms to help us monitor the health of the EC2 stack after it is released to PROD.  For each of the platforms (`android, ios`, `android-beta`, `android-edition`, `ios-edition`), it creates four alarms according to the [proposal](https://github.com/guardian/mobile-n10n/blob/main/docs/architecture/06-monitor-ec2-stack-rollout.md) in #825  

## Threshold

I examined similar metrics on the existing worker lambdas to figure out what reasonable values we should use for the thresholds initially:

### Age of the oldest message
<img width="1403" alt="Screenshot 2022-11-24 at 10 39 46" src="https://user-images.githubusercontent.com/89925410/203763673-f80d0176-0ce7-4a6f-9916-6030d8d13cfd.png">

The largest value for this metric was 650.  I set the threshold of the alarm to 700

### Number of messages in flight
<img width="1420" alt="Screenshot 2022-11-24 at 10 37 50" src="https://user-images.githubusercontent.com/89925410/203763346-95d036a2-7dab-431d-adb5-d4bb7bc9a3f5.png">

The largest value for this metric was 350.  I set the threshold to 400.

### Processed messages percentage
It is worth noting that there is a time lapse between the time a message is received and the time a message has been processed, and that is the reason why the percentage sometimes drops to zero and then goes up well above 100%.

Despite this, we could still make use of this metric to monitor whether the EC2 _is processing_ SQS messages at all.  To make it useful, I set the evaluation period to 3 to avoid false alarms as described above, and set the threshold to 50%.

### Failure rate
I notice high failure rate was high on Android occasionally, but it happened probably because we were running an experiment on Android platform  For ios, it is consistently below 1%.  So the failure rate threshold is set to 1%.

<img width="1461" alt="Screenshot 2022-11-24 at 12 16 00" src="https://user-images.githubusercontent.com/89925410/203783095-9599c18e-fd9b-4c16-9b5d-ddedec06d5e6.png">

## How to test

I deployed it to `CODE` and verified the created cloudwatch alarms and the metrics behind them.

## How can we measure success?

An alarm is raised when the EC2 stack stops working.


