### PR TITLE
LIVE-4850 upgrade to Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ dynamodb-local-schedule-lambda/
 project/.bloop/
 project/metals.sbt
 .bsp/
-.tool-versions

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.17.8.1

--- a/eventconsumer/cfn.yaml
+++ b/eventconsumer/cfn.yaml
@@ -128,7 +128,7 @@ Resources:
       Handler: com.gu.notifications.events.AthenaLambda::handleRequest
       MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
+      Runtime: java11
       Timeout: 120
       Tags:
         - Key: Stage

--- a/fakebreakingnewslambda/fakebreakingnewslambda-cfn.yaml
+++ b/fakebreakingnewslambda/fakebreakingnewslambda-cfn.yaml
@@ -78,7 +78,7 @@ Resources:
       Handler: fakebreakingnews.FakeBreakingNewsLambda::handleRequest
       MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
+      Runtime: java11
       Timeout: 300
       Tags:
         - Key: Stage

--- a/fakebreakingnewslambda/riff-raff.yaml
+++ b/fakebreakingnewslambda/riff-raff.yaml
@@ -6,7 +6,8 @@ deployments:
     type: aws-lambda
     app: fakebreakingnewslambda
     parameters:
-      bucket: mobile-notifications-dist
+      bucketSsmLookup: true
+      bucketSsmKey: /account/services/artifact.bucket.n10n
       functionNames: [mobile-notifications-fakebreakingnews-]
       fileName: fakebreakingnewslambda.jar
       prefixStack: false

--- a/football/cfn.yaml
+++ b/football/cfn.yaml
@@ -86,7 +86,7 @@ Resources:
       Handler: com.gu.mobile.notifications.football.Lambda::handler
       MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
+      Runtime: java11
       Timeout: 60
 
   MinuteEvent:

--- a/notification/conf/riff-raff.yaml
+++ b/notification/conf/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: notification
     parameters:
       amiTags:
-        Recipe: bionic-mobile-ARM
+        Recipe: bionic-mobile-java11-ARM
         AmigoStage: PROD
       templatePath: cfn.yaml
       templateStageParameters:

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -177,6 +177,8 @@ trait HarvesterRequestHandler extends Logging {
   def handleHarvesting(event: SQSEvent, context: Context): Unit = {
     // open connection
     val (transactor, datasource): (Transactor[IO], HikariDataSource) = DatabaseConfig.transactorAndDataSource[IO](jdbcConfig)
+    logger.info("Java version: " + System.getProperty("java.version"))
+
     logger.info("SQL connection open")
 
     // create services that rely on the connection

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
@@ -98,6 +98,8 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
       .map(r => (r.getBody, r.getAttributes.getOrDefault("SentTimestamp", "0").toLong))
       .map { case (body, sentTimestamp) => (NotificationParser.parseChunkedTokenEvent(body), sentTimestamp, startTime, sqsMessageBatchSize) }
 
+    logger.info("Java version: " + System.getProperty("java.version"))
+
     deliverChunkedTokens(chunkedTokenStream)
       .compile
       .drain

--- a/registration/conf/riff-raff.yaml
+++ b/registration/conf/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: registration
     parameters:
       amiTags:
-        Recipe: bionic-mobile-ARM
+        Recipe: bionic-mobile-java11-ARM
         AmigoStage: PROD
       templateStagePaths:
         CODE: Registration-CODE.template.json

--- a/report/conf/riff-raff.yaml
+++ b/report/conf/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: report
     parameters:
       amiTags:
-        Recipe: bionic-mobile-ARM
+        Recipe: bionic-mobile-java11-ARM
         AmigoStage: PROD
       templatePath: cfn.yaml
   report:

--- a/reportextractor/cfn.yaml
+++ b/reportextractor/cfn.yaml
@@ -80,7 +80,7 @@ Resources:
       MemorySize: 1024
       ReservedConcurrentExecutions: 1
       Role: !GetAtt Role.Arn
-      Runtime: java8
+      Runtime: java11
       Timeout: 60
   EventRule:
     Type: AWS::Events::Rule

--- a/schedulelambda/cfn.yaml
+++ b/schedulelambda/cfn.yaml
@@ -76,7 +76,7 @@ Resources:
       MemorySize: 1024
       ReservedConcurrentExecutions: 1
       Role: !GetAtt MobileNotificationsScheduleRole.Arn
-      Runtime: java8
+      Runtime: java11
       Timeout: 300
   MobileNotificationsScheduleEventRule:
     Type: AWS::Events::Rule

--- a/senderworker/riff-raff.yaml
+++ b/senderworker/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
     parameters:
       amiParameter: AMISenderworker
       amiTags:
-        Recipe: bionic-mobile-ARM
+        Recipe: bionic-mobile-java11-ARM
         AmigoStage: PROD
       templateStagePaths: 
         CODE: SenderWorker-CODE.template.json


### PR DESCRIPTION
## What does this change?

We are exploring the new AWS `Snapstart` feature to reduce the cold start initialisation time of the sender lambda in our effort to increase the overall notification delivery performance.  The `Snapstart` feature requires Java11 runtime so we have to upgrade the lambda function from Java 8 to Java11.

Other important reasons are:
1.  it was reported that Graviton servers achieve better performance on Java 11 
2. more generally, newer Java versions support newer language and platform features
3. it is suggested that future Scala 3 versions may drop support for Java 8
4. the Play Framework, which is used in `registration`, `notification` and `report`, announced that the next major version (2.9) will drop support for Java 8
 
This PR upgrades the whole project to use Java11.

Major changes are:
1. Set the lambda runtime to Java11 (for those which do not use docker)
2. Change AMI recipe to `bionic-mobile-java11-ARM` for EC2 app.  This recipe is basically identical to the old recipe `bionic-mobile-ARM` except that Java 8 is replaced with Java 11.
3. Add `.tool-version` so that the `asdf` (if installed) attempts to use JDK11 when we compile and test the project locally

## How to test
All test cases passed.  All modules were deployed on CODE successfully.  I tried registering tokens and sending push notifications on CODE, and it worked as expected.

## How can we measure success?
All services run properly.
