### PR TITLE
Categorise notifications based on their audience size to support SLI bucketing

### DIFF
--- a/common/src/main/scala/models/NotificationMetadata.scala
+++ b/common/src/main/scala/models/NotificationMetadata.scala
@@ -1,0 +1,11 @@
+package models
+
+import play.api.libs.json.{Format, Json}
+
+import java.time.Instant
+
+case class NotificationMetadata(notificationAppReceivedTime: Instant, audienceSize: Option[Int])
+
+object NotificationMetadata {
+  implicit val notificationMetadataJF: Format[NotificationMetadata] = Json.format[NotificationMetadata]
+}

--- a/common/src/main/scala/models/ShardedNotification.scala
+++ b/common/src/main/scala/models/ShardedNotification.scala
@@ -2,8 +2,6 @@ package models
 
 import play.api.libs.json.{Format, Json}
 
-import java.time.Instant
-
 case class ShardRange(start: Short, end: Short) {
   def range: Range = Range.inclusive(start, end)
 }
@@ -15,7 +13,7 @@ object ShardRange {
 case class ShardedNotification(
   notification: Notification,
   range: ShardRange,
-  notificationAppReceivedTime: Option[Instant]
+  metadata: Option[NotificationMetadata]
 )
 
 object ShardedNotification {

--- a/notification/app/notification/services/guardian/GuardianNotificationSender.scala
+++ b/notification/app/notification/services/guardian/GuardianNotificationSender.scala
@@ -112,7 +112,7 @@ class GuardianNotificationSender(
     }
 
     shard(countWithDefault).map { shard =>
-      val shardedNotification = ShardedNotification(notification, shard, Some(notificationReceivedTime))
+      val shardedNotification = ShardedNotification(notification, shard, Some(NotificationMetadata(notificationReceivedTime, registrationCount)))
       val payloadJson = Json.stringify(Json.toJson(shardedNotification))
       val messageId = s"${notification.id}-${shard.start}-${shard.end}"
       new SendMessageBatchRequestEntry(messageId, payloadJson)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -45,7 +45,7 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
         deliverBatchNotificationStream(Stream.emits(chunkedTokens.toBatchNotificationToSends).covary[IO])
           .broadcastTo(
             reportBatchSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
-            reportBatchLatency(chunkedTokens, chunkedTokens.notificationAppReceivedTime.getOrElse(functionStartTime)), // FIXME: remove this fallback after initial deployment
+            reportBatchLatency(chunkedTokens, chunkedTokens.metadata.map(_.notificationAppReceivedTime).getOrElse(functionStartTime)), // FIXME: remove this fallback after initial deployment
             cleanupBatchFailures(chunkedTokens.notification.id),
             trackBatchProgress(chunkedTokens.notification.id))
     }.parJoin(maxConcurrency)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -1,5 +1,6 @@
 package com.gu.notifications.worker
 
+import _root_.models.NotificationMetadata
 import cats.effect.{ContextShift, IO, Timer}
 import com.gu.notifications.worker.cleaning.CleaningClientImpl
 import com.gu.notifications.worker.delivery.DeliveryException.InvalidToken
@@ -45,7 +46,7 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
         deliverBatchNotificationStream(Stream.emits(chunkedTokens.toBatchNotificationToSends).covary[IO])
           .broadcastTo(
             reportBatchSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
-            reportBatchLatency(chunkedTokens, chunkedTokens.metadata.map(_.notificationAppReceivedTime).getOrElse(functionStartTime)), // FIXME: remove this fallback after initial deployment
+            reportBatchLatency(chunkedTokens, chunkedTokens.metadata),
             cleanupBatchFailures(chunkedTokens.notification.id),
             trackBatchProgress(chunkedTokens.notification.id))
     }.parJoin(maxConcurrency)
@@ -70,14 +71,14 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
       .through(cloudwatch.sendResults(env.stage, Configuration.platform))
   }
 
-  def reportBatchLatency[C <: DeliveryClient](chunkedTokens: ChunkedTokens, notificationSentTime: Instant): Pipe[IO, Either[DeliveryException, BatchDeliverySuccess], Unit] = { input =>
+  def reportBatchLatency[C <: DeliveryClient](chunkedTokens: ChunkedTokens, metadata: Option[NotificationMetadata]): Pipe[IO, Either[DeliveryException, BatchDeliverySuccess], Unit] = { input =>
     val shouldPushMetricsToAws = chunkedTokens.notification.dryRun match {
       case Some(true) => false
       case _ => true
     }
     input
-      .fold(List.empty[Long]) { case (acc, resp) => LatencyMetrics.collectBatchLatency(acc, resp, notificationSentTime) }
-      .through(cloudwatch.sendLatencyMetrics(shouldPushMetricsToAws, env.stage, Configuration.platform, Reporting.notificationTypeForObservability(chunkedTokens.notification)))
+      .fold(List.empty[Long]) { case (acc, resp) => LatencyMetrics.collectBatchLatency(acc, resp, metadata.map(_.notificationAppReceivedTime).getOrElse(Instant.now())) } // FIXME: remove this fallback after initial deployment
+      .through(cloudwatch.sendLatencyMetrics(shouldPushMetricsToAws, env.stage, Configuration.platform, metadata.flatMap(_.audienceSize)))
   }
 
   def cleanupBatchFailures[C <: DeliveryClient](notificationId: UUID): Pipe[IO, Either[Throwable, BatchDeliverySuccess], Unit] = { input =>

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Harvester.scala
@@ -65,7 +65,7 @@ trait HarvesterRequestHandler extends Logging {
           case (targetSqs, harvestedToken) if targetSqs == workerSqs => harvestedToken.token
         }
         .chunkN(1000)
-        .map(chunk => ChunkedTokens(shardedNotification.notification, chunk.toList, shardedNotification.range, shardedNotification.notificationAppReceivedTime))
+        .map(chunk => ChunkedTokens(shardedNotification.notification, chunk.toList, shardedNotification.range, shardedNotification.metadata))
         .map(deliveryService.sending)
         .parJoin(maxConcurrency)
         .collect {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
@@ -35,7 +35,7 @@ object NotificationWorkerLocalRun extends App {
     notification = notification,
     range = ShardRange(0, 1),
     tokens = List("token"),
-    notificationAppReceivedTime = Some(Instant.now())
+    metadata = Some(NotificationMetadata(Instant.now(), Some(1234)))
   )
 
   val sqsEvent: SQSEvent = {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
@@ -1,5 +1,6 @@
 package com.gu.notifications.worker
 
+import _root_.models.NotificationMetadata
 import java.util.UUID
 import cats.effect.{ContextShift, IO, Timer}
 import com.amazonaws.services.lambda.runtime.Context
@@ -45,14 +46,14 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
       .through(cloudwatch.sendResults(env.stage, Configuration.platform))
   }
 
-  def reportLatency[C <: DeliveryClient](chunkedTokens: ChunkedTokens, notificationSentTime: Instant): Pipe[IO, Either[DeliveryException, DeliverySuccess], Unit] = { input =>
+  def reportLatency[C <: DeliveryClient](chunkedTokens: ChunkedTokens, metadata: Option[NotificationMetadata]): Pipe[IO, Either[DeliveryException, DeliverySuccess], Unit] = { input =>
     val shouldPushMetricsToAws = chunkedTokens.notification.dryRun match {
       case Some(true) => false
       case _ => true
     }
     input
-      .fold(List.empty[Long]) { case (acc, resp) => LatencyMetrics.collectLatency(acc, resp, notificationSentTime) }
-      .through(cloudwatch.sendLatencyMetrics(shouldPushMetricsToAws, env.stage, Configuration.platform, Reporting.notificationTypeForObservability(chunkedTokens.notification)))
+      .fold(List.empty[Long]) { case (acc, resp) => LatencyMetrics.collectLatency(acc, resp, metadata.map(_.notificationAppReceivedTime).getOrElse(Instant.now())) } // FIXME: remove this fallback after initial deployment
+      .through(cloudwatch.sendLatencyMetrics(shouldPushMetricsToAws, env.stage, Configuration.platform, metadata.flatMap(_.audienceSize)))
   }
 
   def trackProgress[C <: DeliveryClient](notificationId: UUID): Pipe[IO, Either[DeliveryException, DeliverySuccess], Unit] = { input =>
@@ -84,7 +85,7 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
         deliverIndividualNotificationStream(individualNotifications)
           .broadcastTo(
             reportSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
-            reportLatency(chunkedTokens, chunkedTokens.metadata.map(_.notificationAppReceivedTime).getOrElse(functionStartTime)), // FIXME: remove this fallback after initial deployment
+            reportLatency(chunkedTokens, chunkedTokens.metadata),
             cleanupFailures,
             trackProgress(chunkedTokens.notification.id))
       }.parJoin(maxConcurrency)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
@@ -84,7 +84,7 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
         deliverIndividualNotificationStream(individualNotifications)
           .broadcastTo(
             reportSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
-            reportLatency(chunkedTokens, chunkedTokens.notificationAppReceivedTime.getOrElse(functionStartTime)), // FIXME: remove this fallback after initial deployment
+            reportLatency(chunkedTokens, chunkedTokens.metadata.map(_.notificationAppReceivedTime).getOrElse(functionStartTime)), // FIXME: remove this fallback after initial deployment
             cleanupFailures,
             trackProgress(chunkedTokens.notification.id))
       }.parJoin(maxConcurrency)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
@@ -84,5 +84,14 @@ object LatencyMetrics {
       }
     }.getOrElse(previous) // If the overall batch was a failure (or the batch only contained failures) just return the previous result
   }
+
+  def audienceSizeBucket(audienceSize: Option[Int]): String = audienceSize match {
+    case None => "unknown"
+    case Some(audience) if audience < 100000 => "S"
+    case Some(audience) if audience < 500000 => "M"
+    case Some(audience) if audience < 1000000 => "L"
+    case _ => "XL"
+  }
+
 }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
@@ -1,6 +1,6 @@
 package com.gu.notifications.worker.tokens
 
-import _root_.models.{Notification, ShardRange}
+import _root_.models.{Notification, NotificationMetadata, ShardRange}
 import cats.data.NonEmptyList
 import cats.effect.{Async, Concurrent, Timer}
 import cats.syntax.list._
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContextExecutor
 case class IndividualNotification(notification: Notification, token: String)
 case class BatchNotification(notification: Notification, token: List[String])
 
-case class ChunkedTokens(notification: Notification, tokens: List[String], range: ShardRange, notificationAppReceivedTime: Option[Instant]) {
+case class ChunkedTokens(notification: Notification, tokens: List[String], range: ShardRange, metadata: Option[NotificationMetadata]) {
   def toNotificationToSends: List[IndividualNotification] = tokens.map(IndividualNotification(notification, _))
   def toBatchNotificationToSends: List[BatchNotification] = tokens.grouped(500).map(BatchNotification(notification, _)).toList
 }

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -156,7 +156,7 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
       val shardedNotification = ShardedNotification(
         notification = notification,
         range = ShardRange(0, 1),
-        notificationAppReceivedTime = Some(Instant.now()),
+        metadata = Some(NotificationMetadata(Instant.now(), Some(1234))),
       )
       val event = new SQSEvent()
       val sqsMessage = new SQSMessage()

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -269,7 +269,7 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
       override val cloudwatch: Cloudwatch = new Cloudwatch {
         override def sendResults(stage: String, platform: Option[Platform]): Pipe[IO, SendingResults, Unit] = ???
 
-        override def sendLatencyMetrics(shouldPushMetricsToAws: Boolean, stage: String, platform: Option[Platform], notificationType: String): Pipe[IO, List[Long], Unit] = ???
+        override def sendLatencyMetrics(shouldPushMetricsToAws: Boolean, stage: String, platform: Option[Platform], audienceSize: Option[Int]): Pipe[IO, List[Long], Unit] = ???
 
         override def sendPerformanceMetrics(stage: String, enablePerformanceMetric: Boolean): PerformanceMetrics => Unit = ???
 

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -90,7 +90,7 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
       notification = notification,
       range = ShardRange(0, 1),
       tokens = List("token"),
-      notificationAppReceivedTime = Some(Instant.now())
+      metadata = Some(NotificationMetadata(Instant.now(), Some(1234)))
     )
 
     val chunkedTokensNotification: SQSEvent = {

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -150,7 +150,7 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
           }
         }
 
-        override def sendLatencyMetrics(shouldPushMetricsToAws: Boolean, stage: String, platform: Option[Platform], notificationType: String): Pipe[IO, List[Long], Unit] = { stream =>
+        override def sendLatencyMetrics(shouldPushMetricsToAws: Boolean, stage: String, platform: Option[Platform], audienceSize: Option[Int]): Pipe[IO, List[Long], Unit] = { stream =>
           stream.map { _ => () }
         }
 


### PR DESCRIPTION
cc @michaelwmcnamara (who also worked on this PR)

## What does this change?

This change is a follow-up to https://github.com/guardian/mobile-n10n/pull/884. It modifies the CloudWatch metrics sent from the notifications worker lambdas to include a dimension tracking the audience size for each notification. This replaces the `type` dimension (which captured whether the notification was `breakingNews` or `other`) in order to prevent us from creating too many unique metrics[^1].

The reason for this switch to audience size is:

1. IIUC there is no significant functional difference between the handling of Breaking News and other notifications.
2. The size of the audience for Breaking News notifications varies wildly between 10,000 and more than 1,000,000 (see the [Ophan notifications page](https://dashboard.ophan.co.uk/notifications) for examples).

The audience size of these notifications has been shown to have a very significant impact on the latency of the notification process and it is unrealistic expect the p90 latency for a notification sent to a small audience to be comparable with the p90 latency for a notification sent to a very large audience. This change allows us to bucket notifications by audience size instead, comparing like with like. 

This means that increases in latency can be attributed to performance problems, rather than notifications being sent to a different audience. There is more detail on the rationale for this [bucketing](https://cloud.google.com/stackdriver/docs/solutions/slo-monitoring/sli-metrics/overview#sli-bucket) approach [here](https://docs.google.com/document/d/1ao5-YGkAqN0NJ5x3EVOL0nv86QkMPSWSpw0JYMSSqUU/edit#heading=h.gphldjjod3y0).

## How to test
1. Using a copy of this branch, modify the worker to send metrics on a dry run ([example here](https://github.com/guardian/mobile-n10n/tree/jw-test-bucket-notifications))

2. Deploy this testing branch to code and use the instructions in the Readme docs to send a notification.
- note Make sure you set this notification up as a "dry-run" to prevent any accidental sendings.

- Once the notification has been sent wait 10 mins then, in Cloudwatch, examine the "Notifications/CODE/workers" metrics and confirm the expected Cloudwatch metrics and dimensions are visible.   

## How can we measure success?

We are able to get meaningful and useful data on the internal latency of notifications.

We are able to establish an SLI (or SLIs) which accurately capture performance issues (unfortunately it is [difficult to do this with the current metrics](https://docs.google.com/document/d/1ao5-YGkAqN0NJ5x3EVOL0nv86QkMPSWSpw0JYMSSqUU/edit#heading=h.gphldjjod3y0)).

[^1]: We want to avoid creating too many unique metrics because we will need to use metric math to combine them for alerts/dashboard. We need to strike the balance between having granular data and keeping the number of metrics that we're working with manageable. Furthermore, each unique dimension creates a new custom metric in CloudWatch (and this costs money!).