### PR TITLE
Collect token delivery latency metrics

### DIFF
--- a/common/src/main/scala/models/ShardedNotification.scala
+++ b/common/src/main/scala/models/ShardedNotification.scala
@@ -2,6 +2,8 @@ package models
 
 import play.api.libs.json.{Format, Json}
 
+import java.time.Instant
+
 case class ShardRange(start: Short, end: Short) {
   def range: Range = Range.inclusive(start, end)
 }
@@ -13,6 +15,7 @@ object ShardRange {
 case class ShardedNotification(
   notification: Notification,
   range: ShardRange,
+  notificationAppReceivedTime: Option[Instant]
 )
 
 object ShardedNotification {

--- a/notification/app/notification/services/NotificationSender.scala
+++ b/notification/app/notification/services/NotificationSender.scala
@@ -2,8 +2,9 @@ package notification.services
 
 import models.Notification
 
+import java.time.Instant
 import scala.concurrent.Future
 
 trait NotificationSender {
-  def sendNotification(notification: Notification): Future[SenderResult]
+  def sendNotification(notification: Notification, notificationReceivedTime: Instant): Future[SenderResult]
 }

--- a/notification/app/notification/services/frontend/FrontendAlerts.scala
+++ b/notification/app/notification/services/frontend/FrontendAlerts.scala
@@ -1,7 +1,6 @@
 package notification.services.frontend
 
 import java.net.URI
-
 import models.{BreakingNewsNotification, Notification, SenderReport}
 import notification.services.{NotificationSender, SenderError, SenderResult, Senders}
 import org.joda.time.DateTime
@@ -10,6 +9,7 @@ import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.mvc.Http.Status.CREATED
 
+import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 
 case class FrontendAlertsConfig(endpoint: URI, apiKey: String)
@@ -31,7 +31,7 @@ class FrontendAlerts(config: FrontendAlertsConfig, wsClient: WSClient)(implicit 
       }
     }
 
-  override def sendNotification(notification: Notification): Future[SenderResult] = notification match {
+  override def sendNotification(notification: Notification, notificationReceivedTime: Instant): Future[SenderResult] = notification match {
     case bn: BreakingNewsNotification =>
       sendAsBreakingNewsAlert(notification, bn)
     case _ =>

--- a/notification/test/notification/controllers/MainSpec.scala
+++ b/notification/test/notification/controllers/MainSpec.scala
@@ -1,8 +1,8 @@
 package notification.controllers
 
 import models.TopicTypes.Breaking
-import java.util.UUID
 
+import java.util.UUID
 import models._
 import notification.{DateTimeFreezed, NotificationsFixtures}
 import notification.services.{NewsstandSender, _}
@@ -19,6 +19,8 @@ import play.api.test.Helpers.stubControllerComponents
 import cats.syntax.either._
 import metrics.CloudWatchMetrics
 import org.joda.time.DateTime
+
+import java.time.Instant
 
 
 class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito with JsonMatchers with DateTimeFreezed {
@@ -112,7 +114,7 @@ class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito
     newsstandNotificationSender.sendNotification(any[UUID]) returns Future.successful(Right(Some("")))
     val mockNotificationSender = {
       new NotificationSender {
-        override def sendNotification(notification: Notification): Future[SenderResult] = {
+        override def sendNotification(notification: Notification, notificationAppSentTime: Instant): Future[SenderResult] = {
           pushSent = Some(notification)
           Future.successful(Right(senderReport(Senders.AzureNotificationsHub)))
         }
@@ -121,7 +123,7 @@ class MainSpec(implicit ec: ExecutionEnv) extends PlaySpecification with Mockito
 
     val mockBadNotificationSender = {
       new NotificationSender {
-        override def sendNotification(notification: Notification): Future[SenderResult] = {
+        override def sendNotification(notification: Notification, notificationAppSentTime: Instant): Future[SenderResult] = {
           Future.failed(new Throwable("non fatal error"))
         }
       }

--- a/notification/test/notification/services/frontend/FrontendAlertsSpec.scala
+++ b/notification/test/notification/services/frontend/FrontendAlertsSpec.scala
@@ -1,7 +1,6 @@
 package notification.services.frontend
 
 import java.net.URI
-
 import models.BreakingNewsNotification
 import models.Link.External
 import notification.NotificationsFixtures
@@ -15,13 +14,15 @@ import play.api.routing.sird._
 import play.api.mvc._
 import play.api.test._
 
+import java.time.Instant
+
 class FrontendAlertsSpec(implicit ee: ExecutionEnv) extends Specification with Mockito {
   "Frontend alerts notified about notification" should {
     "skip breaking news notification without capi id (i.e. with non-internal Link)" in new FrontendAlertsScope {
 
       val push = contentTargetedBreakingNewsPush().asInstanceOf[BreakingNewsNotification].copy(link = External("url"))
 
-      alerts.sendNotification(push) must beEqualTo(Left(FrontendAlertsProviderError("Alert could not be created"))).await
+      alerts.sendNotification(push, Instant.now()) must beEqualTo(Left(FrontendAlertsProviderError("Alert could not be created"))).await
 
       there was no(wsClient).url(any)
     }
@@ -35,7 +36,7 @@ class FrontendAlertsSpec(implicit ee: ExecutionEnv) extends Specification with M
       } { implicit port =>
         WsTestClient.withClient { client =>
           val alerts = new FrontendAlerts(config, client)
-          alerts.sendNotification(contentTargetedBreakingNewsPush()) must beRight.await
+          alerts.sendNotification(contentTargetedBreakingNewsPush(), Instant.now()) must beRight.await
         }
       }
     }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -5,7 +5,7 @@ import com.gu.notifications.worker.cleaning.CleaningClientImpl
 import com.gu.notifications.worker.delivery.DeliveryException.InvalidToken
 import com.gu.notifications.worker.delivery.{BatchDeliverySuccess, DeliveryClient, DeliveryException}
 import com.gu.notifications.worker.delivery.fcm.{Fcm, FcmClient}
-import com.gu.notifications.worker.models.SendingResults
+import com.gu.notifications.worker.models.{LatencyMetrics, SendingResults}
 import com.gu.notifications.worker.tokens.{BatchNotification, ChunkedTokens}
 import com.gu.notifications.worker.utils.{Cloudwatch, CloudwatchImpl, Reporting}
 import fs2.{Pipe, Stream}
@@ -45,6 +45,7 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
         deliverBatchNotificationStream(Stream.emits(chunkedTokens.toBatchNotificationToSends).covary[IO])
           .broadcastTo(
             reportBatchSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
+            reportBatchLatency(chunkedTokens, functionStartTime), // FIXME - we want the time that the MSS stack received the notification, not the function start time
             cleanupBatchFailures(chunkedTokens.notification.id),
             trackBatchProgress(chunkedTokens.notification.id))
     }.parJoin(maxConcurrency)
@@ -66,7 +67,17 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
     input
       .fold(SendingResults.empty) { case (acc, resp) => SendingResults.aggregateBatch(acc, chunkedTokens.tokens.size, resp) }
       .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform, sqsMessageBatchSize), prefix = s"Results $notificationLog: ").andThen(_.map(cloudwatch.sendPerformanceMetrics(env.stage, enableAwsMetric))))
-      .through(cloudwatch.sendMetrics(env.stage, Configuration.platform))
+      .through(cloudwatch.sendResults(env.stage, Configuration.platform))
+  }
+
+  def reportBatchLatency[C <: DeliveryClient](chunkedTokens: ChunkedTokens, notificationSentTime: Instant): Pipe[IO, Either[DeliveryException, BatchDeliverySuccess], Unit] = { input =>
+    val shouldPushMetricsToAws = chunkedTokens.notification.dryRun match {
+      case Some(true) => false
+      case _ => true
+    }
+    input
+      .fold(LatencyMetrics.empty) { case (acc, resp) => LatencyMetrics.aggregateBatchLatency(acc, resp, notificationSentTime) }
+      .through(cloudwatch.sendLatencyMetrics(shouldPushMetricsToAws, env.stage, Configuration.platform))
   }
 
   def cleanupBatchFailures[C <: DeliveryClient](notificationId: UUID): Pipe[IO, Either[Throwable, BatchDeliverySuccess], Unit] = { input =>

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -76,7 +76,7 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
       case _ => true
     }
     input
-      .fold(LatencyMetrics.empty) { case (acc, resp) => LatencyMetrics.aggregateBatchLatency(acc, resp, notificationSentTime) }
+      .fold(List.empty[Long]) { case (acc, resp) => LatencyMetrics.collectBatchLatency(acc, resp, notificationSentTime) }
       .through(cloudwatch.sendLatencyMetrics(shouldPushMetricsToAws, env.stage, Configuration.platform))
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -45,7 +45,7 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
         deliverBatchNotificationStream(Stream.emits(chunkedTokens.toBatchNotificationToSends).covary[IO])
           .broadcastTo(
             reportBatchSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
-            reportBatchLatency(chunkedTokens, functionStartTime), // FIXME - we want the time that the MSS stack received the notification, not the function start time
+            reportBatchLatency(chunkedTokens, chunkedTokens.notificationAppReceivedTime.getOrElse(functionStartTime)), // FIXME: remove this fallback after initial deployment
             cleanupBatchFailures(chunkedTokens.notification.id),
             trackBatchProgress(chunkedTokens.notification.id))
     }.parJoin(maxConcurrency)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -77,7 +77,7 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
     }
     input
       .fold(List.empty[Long]) { case (acc, resp) => LatencyMetrics.collectBatchLatency(acc, resp, notificationSentTime) }
-      .through(cloudwatch.sendLatencyMetrics(shouldPushMetricsToAws, env.stage, Configuration.platform))
+      .through(cloudwatch.sendLatencyMetrics(shouldPushMetricsToAws, env.stage, Configuration.platform, Reporting.notificationTypeForObservability(chunkedTokens.notification)))
   }
 
   def cleanupBatchFailures[C <: DeliveryClient](notificationId: UUID): Pipe[IO, Either[Throwable, BatchDeliverySuccess], Unit] = { input =>

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -65,7 +65,7 @@ trait HarvesterRequestHandler extends Logging {
           case (targetSqs, harvestedToken) if targetSqs == workerSqs => harvestedToken.token
         }
         .chunkN(1000)
-        .map(chunk => ChunkedTokens(shardedNotification.notification, chunk.toList, shardedNotification.range))
+        .map(chunk => ChunkedTokens(shardedNotification.notification, chunk.toList, shardedNotification.range, shardedNotification.notificationAppReceivedTime))
         .map(deliveryService.sending)
         .parJoin(maxConcurrency)
         .collect {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
@@ -34,7 +34,8 @@ object NotificationWorkerLocalRun extends App {
   val tokens = ChunkedTokens(
     notification = notification,
     range = ShardRange(0, 1),
-    tokens = List("token")
+    tokens = List("token"),
+    notificationAppReceivedTime = Some(Instant.now())
   )
 
   val sqsEvent: SQSEvent = {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
@@ -52,7 +52,7 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
     }
     input
       .fold(List.empty[Long]) { case (acc, resp) => LatencyMetrics.collectLatency(acc, resp, notificationSentTime) }
-      .through(cloudwatch.sendLatencyMetrics(shouldPushMetricsToAws, env.stage, Configuration.platform))
+      .through(cloudwatch.sendLatencyMetrics(shouldPushMetricsToAws, env.stage, Configuration.platform, Reporting.notificationTypeForObservability(chunkedTokens.notification)))
   }
 
   def trackProgress[C <: DeliveryClient](notificationId: UUID): Pipe[IO, Either[DeliveryException, DeliverySuccess], Unit] = { input =>

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
@@ -1,20 +1,19 @@
 package com.gu.notifications.worker
 
 import java.util.UUID
-import _root_.models.{Notification, NotificationType, ShardRange}
 import cats.effect.{ContextShift, IO, Timer}
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.gu.notifications.worker.cleaning.CleaningClient
 import com.gu.notifications.worker.delivery.DeliveryException.InvalidToken
 import com.gu.notifications.worker.delivery._
-import models.SendingResults
+import models.{LatencyMetrics, SendingResults}
 import com.gu.notifications.worker.tokens.{ChunkedTokens, IndividualNotification}
 import com.gu.notifications.worker.utils.{Cloudwatch, Logging, NotificationParser, Reporting}
 import fs2.{Pipe, Stream}
 import org.slf4j.{Logger, LoggerFactory}
 
-import java.time.{Duration, Instant}
+import java.time.Instant
 import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
@@ -84,7 +84,7 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
         deliverIndividualNotificationStream(individualNotifications)
           .broadcastTo(
             reportSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
-            reportLatency(chunkedTokens, functionStartTime), // FIXME - we want the time that the MSS stack received the notification, not the function start time
+            reportLatency(chunkedTokens, chunkedTokens.notificationAppReceivedTime.getOrElse(functionStartTime)), // FIXME: remove this fallback after initial deployment
             cleanupFailures,
             trackProgress(chunkedTokens.notification.id))
       }.parJoin(maxConcurrency)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
@@ -46,6 +46,19 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
       .through(cloudwatch.sendMetrics(env.stage, Configuration.platform))
   }
 
+  def reportLatency[C <: DeliveryClient](chunkedTokens: ChunkedTokens, sentTime: Long, functionStartTime: Instant, sqsMessageBatchSize: Int): Pipe[IO, Either[DeliveryException, DeliverySuccess], Unit] = { input =>
+    val enableAwsMetric = chunkedTokens.notification.dryRun match {
+      case Some(true) => false
+      case _          => true
+    }
+
+//Aggregates results of the different BatchResponses //todo - modify this to aggregate durations into time buckets
+    input.fold(SendingResults.empty) { case (acc, resp) => SendingResults.aggregate(acc, resp) }
+//Sends aggregated results to Cloudwatch // todo - modify to push metrics in the format we want
+      .through(cloudwatch.sendMetrics(env.stage, Configuration.platform))
+  }
+
+
   def trackProgress[C <: DeliveryClient](notificationId: UUID): Pipe[IO, Either[DeliveryException, DeliverySuccess], Unit] = { input =>
     input.chunkN(100).evalMap(chunk => IO.delay(logger.info(Map("notificationId" -> notificationId), s"Processed ${chunk.size} individual notification")))
   }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
@@ -43,21 +43,8 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
 
     input.fold(SendingResults.empty) { case (acc, resp) => SendingResults.aggregate(acc, resp) }
       .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform, sqsMessageBatchSize = sqsMessageBatchSize), prefix = s"Results $notificationLog: ").andThen(_.map(cloudwatch.sendPerformanceMetrics(env.stage, enableAwsMetric))))
-      .through(cloudwatch.sendMetrics(env.stage, Configuration.platform))
+      .through(cloudwatch.sendResults(env.stage, Configuration.platform))
   }
-
-  def reportLatency[C <: DeliveryClient](chunkedTokens: ChunkedTokens, sentTime: Long, functionStartTime: Instant, sqsMessageBatchSize: Int): Pipe[IO, Either[DeliveryException, DeliverySuccess], Unit] = { input =>
-    val enableAwsMetric = chunkedTokens.notification.dryRun match {
-      case Some(true) => false
-      case _          => true
-    }
-
-//Aggregates results of the different BatchResponses //todo - modify this to aggregate durations into time buckets
-    input.fold(SendingResults.empty) { case (acc, resp) => SendingResults.aggregate(acc, resp) }
-//Sends aggregated results to Cloudwatch // todo - modify to push metrics in the format we want
-      .through(cloudwatch.sendMetrics(env.stage, Configuration.platform))
-  }
-
 
   def trackProgress[C <: DeliveryClient](notificationId: UUID): Pipe[IO, Either[DeliveryException, DeliverySuccess], Unit] = { input =>
     input.chunkN(100).evalMap(chunk => IO.delay(logger.info(Map("notificationId" -> notificationId), s"Processed ${chunk.size} individual notification")))

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliverySuccess.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliverySuccess.scala
@@ -5,16 +5,17 @@ import java.time.Instant
 sealed trait DeliverySuccess {
   def token: String
   def dryRun: Boolean
+
+  val deliveryTime: Instant
 }
 
 sealed trait BatchDeliverySuccess {
   def responses: List[Either[DeliveryException, DeliverySuccess]]
-  val timeOfCompletion: Instant
 }
-case class ApnsDeliverySuccess(token: String, dryRun: Boolean = false) extends DeliverySuccess
-case class FcmDeliverySuccess(token: String, messageId: String, dryRun: Boolean = false) extends DeliverySuccess
-case class FcmBatchDeliverySuccess(responses: List[Either[DeliveryException, FcmDeliverySuccess]], notificationId: String, timeOfCompletion: Instant = Instant.now()) extends BatchDeliverySuccess
+case class ApnsDeliverySuccess(token: String, deliveryTime: Instant, dryRun: Boolean = false) extends DeliverySuccess
+case class FcmDeliverySuccess(token: String, messageId: String, deliveryTime: Instant, dryRun: Boolean = false) extends DeliverySuccess
+case class FcmBatchDeliverySuccess(responses: List[Either[DeliveryException, FcmDeliverySuccess]], notificationId: String) extends BatchDeliverySuccess
 
-case class ApnsBatchDeliverySuccess(responses: List[Either[DeliveryException, ApnsDeliverySuccess]], notificationId: String, timeOfCompletion: Instant = Instant.now()) extends BatchDeliverySuccess
+case class ApnsBatchDeliverySuccess(responses: List[Either[DeliveryException, ApnsDeliverySuccess]], notificationId: String) extends BatchDeliverySuccess
 
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliverySuccess.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliverySuccess.scala
@@ -1,5 +1,7 @@
 package com.gu.notifications.worker.delivery
 
+import java.time.Instant
+
 sealed trait DeliverySuccess {
   def token: String
   def dryRun: Boolean
@@ -7,11 +9,12 @@ sealed trait DeliverySuccess {
 
 sealed trait BatchDeliverySuccess {
   def responses: List[Either[DeliveryException, DeliverySuccess]]
+  val timeOfCompletion: Instant
 }
 case class ApnsDeliverySuccess(token: String, dryRun: Boolean = false) extends DeliverySuccess
 case class FcmDeliverySuccess(token: String, messageId: String, dryRun: Boolean = false) extends DeliverySuccess
-case class FcmBatchDeliverySuccess(responses: List[Either[DeliveryException, FcmDeliverySuccess]], notificationId: String) extends BatchDeliverySuccess
+case class FcmBatchDeliverySuccess(responses: List[Either[DeliveryException, FcmDeliverySuccess]], notificationId: String, timeOfCompletion: Instant = Instant.now()) extends BatchDeliverySuccess
 
-case class ApnsBatchDeliverySuccess(responses: List[Either[DeliveryException, ApnsDeliverySuccess]], notificationId: String) extends BatchDeliverySuccess
+case class ApnsBatchDeliverySuccess(responses: List[Either[DeliveryException, ApnsDeliverySuccess]], notificationId: String, timeOfCompletion: Instant = Instant.now()) extends BatchDeliverySuccess
 
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
@@ -78,7 +78,7 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
         if (feedback.isSuccess) {
           val response = feedback.getNow
           if (response.isAccepted) {
-            onComplete(Right(ApnsDeliverySuccess(token)))
+            onComplete(Right(ApnsDeliverySuccess(token, Instant.now())))
           } else {
             val invalidationTimestamp = Option(response.getTokenInvalidationTimestamp)
               .map(d => new Timestamp(d.getTime).toLocalDateTime)
@@ -104,7 +104,7 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
     }
 
     if(dryRun) {
-      onComplete(Right(ApnsDeliverySuccess(token, dryRun = true)))
+      onComplete(Right(ApnsDeliverySuccess(token, Instant.now(), dryRun = true)))
     } else {
       val start = Instant.now
       val futureResult = underlying.sendNotification(pushNotification)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -93,7 +93,7 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
       onAPICallComplete(Right(
         FcmBatchDeliverySuccess(
           List.fill(tokens.size)(Right(FcmDeliverySuccess(s"success", "dryrun", dryRun = true))),
-          notificationId.toString,
+          notificationId.toString
         )))
     } else {
       import FirebaseHelpers._

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -61,20 +61,20 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
       .build
 
     if (dryRun) { // Firebase has a dry run mode but in order to get the same behavior for both APNS and Firebase we don't send the request
-      onAPICallComplete(Right(FcmDeliverySuccess(token, "dryrun", dryRun = true)))
+      onAPICallComplete(Right(FcmDeliverySuccess(token, "dryrun", Instant.now(), dryRun = true)))
     } else {
       import FirebaseHelpers._
       val start = Instant.now
       firebaseMessaging
         .sendAsync(message)
         .asScala
-        .onComplete { response => {
-            logger.info(Map(
-              "worker.individualRequestLatency" -> Duration.between(start, Instant.now).toMillis,
-              "notificationId" -> notificationId,
-            ), "Individual send request completed")
-            onAPICallComplete(parseSendResponse(notificationId, token, response))
-          }
+        .onComplete { response =>
+          val requestCompletionTime = Instant.now
+          logger.info(Map(
+            "worker.individualRequestLatency" -> Duration.between(start, requestCompletionTime).toMillis,
+            "notificationId" -> notificationId,
+          ), "Individual send request completed")
+          onAPICallComplete(parseSendResponse(notificationId, token, response, requestCompletionTime))
         }
     }
   }
@@ -92,7 +92,7 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
     if (dryRun) { // Firebase has a dry run mode but in order to get the same behavior for both APNS and Firebase we don't send the request
       onAPICallComplete(Right(
         FcmBatchDeliverySuccess(
-          List.fill(tokens.size)(Right(FcmDeliverySuccess(s"success", "dryrun", dryRun = true))),
+          List.fill(tokens.size)(Right(FcmDeliverySuccess(s"success", "dryrun", Instant.now(), dryRun = true))),
           notificationId.toString
         )))
     } else {
@@ -101,22 +101,22 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
       firebaseMessaging
         .sendMulticastAsync(message)
         .asScala
-        .onComplete { response => {
-            logger.info(Map(
-              "worker.batchRequestLatency" -> Duration.between(start, Instant.now).toMillis,
-              "notificationId" -> notificationId
-            ), "Batch send request completed")
-            parseBatchSendResponse(notificationId, tokens, response)(onAPICallComplete)
-          }
+        .onComplete { response =>
+          val requestCompletionTime = Instant.now
+          logger.info(Map(
+            "worker.batchRequestLatency" -> Duration.between(start, requestCompletionTime).toMillis,
+            "notificationId" -> notificationId
+          ), "Batch send request completed")
+          parseBatchSendResponse(notificationId, tokens, response, requestCompletionTime)(onAPICallComplete)
         }
     }
   }
 
   def parseSendResponse(
-    notificationId: UUID, token: String, response: Try[String]
+    notificationId: UUID, token: String, response: Try[String], requestCompletionTime: Instant
   ): Either[DeliveryException, Success] = response match {
     case Success(messageId) =>
-      Right(FcmDeliverySuccess(token, messageId))
+      Right(FcmDeliverySuccess(token, messageId, requestCompletionTime))
     case Failure(UnwrappingExecutionException(e: FirebaseMessagingException)) if invalidTokenErrorCodes.contains(e.getErrorCode) || isUnregistered(e) =>
       Left(InvalidToken(notificationId, token, e.getMessage))
     case Failure(UnwrappingExecutionException(e: FirebaseMessagingException)) =>
@@ -128,7 +128,7 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
   }
 
   def parseBatchSendResponse(
-    notificationId: UUID, tokens: List[String], triedResponse: Try[BatchResponse]
+    notificationId: UUID, tokens: List[String], triedResponse: Try[BatchResponse], requestCompletionTime: Instant
   )(cb: Either[DeliveryException, BatchSuccess] => Unit): Unit = triedResponse match {
     case Success(batchResponse) =>
       cb(Right(FcmBatchDeliverySuccess(
@@ -136,9 +136,9 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
         batchResponse.getResponses.asScala.toList.zip(tokens).map { el => {
           val (r, token) = el
           if (!r.isSuccessful) {
-            parseSendResponse(notificationId, token, Failure(r.getException))
+            parseSendResponse(notificationId, token, Failure(r.getException), requestCompletionTime)
           } else {
-            Right(FcmDeliverySuccess(s"Token in batch response succeeded", token))
+            Right(FcmDeliverySuccess(s"Token in batch response succeeded", token, requestCompletionTime))
           }
         }
         }, notificationId.toString)))

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
@@ -49,13 +49,13 @@ case class LatencyMetricsForCloudWatch(uniqueValues: List[Long], orderedCounts: 
 
 object LatencyMetrics {
 
-  def aggregateForCloudWatch(allTokenDeliveryLatencies: List[Long]): List[LatencyMetricsForCloudWatch] = {
-    val uniqueValues = allTokenDeliveryLatencies.distinct
-    val countsForEachValue = allTokenDeliveryLatencies.groupBy(identity).view.mapValues(_.size)
-    val orderedCounts = uniqueValues.map(value => countsForEachValue(value))
-    uniqueValues.grouped(150).toList.zipWithIndex.map { case (uniqueValueBatch, index) =>
-      val orderedCountsGrouped = orderedCounts.grouped(150).toList(index)
-      LatencyMetricsForCloudWatch(uniqueValueBatch, orderedCountsGrouped)
+  def aggregateForCloudWatch(allTokenDeliveryLatencies: List[Long], batchSize: Int = 150): List[LatencyMetricsForCloudWatch] = {
+    val uniqueLatencies = allTokenDeliveryLatencies.distinct
+    val countsForEachLatency = allTokenDeliveryLatencies.groupBy(identity).view.mapValues(_.size)
+    val orderedCounts = uniqueLatencies.map(value => countsForEachLatency(value))
+    uniqueLatencies.grouped(batchSize).toList.zipWithIndex.map { case (uniqueValueBatch, index) =>
+      val orderedCountsForBatch = orderedCounts.grouped(batchSize).toList(index)
+      LatencyMetricsForCloudWatch(uniqueValueBatch, orderedCountsForBatch)
     }
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
@@ -1,6 +1,8 @@
 package com.gu.notifications.worker.models
 
 import com.gu.notifications.worker.delivery.{BatchDeliverySuccess, DeliveryException, DeliverySuccess}
+import com.gu.notifications.worker.utils.Logging
+import org.slf4j.LoggerFactory
 
 import java.time.{Duration, Instant}
 
@@ -52,8 +54,8 @@ object LatencyMetrics {
     val countsForEachValue = allTokenDeliveryLatencies.groupBy(identity).view.mapValues(_.size)
     val orderedCounts = uniqueValues.map(value => countsForEachValue(value))
     uniqueValues.grouped(150).toList.zipWithIndex.map { case (uniqueValueBatch, index) =>
-      orderedCounts.grouped(150).toList(index)
-      LatencyMetricsForCloudWatch(uniqueValueBatch, orderedCounts)
+      val orderedCountsGrouped = orderedCounts.grouped(150).toList(index)
+      LatencyMetricsForCloudWatch(uniqueValueBatch, orderedCountsGrouped)
     }
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
@@ -2,7 +2,6 @@ package com.gu.notifications.worker.models
 
 import com.gu.notifications.worker.delivery.{BatchDeliverySuccess, DeliveryException, DeliverySuccess}
 
-import java.time.temporal.{ChronoUnit, TemporalUnit}
 import java.time.{Duration, Instant}
 
 case class SendingResults(

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
@@ -46,6 +46,14 @@ case class PerformanceMetrics(
 
 object LatencyMetrics {
 
+  def collectLatency(previous: List[Long], result: Either[Throwable, DeliverySuccess], notificationSentTime: Instant): List[Long] = {
+    result.map { successfulDelivery =>
+      val timeOfDeliveries: Instant = successfulDelivery.deliveryTime
+      val duration = Duration.between(notificationSentTime, timeOfDeliveries).toSeconds
+      previous :+ duration
+    }.getOrElse(previous) // If the overall batch was a failure (or the batch only contained failures) just return the previous result
+  }
+
   def collectBatchLatency(previous: List[Long], result: Either[Throwable, BatchDeliverySuccess], notificationSentTime: Instant): List[Long] = {
     result.toOption.flatMap { batchSuccess =>
       val successes = batchSuccess.responses.collect { case Right(success) => success }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
@@ -50,7 +50,7 @@ object LatencyMetrics {
       val timeOfDeliveries: Instant = successfulDelivery.deliveryTime
       val duration = Duration.between(notificationSentTime, timeOfDeliveries).toSeconds
       previous :+ duration
-    }.getOrElse(previous) // If the overall batch was a failure (or the batch only contained failures) just return the previous result
+    }.getOrElse(previous) // If the delivery was a failure just return the previous result
   }
 
   def collectBatchLatency(previous: List[Long], result: Either[Throwable, BatchDeliverySuccess], notificationSentTime: Instant): List[Long] = {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
@@ -43,7 +43,16 @@ case class PerformanceMetrics(
   chunkTokenSize: Int,
 )
 
+case class LatencyMetricsForCloudWatch(uniqueValues: List[Long], orderedCounts: List[Int])
+
 object LatencyMetrics {
+
+  def aggregateForCloudWatch(allTokenDeliveryLatencies: List[Long]): LatencyMetricsForCloudWatch = {
+    val uniqueValues = allTokenDeliveryLatencies.distinct
+    val countsForEachValue = allTokenDeliveryLatencies.groupBy(identity).view.mapValues(_.size)
+    val orderedCounts = uniqueValues.map(value => countsForEachValue(value))
+    LatencyMetricsForCloudWatch(uniqueValues, orderedCounts)
+  }
 
   def collectLatency(previous: List[Long], result: Either[Throwable, DeliverySuccess], notificationSentTime: Instant): List[Long] = {
     result.map { successfulDelivery =>

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
@@ -2,6 +2,7 @@ package com.gu.notifications.worker.models
 
 import com.gu.notifications.worker.delivery.{BatchDeliverySuccess, DeliveryException, DeliverySuccess}
 
+import java.time.temporal.{ChronoUnit, TemporalUnit}
 import java.time.{Duration, Instant}
 
 case class SendingResults(
@@ -43,36 +44,19 @@ case class PerformanceMetrics(
   chunkTokenSize: Int,
 )
 
-case class LatencyMetrics(
-  tokenDeliveriesWithin10: Int,
-  tokenDeliveriesWithin20: Int,
-  totalTokenDeliveries: Int
-)
-
 object LatencyMetrics {
 
-  def empty = LatencyMetrics(tokenDeliveriesWithin10 = 0, tokenDeliveriesWithin20 = 0, totalTokenDeliveries = 0)
-
-  def aggregateBatchLatency(previous: LatencyMetrics, result: Either[Throwable, BatchDeliverySuccess], notificationSentTime: Instant): LatencyMetrics = {
+  def collectBatchLatency(previous: List[Long], result: Either[Throwable, BatchDeliverySuccess], notificationSentTime: Instant): List[Long] = {
     result.toOption.flatMap { batchSuccess =>
       val successes = batchSuccess.responses.collect { case Right(success) => success }
       successes.headOption.map { firstDelivery =>
         val successfulDeliveries = successes.size
         val timeOfDeliveries: Instant = firstDelivery.deliveryTime
-        Duration.between(notificationSentTime, timeOfDeliveries).getSeconds match {
-          case seconds if seconds <= 10 => previous.copy(
-            tokenDeliveriesWithin10 = previous.tokenDeliveriesWithin10 + successfulDeliveries,
-            tokenDeliveriesWithin20 = previous.tokenDeliveriesWithin20 + successfulDeliveries,
-            totalTokenDeliveries = previous.totalTokenDeliveries + successfulDeliveries
-          )
-          case seconds if seconds <= 20 => previous.copy(
-            tokenDeliveriesWithin20 = previous.tokenDeliveriesWithin20 + successfulDeliveries,
-            totalTokenDeliveries = previous.totalTokenDeliveries + successfulDeliveries
-          )
-          case _ => previous.copy(
-            totalTokenDeliveries = previous.totalTokenDeliveries + successfulDeliveries
-          )
-        }
+        val duration = Duration.between(notificationSentTime, timeOfDeliveries).toSeconds
+        // The batch are all delivered at the same time so we dont need to recalculate for every delivery in the batch.
+        // However we do want to record a time for each delivery.
+        val batchDeliveryTimes = List.fill(successfulDeliveries)(duration)
+        previous ++ batchDeliveryTimes
       }
     }.getOrElse(previous) // If the overall batch was a failure (or the batch only contained failures) just return the previous result
   }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
@@ -9,12 +9,13 @@ import db.{HarvestedToken, RegistrationService, Topic}
 import fs2.Stream
 import play.api.libs.json.{Format, Json}
 
+import java.time.Instant
 import scala.concurrent.ExecutionContextExecutor
 
 case class IndividualNotification(notification: Notification, token: String)
 case class BatchNotification(notification: Notification, token: List[String])
 
-case class ChunkedTokens(notification: Notification, tokens: List[String], range: ShardRange) {
+case class ChunkedTokens(notification: Notification, tokens: List[String], range: ShardRange, notificationAppReceivedTime: Option[Instant]) {
   def toNotificationToSends: List[IndividualNotification] = tokens.map(IndividualNotification(notification, _))
   def toBatchNotificationToSends: List[BatchNotification] = tokens.grouped(500).map(BatchNotification(notification, _)).toList
 }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Cloudwatch.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Cloudwatch.scala
@@ -74,7 +74,7 @@ class CloudwatchImpl(val senderMetricNs: String) extends Cloudwatch {
       val orderedCounts = uniqueValues.map(value => countsForEachValue(value))
       val dimension = new Dimension().withName("platform").withValue(platform.map(_.toString).getOrElse("unknown"))
       // TODO: split into batches of 150 unique values: https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html
-      val cloudWatchMetric: MetricDatum = latencyDatum(name = "NotificationDeliveryLatency", dimension = dimension, values = uniqueValues, counts = orderedCounts)
+      val cloudWatchMetric: MetricDatum = latencyDatum(name = "TokenDeliveryLatency", dimension = dimension, values = uniqueValues, counts = orderedCounts)
       val req = new PutMetricDataRequest()
         .withNamespace(s"Notifications/$stage/$senderMetricNs")
         .withMetricData(cloudWatchMetric)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Cloudwatch.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Cloudwatch.scala
@@ -70,7 +70,6 @@ class CloudwatchImpl(val senderMetricNs: String) extends Cloudwatch {
   def sendLatencyMetrics(shouldPushMetricsToAws: Boolean, stage: String, platform: Option[Platform]): Pipe[IO, List[Long], Unit] = _.evalMap { deliveryTimes =>
     IO.delay {
       val latencyMetrics = LatencyMetrics.aggregateForCloudWatch(deliveryTimes)
-      // TODO: split into batches of 150 unique values: https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html
       val dimension = new Dimension().withName("platform").withValue(platform.map(_.toString).getOrElse("unknown"))
       val requests = latencyMetrics.map { valuesAndCounts =>
         val cloudWatchMetric: MetricDatum = latencyDatum("TokenDeliveryLatency", valuesAndCounts.uniqueValues, valuesAndCounts.orderedCounts, dimension)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Cloudwatch.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Cloudwatch.scala
@@ -1,20 +1,14 @@
 package com.gu.notifications.worker.utils
 
 import cats.effect.IO
-import com.amazonaws.internal.SdkInternalList
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
-import com.gu.notifications.worker.models.{LatencyMetrics, PerformanceMetrics, SendingResults}
+import com.gu.notifications.worker.models.{PerformanceMetrics, SendingResults}
 import fs2.Pipe
 import models.Platform
 
 import scala.jdk.CollectionConverters._
-import models.Notification
-import models.NotificationType
-
-import java.time.Instant
-import java.time.Duration
 
 trait Cloudwatch {
   def sendResults(stage: String, platform: Option[Platform]): Pipe[IO, SendingResults, Unit]

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
@@ -59,12 +59,7 @@ trait Logging {
     Map(
       "notificationId" -> notification.id,
       "platform" -> maybePlatform.map(_.toString).getOrElse("unknown"),
-      "type" -> {
-        notification.`type` match {
-          case NotificationType.BreakingNews => "breakingNews"
-          case _                             => "other"
-        }
-      },
+      "type" -> Reporting.notificationTypeForObservability(notification),
       "worker.functionProcessingRate" -> processingRate,
       "worker.functionProcessingTime" -> processingTime,
       "worker.notificationProcessingTime" -> Duration.between(start, end).toMillis,

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Reporting.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Reporting.scala
@@ -3,9 +3,15 @@ package com.gu.notifications.worker.utils
 import cats.effect.IO
 import com.gu.notifications.worker.delivery.DeliveryException.{FailedRequest, InvalidToken}
 import com.gu.notifications.worker.delivery.{BatchDeliverySuccess, DeliveryClient, DeliveryException, DeliverySuccess}
+import models.{Notification, NotificationType}
 import org.slf4j.Logger
 
 object Reporting {
+
+  def notificationTypeForObservability(notification: Notification): String = notification.`type` match {
+    case NotificationType.BreakingNews => "breakingNews"
+    case _ => "other"
+  }
 
   private def logMatchCase(response: Either[DeliveryException, DeliverySuccess], prefix: String)(implicit logger: Logger): Unit = response match {
     case Left(e: InvalidToken) => logger.warn(s"$prefix $e")

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -155,7 +155,8 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
     def sqsEventShardNotification(notification: Notification): SQSEvent = {
       val shardedNotification = ShardedNotification(
         notification = notification,
-        range = ShardRange(0, 1)
+        range = ShardRange(0, 1),
+        notificationAppReceivedTime = Some(Instant.now()),
       )
       val event = new SQSEvent()
       val sqsMessage = new SQSMessage()

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -268,6 +268,8 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
       override val cloudwatch: Cloudwatch = new Cloudwatch {
         override def sendResults(stage: String, platform: Option[Platform]): Pipe[IO, SendingResults, Unit] = ???
 
+        override def sendLatencyMetrics(shouldPushMetricsToAws: Boolean, stage: String, platform: Option[Platform]): Pipe[IO, List[Long], Unit] = ???
+
         override def sendPerformanceMetrics(stage: String, enablePerformanceMetric: Boolean): PerformanceMetrics => Unit = ???
 
         override def sendFailures(stage: String, platform: Platform): Pipe[IO, Throwable, Unit] = {

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -266,7 +266,7 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
       override val ec2ServiceSet: SqsDeliveryStack = createTestSqsDeliveryStack(ec2Deliveries)
 
       override val cloudwatch: Cloudwatch = new Cloudwatch {
-        override def sendMetrics(stage: String, platform: Option[Platform]): Pipe[IO, SendingResults, Unit] = ???
+        override def sendResults(stage: String, platform: Option[Platform]): Pipe[IO, SendingResults, Unit] = ???
 
         override def sendPerformanceMetrics(stage: String, enablePerformanceMetric: Boolean): PerformanceMetrics => Unit = ???
 

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -269,7 +269,7 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
       override val cloudwatch: Cloudwatch = new Cloudwatch {
         override def sendResults(stage: String, platform: Option[Platform]): Pipe[IO, SendingResults, Unit] = ???
 
-        override def sendLatencyMetrics(shouldPushMetricsToAws: Boolean, stage: String, platform: Option[Platform]): Pipe[IO, List[Long], Unit] = ???
+        override def sendLatencyMetrics(shouldPushMetricsToAws: Boolean, stage: String, platform: Option[Platform], notificationType: String): Pipe[IO, List[Long], Unit] = ???
 
         override def sendPerformanceMetrics(stage: String, enablePerformanceMetric: Boolean): PerformanceMetrics => Unit = ???
 

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -141,7 +141,7 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
 
         override def sendPerformanceMetrics(stage: String, enablePerformanceMetric: Boolean): PerformanceMetrics => Unit = _ => ()
 
-        override def sendMetrics(stage: String, platform: Option[Platform]): Pipe[IO, SendingResults, Unit] = { stream =>
+        override def sendResults(stage: String, platform: Option[Platform]): Pipe[IO, SendingResults, Unit] = { stream =>
           cloudwatchCallsCount += 1
           stream.map { results =>
             sendingResults = Some(results)

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -57,7 +57,7 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
     "Count dry runs" in new WRHSScope {
       override def deliveries: Stream[IO, Either[DeliveryException, ApnsDeliverySuccess]] =
         Stream(
-          Right(ApnsDeliverySuccess("token", dryRun = true))
+          Right(ApnsDeliverySuccess("token", Instant.now(), dryRun = true))
         )
 
       workerRequestHandler.handleChunkTokens(chunkedTokensNotification, null)
@@ -102,7 +102,7 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
     }
 
 
-    def deliveries: Stream[IO, Either[DeliveryException, ApnsDeliverySuccess]] = Stream(Right(ApnsDeliverySuccess("token")))
+    def deliveries: Stream[IO, Either[DeliveryException, ApnsDeliverySuccess]] = Stream(Right(ApnsDeliverySuccess("token", Instant.now())))
 
     def sqsDeliveries: Stream[IO, Either[Throwable, Unit]] = Stream(Right(()))
 
@@ -147,6 +147,10 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
             sendingResults = Some(results)
             ()
           }
+        }
+
+        override def sendLatencyMetrics(shouldPushMetricsToAws: Boolean, stage: String, platform: Option[Platform]): Pipe[IO, List[Long], Unit] = { stream =>
+          stream.map { _ => () }
         }
 
         override def sendFailures(stage: String, platform: Platform): Pipe[IO, Throwable, Unit] = throw new RuntimeException()

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -150,7 +150,7 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
           }
         }
 
-        override def sendLatencyMetrics(shouldPushMetricsToAws: Boolean, stage: String, platform: Option[Platform]): Pipe[IO, List[Long], Unit] = { stream =>
+        override def sendLatencyMetrics(shouldPushMetricsToAws: Boolean, stage: String, platform: Option[Platform], notificationType: String): Pipe[IO, List[Long], Unit] = { stream =>
           stream.map { _ => () }
         }
 

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -89,7 +89,8 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
     val chunkedTokens = ChunkedTokens(
       notification = notification,
       range = ShardRange(0, 1),
-      tokens = List("token")
+      tokens = List("token"),
+      notificationAppReceivedTime = Some(Instant.now())
     )
 
     val chunkedTokensNotification: SQSEvent = {

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/models/SendingResultsSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/models/SendingResultsSpec.scala
@@ -7,15 +7,34 @@ import org.specs2.specification.Scope
 class SendingResultsSpec extends Specification with Matchers {
 
   "LatencyMetrics.aggregateForCloudWatch" should {
-    "Batch token delivery latencies into the correct format" in new Scope {
+    "Create a single batch of token delivery latencies if there are less than 150 unique values" in new Scope {
       val allDeliveries = List(1L,1L,1L,1L,2L,2L,2L,3L)
       val result = LatencyMetrics.aggregateForCloudWatch(allDeliveries)
-      val expected = LatencyMetricsForCloudWatch(
+      val expected = List(LatencyMetricsForCloudWatch(
         uniqueValues = List(1L, 2L, 3L),
         orderedCounts = List(4, 3, 1),
-      )
+      ))
       result shouldEqual(expected)
     }
+
+    "Create multiple batches of token delivery latencies if there are more than 150 unique values" in new Scope {
+      val threeHundredUniques = (1L to 300L).toList
+      val moreData = List(1L, 1L, 1L, 1L, 300L, 300L, 300L)
+      val allDeliveries = threeHundredUniques ++ moreData
+      val result = LatencyMetrics.aggregateForCloudWatch(allDeliveries)
+      val expected = List(
+        LatencyMetricsForCloudWatch(
+          uniqueValues = (1L to 150L).toList,
+          orderedCounts = List(5) ++ List.fill(149)(1),
+        ),
+        LatencyMetricsForCloudWatch(
+          uniqueValues = (151L to 300L).toList,
+          orderedCounts = List.fill(149)(1) ++ List(4),
+        )
+      )
+      result shouldEqual (expected)
+    }
+
   }
 
 }

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/models/SendingResultsSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/models/SendingResultsSpec.scala
@@ -1,0 +1,21 @@
+package com.gu.notifications.worker.models
+
+import org.specs2.matcher.Matchers
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+class SendingResultsSpec extends Specification with Matchers {
+
+  "LatencyMetrics.aggregateForCloudWatch" should {
+    "Batch token delivery latencies into the correct format" in new Scope {
+      val allDeliveries = List(1L,1L,1L,1L,2L,2L,2L,3L)
+      val result = LatencyMetrics.aggregateForCloudWatch(allDeliveries)
+      val expected = LatencyMetricsForCloudWatch(
+        uniqueValues = List(1L, 2L, 3L),
+        orderedCounts = List(4, 3, 1),
+      )
+      result shouldEqual(expected)
+    }
+  }
+
+}

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/models/SendingResultsSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/models/SendingResultsSpec.scala
@@ -7,32 +7,36 @@ import org.specs2.specification.Scope
 class SendingResultsSpec extends Specification with Matchers {
 
   "LatencyMetrics.aggregateForCloudWatch" should {
-    "Create a single batch of token delivery latencies if there are less than 150 unique values" in new Scope {
+    "Create a single batch of token delivery latencies if there are less than 150 unique values (and the default batch size is used)" in new Scope {
       val allDeliveries = List(1L,1L,1L,1L,2L,2L,2L,3L)
       val result = LatencyMetrics.aggregateForCloudWatch(allDeliveries)
       val expected = List(LatencyMetricsForCloudWatch(
         uniqueValues = List(1L, 2L, 3L),
         orderedCounts = List(4, 3, 1),
       ))
-      result shouldEqual(expected)
+      result shouldEqual expected
     }
 
-    "Create multiple batches of token delivery latencies if there are more than 150 unique values" in new Scope {
-      val threeHundredUniques = (1L to 300L).toList
-      val moreData = List(1L, 1L, 1L, 1L, 300L, 300L, 300L)
-      val allDeliveries = threeHundredUniques ++ moreData
-      val result = LatencyMetrics.aggregateForCloudWatch(allDeliveries)
+    "Create multiple batches of token delivery latencies if the number of items exceeds the batch size" in new Scope {
+      val allDeliveries = List(7L, 5L, 7L, 6L, 6L, 6L, 6L, 10L, 10L, 10L, 10L, 10L, 9L, 4L, 4L, 4L, 4L, 4L, 4L, 9L, 9L)
+      val result = LatencyMetrics.aggregateForCloudWatch(allDeliveries, batchSize = 3)
       val expected = List(
         LatencyMetricsForCloudWatch(
-          uniqueValues = (1L to 150L).toList,
-          orderedCounts = List(5) ++ List.fill(149)(1),
+          uniqueValues = List(7L, 5L, 6L),
+          orderedCounts = List(2, 1, 4),
         ),
         LatencyMetricsForCloudWatch(
-          uniqueValues = (151L to 300L).toList,
-          orderedCounts = List.fill(149)(1) ++ List(4),
+          uniqueValues = List(10L, 9L, 4L),
+          orderedCounts = List(5, 3, 6),
         )
       )
-      result shouldEqual (expected)
+      result shouldEqual expected
+    }
+
+    "Create multiple batches of 150 by default" in new Scope {
+      val sixHundredUniques = (1L to 600L).toList
+      val result = LatencyMetrics.aggregateForCloudWatch(sixHundredUniques)
+      result.map(_.uniqueValues.size) shouldEqual List(150, 150, 150, 150)
     }
 
   }


### PR DESCRIPTION
cc @michaelwmcnamara (who also worked on this PR)

## What does this change?

This PR allows us to calculate (and collect CloudWatch metrics for) token delivery latency.

This means that we can use a standard latency metric in CloudWatch to visualise internal stack performance (i.e. we can check how the stack is performing in isolation of Firebase/APNS delivery times, which may be unpredictable). For example, we can calculate the 99th, 95th & 90th percentiles for token delivery latency. 

![image](https://user-images.githubusercontent.com/19384074/208446675-d5163adb-1edd-4b90-9832-34588babbb13.png)

We can also calculate an SLI based on this metric, for example:

Good events = _the number of token deliveries where the delivery took less than X seconds_
Valid events = _the number of token deliveries_
SLI = _(the number of token deliveries where the delivery took less than X seconds / the number of token deliveries) * 100_ 

IIUC a single token delivery directly corresponds to an individual user receiving a notification[^1]. Consequently, using token delivery latency is likely to be useful for an SLI (and potentially an SLO) because:

1. It is easy to understand/reason about the correlation between latency increasing and user happiness decreasing[^2]
2. It allows us to easily compare a (new) token delivery SLI with the (existing) 90in2 SLI, which also operates at the level of individual-user deliveries

## How to test

* I have deployed this to `CODE` and confirmed that the latency metrics being calculated look sensible
* Since this PR changes the JSON that is passed between the various microservices, I have also confirmed that:
  * A (dry-run) notification can be sent if `notification` is running an old build and the `workers` are running this new build
  * A (dry-run) notification can be sent if `notification` is running this new build and the `workers` are still running an old build
* I sent a single 'standard' notification (i.e. not a dry-run) to confirm that metrics were actually being pushed to CloudWatch. There were not many datapoints for this; I assume that we must have thousands of 'fake' tokens in `CODE`?
* We have added unit tests for the latency metric batching logic, as this was a little tricky to write

## How can we measure success?

* We can better visualise performance of the stack via CloudWatch (and Grafana)
* We should also be able to create alerts related to this metric/SLI (if desired)

## Have we considered potential risks?

I can think of a few potential risks here:

1. We are adding a new field to the JSON that is passed between the different microservices (see https://github.com/guardian/mobile-n10n/commit/a8d26d171c249e229a2240bf472d9d183866d3c2). I have tried to mitigate this risk making the field optional (for consumers) in the first instance. This means that any messages that are already in the queue(s) should still be processed correctly, even though they lack this new field. I have also tested (see above) to confirm that the service can continue operating successfully even if this build is rolled out to different microservices at different times. Once this PR has been deployed, we'll be able to make the new field mandatory in all of the models and this complexity will be removed.

1. We are making more API calls to CloudWatch as a result of this PR. This has the potential to:
   1. Slow the worker function(s) down 
   1. ~Introduce invocation failures (e.g. due to a CloudWatch API call failing).~ Update: I don't think a CloudWatch call failing will cause the invocation to fail, see [this comment](https://github.com/guardian/mobile-n10n/pull/884#discussion_r1052310294).
   1. Increase AWS costs[^3]
  
In order to mitigate the above, we have implemented batching logic so that latency metrics are pushed to CloudWatch in batches of _150 unique values_. 

I think each worker is currently [processing 1000 tokens](https://github.com/guardian/mobile-n10n/blob/471357ac709baada6dc9cfb6830a4bdc88c3e4b3/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala#L67)? So in theory a worker invocation could result in 7 additional API calls.

However, as a unique value in this context is the number of seconds spent processing a notification and Lambda invocations are well below 150 seconds, I would expect each Lambda to make one additional API call in practice[^4].

Note that there are options for optimising further here (e.g. we could move to [embedded metric format](https://aws.amazon.com/about-aws/whats-new/2019/11/amazon-cloudwatch-launches-embedded-metric-format/), or combine [some of the other CloudWatch monitoring functionality](https://github.com/guardian/mobile-n10n/blob/471357ac709baada6dc9cfb6830a4bdc88c3e4b3/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Cloudwatch.scala#L45-L77) into the same API calls).

[^1]: Assuming that the Firebase/APNS delivery succeeds eventually.
[^2]: I think it will be easier to explain this SLI to stakeholders than something more technical (e.g. throughput).
[^3]: Since we [pay per API call](https://aws.amazon.com/cloudwatch/pricing/).
[^4]: For example, when testing in `CODE` I observed that the Android Worker makes a single API call where there is only unique value - the number of seconds spent processing  (e.g. 45 seconds) - and the count is the number of tokens processed in that time (e.g. 1000).