### PR TITLE
Remove optionality from notificationAppReceivedTime in models

### DIFF
--- a/common/src/main/scala/models/ShardedNotification.scala
+++ b/common/src/main/scala/models/ShardedNotification.scala
@@ -15,7 +15,7 @@ object ShardRange {
 case class ShardedNotification(
   notification: Notification,
   range: ShardRange,
-  notificationAppReceivedTime: Option[Instant]
+  notificationAppReceivedTime: Instant
 )
 
 object ShardedNotification {

--- a/notification/app/notification/services/guardian/GuardianNotificationSender.scala
+++ b/notification/app/notification/services/guardian/GuardianNotificationSender.scala
@@ -112,7 +112,7 @@ class GuardianNotificationSender(
     }
 
     shard(countWithDefault).map { shard =>
-      val shardedNotification = ShardedNotification(notification, shard, Some(notificationReceivedTime))
+      val shardedNotification = ShardedNotification(notification, shard, notificationReceivedTime)
       val payloadJson = Json.stringify(Json.toJson(shardedNotification))
       val messageId = s"${notification.id}-${shard.start}-${shard.end}"
       new SendMessageBatchRequestEntry(messageId, payloadJson)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -45,7 +45,7 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
         deliverBatchNotificationStream(Stream.emits(chunkedTokens.toBatchNotificationToSends).covary[IO])
           .broadcastTo(
             reportBatchSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
-            reportBatchLatency(chunkedTokens, chunkedTokens.notificationAppReceivedTime.getOrElse(functionStartTime)), // FIXME: remove this fallback after initial deployment
+            reportBatchLatency(chunkedTokens, chunkedTokens.notificationAppReceivedTime),
             cleanupBatchFailures(chunkedTokens.notification.id),
             trackBatchProgress(chunkedTokens.notification.id))
     }.parJoin(maxConcurrency)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -65,7 +65,7 @@ trait HarvesterRequestHandler extends Logging {
           case (targetSqs, harvestedToken) if targetSqs == workerSqs => harvestedToken.token
         }
         .chunkN(1000)
-        .map(chunk => ChunkedTokens(shardedNotification.notification, chunk.toList, shardedNotification.range, Some(shardedNotification.notificationAppReceivedTime)))
+        .map(chunk => ChunkedTokens(shardedNotification.notification, chunk.toList, shardedNotification.range, shardedNotification.notificationAppReceivedTime))
         .map(deliveryService.sending)
         .parJoin(maxConcurrency)
         .collect {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -65,7 +65,7 @@ trait HarvesterRequestHandler extends Logging {
           case (targetSqs, harvestedToken) if targetSqs == workerSqs => harvestedToken.token
         }
         .chunkN(1000)
-        .map(chunk => ChunkedTokens(shardedNotification.notification, chunk.toList, shardedNotification.range, shardedNotification.notificationAppReceivedTime))
+        .map(chunk => ChunkedTokens(shardedNotification.notification, chunk.toList, shardedNotification.range, Some(shardedNotification.notificationAppReceivedTime)))
         .map(deliveryService.sending)
         .parJoin(maxConcurrency)
         .collect {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
@@ -35,7 +35,7 @@ object NotificationWorkerLocalRun extends App {
     notification = notification,
     range = ShardRange(0, 1),
     tokens = List("token"),
-    notificationAppReceivedTime = Some(Instant.now())
+    notificationAppReceivedTime = Instant.now()
   )
 
   val sqsEvent: SQSEvent = {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
@@ -84,7 +84,7 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
         deliverIndividualNotificationStream(individualNotifications)
           .broadcastTo(
             reportSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
-            reportLatency(chunkedTokens, chunkedTokens.notificationAppReceivedTime.getOrElse(functionStartTime)), // FIXME: remove this fallback after initial deployment
+            reportLatency(chunkedTokens, chunkedTokens.notificationAppReceivedTime),
             cleanupFailures,
             trackProgress(chunkedTokens.notification.id))
       }.parJoin(maxConcurrency)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContextExecutor
 case class IndividualNotification(notification: Notification, token: String)
 case class BatchNotification(notification: Notification, token: List[String])
 
-case class ChunkedTokens(notification: Notification, tokens: List[String], range: ShardRange, notificationAppReceivedTime: Option[Instant]) {
+case class ChunkedTokens(notification: Notification, tokens: List[String], range: ShardRange, notificationAppReceivedTime: Instant) {
   def toNotificationToSends: List[IndividualNotification] = tokens.map(IndividualNotification(notification, _))
   def toBatchNotificationToSends: List[BatchNotification] = tokens.grouped(500).map(BatchNotification(notification, _)).toList
 }

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -156,7 +156,7 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
       val shardedNotification = ShardedNotification(
         notification = notification,
         range = ShardRange(0, 1),
-        notificationAppReceivedTime = Some(Instant.now()),
+        notificationAppReceivedTime = Instant.now(),
       )
       val event = new SQSEvent()
       val sqsMessage = new SQSMessage()

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -90,7 +90,7 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
       notification = notification,
       range = ShardRange(0, 1),
       tokens = List("token"),
-      notificationAppReceivedTime = Some(Instant.now())
+      notificationAppReceivedTime = Instant.now()
     )
 
     val chunkedTokensNotification: SQSEvent = {


### PR DESCRIPTION
## What does this change?

Now that https://github.com/guardian/mobile-n10n/pull/884 has been merged for a while, we can be sure that all messages in our SQS queues will have the `notificationAppReceivedTime`. This means that we can simplify the models by making this property mandatory.

## How to test

I have deployed this to `CODE` and confirmed that a dry-run notification can still be processed.

## How can we measure success?

We can simplify the models and remove a couple of fallbacks which don't really make sense.

## Have we considered potential risks?

Merging this will make it a little bit harder to rollback https://github.com/guardian/mobile-n10n/pull/884, so I'll wait for a while before merging this one.