### PR TITLE
Mention SLOs and dashboards in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ It has many uses:
 * Monitoring of notifications
 * Logging for diagnostics and status of each notification
 
+## SLOs and Dashboards
+
+We have Service Level Objectives (SLOs) in place for both the registration and notification services. Please refer to [this document](https://docs.google.com/document/d/1wDKfCFU4geZvpnYIjl3IENlJEu_7506GOvbxBhrocDI) for a full description. 
+
+There are several data visualizations and dashboards available in Grafana related to these SLOs. You can access them through the [Mobile Notifications SLO Hub](https://metrics.gutools.co.uk/d/hwjXe51Vz/mss-slos-start-here?orgId=1), which serves as the jumping-off point to explore them.
+
+
 ## Architecture
 ![Architecture Diagram](Notifications-Architecture.jpg)
 


### PR DESCRIPTION
## What does this change?

This adds a section to the README mentioning the "dashboard of dashboards" I mentioned in our recent meeting. I've renamed it to "Mobile Notifications SLO Hub", which I hope still conveys the intention behind it!

I wasn't too sure in which part of the README to write this, happy to move it to another part of the doc.
