### PR TITLE
LIVE-4823: Define new configurable properties for iOS sender worker

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -110,7 +110,9 @@ object Configuration {
         certificate = config.getString("apns.certificate"),
         mapiBaseUrl = config.getString("mapi.baseUrl"),
         sendingToProdServer = config.getBoolean("apns.sendingToProdServer"),
-        dryRun = config.getBoolean("dryrun")
+        dryRun = config.getBoolean("dryrun"),
+        concurrentPushyConnections = config.getInt("apns.concurrentPushyConnections"),
+        maxConcurrency = config.getInt("apns.maxConcurrency"),
       ),
       config.getInt("apns.threadPoolSize")
     )

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/IOSSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/IOSSender.scala
@@ -26,6 +26,6 @@ class IOSSender(val config: ApnsWorkerConfiguration, val metricNs: String) exten
 
   override val deliveryService: IO[Apns[IO]] =
     ApnsClient(config.apnsConfig).fold(e => IO.raiseError(e), c => IO.delay(new Apns(c)))
-  override val maxConcurrency = 100
+  override val maxConcurrency = config.apnsConfig.maxConcurrency
 
 }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
@@ -130,6 +130,7 @@ object ApnsClient {
         .setApnsServer(apnsServer)
         .setSigningKey(signingKey)
         .setConnectionTimeout(10, TimeUnit.SECONDS)
+        .setConcurrentConnections(config.concurrentPushyConnections)
         .build()
     ).map(pushyClient => new ApnsClient(pushyClient, config))
   }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/ApnsConfig.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/models/ApnsConfig.scala
@@ -7,5 +7,7 @@ case class ApnsConfig(
   certificate: String,
   mapiBaseUrl: String,
   sendingToProdServer: Boolean = false,
-  dryRun: Boolean = true
+  dryRun: Boolean = true,
+  concurrentPushyConnections: Int,
+  maxConcurrency: Int,
 )

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/apns/models/payload/ApnsPayloadBuilderSpec.scala
@@ -60,7 +60,9 @@ class ApnsPayloadBuilderSpec extends Specification with Matchers {
         bundleId = "",
         keyId = "",
         certificate = "",
-        mapiBaseUrl = "https://mobile.guardianapis.com"
+        mapiBaseUrl = "https://mobile.guardianapis.com",
+        maxConcurrency = 100,
+        concurrentPushyConnections = 1,
       )
       val generatedJson = new ApnsPayloadBuilder(dummyConfig)
         .apply(notification)

--- a/senderworker/src/main/scala/com/gu/notifications/ec2worker/Configuration.scala
+++ b/senderworker/src/main/scala/com/gu/notifications/ec2worker/Configuration.scala
@@ -41,7 +41,9 @@ object Configuration {
         certificate = config.getString("apns.certificate"),
         mapiBaseUrl = config.getString("mapi.baseUrl"),
         sendingToProdServer = config.getBoolean("apns.sendingToProdServer"),
-        dryRun = config.getBoolean("dryrun")
+        dryRun = config.getBoolean("dryrun"),
+        concurrentPushyConnections = config.getInt("apns.concurrentPushyConnections"),
+        maxConcurrency = config.getInt("apns.maxConcurrency"),
       ),
       config.getInt("apns.threadPoolSize")
     )


### PR DESCRIPTION
## What does this change?

In this PR we make `maxConcurrency` and the number of concurrent connections configurable properties. This will enable testing and tuning of the ios sender worker as part of future experiments.

SSM variables will be created with the current values:
- maxConcurrency: 100
- number of concurrent connections: this wasn't previously specified, but the [default](https://github.com/jchambers/pushy/blob/master/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientBuilder.java#L75) value is 1

## How to test

Given this change is deployed, we should expect to see no changes. The current values of the new configurable properties have been set to what we already use:
- maxConcurrency: 100
- number of concurrent connections: 1

We should expect both the sender lambdas and the ec2 workers to start up correctly, having retrieved the new properties successfully from SSM.

