### PR TITLE
Modify bucket sizes based on full topic counts

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
@@ -87,9 +87,9 @@ object LatencyMetrics {
 
   def audienceSizeBucket(audienceSize: Option[Int]): String = audienceSize match {
     case None => "unknown"
-    case Some(audience) if audience < 100000 => "S"
-    case Some(audience) if audience < 500000 => "M"
-    case Some(audience) if audience < 1000000 => "L"
+    case Some(audience) if audience < 250000 => "S"
+    case Some(audience) if audience < 1000000 => "M"
+    case Some(audience) if audience < 2000000 => "L"
     case _ => "XL"
   }
 

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/models/SendingResultsSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/models/SendingResultsSpec.scala
@@ -41,4 +41,29 @@ class SendingResultsSpec extends Specification with Matchers {
 
   }
 
+  "LatencyMetrics.audienceSizeBucket" should {
+
+    "Categorise a small audience correctly" in new Scope {
+      LatencyMetrics.audienceSizeBucket(Some(190007)) shouldEqual "S"
+    }
+
+    "Categorise a medium audience correctly" in new Scope {
+      LatencyMetrics.audienceSizeBucket(Some(858927)) shouldEqual "M"
+    }
+
+    "Categorise a large audience correctly" in new Scope {
+      LatencyMetrics.audienceSizeBucket(Some(1425749)) shouldEqual "L"
+    }
+
+    "Categorise an extra large audience correctly" in new Scope {
+      LatencyMetrics.audienceSizeBucket(Some(3012022)) shouldEqual "XL"
+    }
+
+    "Mark a missing audience as unknown" in new Scope {
+      LatencyMetrics.audienceSizeBucket(None) shouldEqual "unknown"
+    }
+
+  }
+
+
 }


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/mobile-n10n/pull/943, we configured audience bucket sizes (for tracking purposes). We [based the initial sizing on the delivery data in Ophan](https://github.com/guardian/mobile-n10n/pull/943#discussion_r1095756893), but this seems to differ significantly from the audience sizes for each topic in the DB.[^1] 

Consequently this PR modifies the bucket sizes so that we treat different audiences as intended (for example, we need to increase the lower limit for the XL audience size to ensure that this only matches global breaking news notifications).

## How to test

I have deployed this to `CODE` and confirmed that a dry-run notification can still be processed. I've also added a unit test.

## How can we measure success?

The bucket sizes should now line up with our original intentions, as explained [here]((https://github.com/guardian/mobile-n10n/pull/943#discussion_r1095756893)).

## Have we considered potential risks?

I think this change should be pretty low risk. We should exclude any data prior to this change when establishing baselines; I think it is simple enough to remember this as we'll be calculating the baselines manually.

[^1]: This disparity is slightly puzzling/worrying but I think that's beyond the scope of this PR!