### PR TITLE
Bump protobuf-java

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -421,7 +421,7 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
       "com.google.firebase" % "firebase-admin" % "9.0.0",
-      "com.google.protobuf" % "protobuf-java" % "3.19.2",
+      "com.google.protobuf" % "protobuf-java" % "3.19.6",
       "com.amazonaws" % "aws-lambda-java-events" % "2.2.8",
       "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,


### PR DESCRIPTION
## What does this change?

This PR bumps the protobuf-java dependency to fix the high severity of snyk vulnerabilities.

## How to test

All unit tests have passed in the teamcity build.
