### PR TITLE
LIVE-5049 Change to AMI using ubuntu Jammy

### DIFF
--- a/notification/conf/riff-raff.yaml
+++ b/notification/conf/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: notification
     parameters:
       amiTags:
-        Recipe: bionic-mobile-java11-ARM
+        Recipe: jammy-mobile-java11-ARM
         AmigoStage: PROD
       templatePath: cfn.yaml
       templateStageParameters:

--- a/registration/conf/riff-raff.yaml
+++ b/registration/conf/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: registration
     parameters:
       amiTags:
-        Recipe: bionic-mobile-java11-ARM
+        Recipe: jammy-mobile-java11-ARM
         AmigoStage: PROD
       templateStagePaths:
         CODE: Registration-CODE.template.json

--- a/report/conf/riff-raff.yaml
+++ b/report/conf/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: report
     parameters:
       amiTags:
-        Recipe: bionic-mobile-java11-ARM
+        Recipe: jammy-mobile-java11-ARM
         AmigoStage: PROD
       templatePath: cfn.yaml
   report:

--- a/senderworker/riff-raff.yaml
+++ b/senderworker/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
     parameters:
       amiParameter: AMISenderworker
       amiTags:
-        Recipe: bionic-mobile-java11-ARM
+        Recipe: jammy-mobile-java11-ARM
         AmigoStage: PROD
       templateStagePaths: 
         CODE: SenderWorker-CODE.template.json


### PR DESCRIPTION
## What does this change?

Ubuntu bionic (v18) will reach end of support by April 2023.  The PR changes the EC2-based services (`registration`, `notification`, `report` and `ec2sender`) to use the new AMI which is based on Ubuntu Jammy (v22).

## How to test

The services were deployed to `CODE` successfully.  

The following tests were performed to validate the new AMI:
1. a notification was sent successfully and my debug app was able to receive it
2. registration requests were handled properly.  Changes were verified in the database
3. we retrieved the report on the test notification from the `report` endpoint successfully
4. no tests were done on `ec2sender` as we are not using it and it will be removed soon

No error logs were found during testing.
