### PR TITLE
Create github workflows to consolidate Scala Steward PR into one PR

### DIFF
--- a/.github/workflows/dependency-updates-automerge.yml
+++ b/.github/workflows/dependency-updates-automerge.yml
@@ -1,0 +1,14 @@
+name: Set automerge on dependency update PRs
+
+on:
+  pull_request:
+    branches:
+      - dependency-updates
+
+jobs:
+  set-automerge:
+    name: Set automerge on opened PRs targeting the tracking branch
+    permissions:
+      contents: write
+      pull-requests: write # only for private repositories
+    uses: guardian/.github/.github/workflows/pr-batching_set-automerge.yml@v1.0.1

--- a/.github/workflows/dependency-updates-batch-updates-PR.yml
+++ b/.github/workflows/dependency-updates-batch-updates-PR.yml
@@ -1,0 +1,12 @@
+name: Create batch dependency update PR
+
+on:
+  schedule:
+    - cron: "45 13 * * TUE"
+  # Provide support for manually triggering the workflow via GitHub.
+  workflow_dispatch:
+
+jobs:
+  pr-tracking-branch:
+    name: Open a PR from dependency-updates targeting main
+    uses: guardian/.github/.github/workflows/pr-batching_pr-tracking-branch-to-default.yml@v1.0.1

--- a/.github/workflows/dependency-updates-sync-default-branch.yml
+++ b/.github/workflows/dependency-updates-sync-default-branch.yml
@@ -1,0 +1,11 @@
+name: Keep the dependency-updates branch up to date with main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-dependency-update-branch:
+    name: Keep tracking branch up to date with main
+    uses: guardian/.github/.github/workflows/pr-batching_tracking-branch.yml@v1.0.1


### PR DESCRIPTION
## What does this change?

The PR creates github workflows so that the PR created by Scala Steward on `dependency-updates` branch are regularly consolidated into one PR.  We look at the PR to check if it is good to merge in our snyk session every week.

There are no changes to the n10n services.