### PR TITLE
Fix logging for 90in2 deliveries

### DIFF
--- a/slomonitor/src/main/scala/com.gu.notifications.slos/SloMonitor.scala
+++ b/slomonitor/src/main/scala/com.gu.notifications.slos/SloMonitor.scala
@@ -154,7 +154,7 @@ object SloMonitor {
         val androidDeliveries = rows.head
         val iosDeliveries = rows(1)
         pushMetricsToCloudWatch(buildMetricsForPlatform(androidDeliveries, "android") ++ buildMetricsForPlatform(iosDeliveries, "ios"))
-        val deliveriesWithinTwoMinutes = androidDeliveries(4) + iosDeliveries(4)
+        val deliveriesWithinTwoMinutes = Try(androidDeliveries(4).toDouble + iosDeliveries(4).toDouble).getOrElse("unknown")
         logger.info(Map(
           "notificationId" -> notificationId,
           "deliveriesWithin2mins" -> deliveriesWithinTwoMinutes


### PR DESCRIPTION
## What does this change?

Fixes a bug introduced by https://github.com/guardian/mobile-n10n/pull/866, which is caused by using `+` with `String`s instead of `Double`s 🤦‍♂️:

![image](https://user-images.githubusercontent.com/19384074/206199232-9861d9bf-01e5-46c7-a12b-78548268675d.png)

`Notifications delivered within 120 seconds was 374718449495` 🤯 

## How to test

I have deployed to `CODE` and checked the logging: 

![image](https://user-images.githubusercontent.com/19384074/206207252-fa1dca3a-2b9e-421f-8c2e-8ed686345898.png)

![image](https://user-images.githubusercontent.com/19384074/206207540-da16e9e0-8323-47c0-ae97-b4d366216944.png)

## How can we measure success?

The logging should be truthful again after this PR is merged.

## Have we considered potential risks?

I think this is pretty low risk.