### PR TITLE
Make NotificationMetadata mandatory in models

### DIFF
--- a/common/src/main/scala/models/ShardedNotification.scala
+++ b/common/src/main/scala/models/ShardedNotification.scala
@@ -13,7 +13,7 @@ object ShardRange {
 case class ShardedNotification(
   notification: Notification,
   range: ShardRange,
-  metadata: Option[NotificationMetadata]
+  metadata: NotificationMetadata
 )
 
 object ShardedNotification {

--- a/notification/app/notification/services/guardian/GuardianNotificationSender.scala
+++ b/notification/app/notification/services/guardian/GuardianNotificationSender.scala
@@ -112,7 +112,7 @@ class GuardianNotificationSender(
     }
 
     shard(countWithDefault).map { shard =>
-      val shardedNotification = ShardedNotification(notification, shard, Some(NotificationMetadata(notificationReceivedTime, registrationCount)))
+      val shardedNotification = ShardedNotification(notification, shard, NotificationMetadata(notificationReceivedTime, registrationCount))
       val payloadJson = Json.stringify(Json.toJson(shardedNotification))
       val messageId = s"${notification.id}-${shard.start}-${shard.end}"
       new SendMessageBatchRequestEntry(messageId, payloadJson)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
@@ -35,7 +35,7 @@ object NotificationWorkerLocalRun extends App {
     notification = notification,
     range = ShardRange(0, 1),
     tokens = List("token"),
-    metadata = Some(NotificationMetadata(Instant.now(), Some(1234)))
+    metadata = NotificationMetadata(Instant.now(), Some(1234))
   )
 
   val sqsEvent: SQSEvent = {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContextExecutor
 case class IndividualNotification(notification: Notification, token: String)
 case class BatchNotification(notification: Notification, token: List[String])
 
-case class ChunkedTokens(notification: Notification, tokens: List[String], range: ShardRange, metadata: Option[NotificationMetadata]) {
+case class ChunkedTokens(notification: Notification, tokens: List[String], range: ShardRange, metadata: NotificationMetadata) {
   def toNotificationToSends: List[IndividualNotification] = tokens.map(IndividualNotification(notification, _))
   def toBatchNotificationToSends: List[BatchNotification] = tokens.grouped(500).map(BatchNotification(notification, _)).toList
 }

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/HarvesterRequestHandlerSpec.scala
@@ -156,7 +156,7 @@ class HarvesterRequestHandlerSpec extends Specification with Matchers {
       val shardedNotification = ShardedNotification(
         notification = notification,
         range = ShardRange(0, 1),
-        metadata = Some(NotificationMetadata(Instant.now(), Some(1234))),
+        metadata = NotificationMetadata(Instant.now(), Some(1234))
       )
       val event = new SQSEvent()
       val sqsMessage = new SQSMessage()

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -90,7 +90,7 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
       notification = notification,
       range = ShardRange(0, 1),
       tokens = List("token"),
-      metadata = Some(NotificationMetadata(Instant.now(), Some(1234)))
+      metadata = NotificationMetadata(Instant.now(), Some(1234))
     )
 
     val chunkedTokensNotification: SQSEvent = {


### PR DESCRIPTION
## What does this change?

Now that https://github.com/guardian/mobile-n10n/pull/943 has been merged for a while, we can be sure that all messages in our SQS queues will have the `metadata` field with `NotificationMetadata`. This means that we can simplify the models by making this property mandatory.

## How to test

I have deployed this to `CODE` and confirmed that a dry-run notification can still be processed.

## How can we measure success?

We can simplify the models and remove a couple of fallbacks which don't really make sense.

## Have we considered potential risks?

Merging this makes it slightly harder to rollback https://github.com/guardian/mobile-n10n/pull/943, but that change has been out for ~24 hours and it seems to be working fine, so I think that's OK.