### PR TITLE
Use encrypted AMI

### DIFF
--- a/notification/conf/riff-raff.yaml
+++ b/notification/conf/riff-raff.yaml
@@ -5,8 +5,9 @@ deployments:
     type: cloud-formation
     app: notification
     parameters:
+      amiEncrypted: true
       amiTags:
-        Recipe: jammy-mobile-java11-ARM
+        Recipe: mobile-java11-jammy-ARM
         AmigoStage: PROD
       templatePath: cfn.yaml
       templateStageParameters:

--- a/registration/conf/riff-raff.yaml
+++ b/registration/conf/riff-raff.yaml
@@ -5,8 +5,9 @@ deployments:
     type: cloud-formation
     app: registration
     parameters:
+      amiEncrypted: true
       amiTags:
-        Recipe: jammy-mobile-java11-ARM
+        Recipe: mobile-java11-jammy-ARM
         AmigoStage: PROD
       templateStagePaths:
         CODE: Registration-CODE.template.json

--- a/report/conf/riff-raff.yaml
+++ b/report/conf/riff-raff.yaml
@@ -5,8 +5,9 @@ deployments:
     type: cloud-formation
     app: report
     parameters:
+      amiEncrypted: true
       amiTags:
-        Recipe: jammy-mobile-java11-ARM
+        Recipe: mobile-java11-jammy-ARM
         AmigoStage: PROD
       templatePath: cfn.yaml
   report:


### PR DESCRIPTION
## What does this change?

It's good practice to use encrypted AMIs and this PR updates the riff raff configuration to consume encrypted ones. The n10n repo defines 3 EC2 services that will consume the encrypted recipe: `notification`, `registration` and `report`.

In amigo I cloned the existing recipe and then edited it to request an encrypted copy for the mobile aws account:

<img width="1162" alt="Screenshot 2023-04-12 at 15 23 16" src="https://user-images.githubusercontent.com/45561419/231488010-07ab12ca-5380-45b0-959b-d448c9089c9f.png">

I manually triggered a bake and could see that an encrypted copy had been created as part of the process:

<img width="1185" alt="Screenshot 2023-04-12 at 15 24 13" src="https://user-images.githubusercontent.com/45561419/231488267-33564385-4985-4505-89ae-059164577300.png">

We can then find the corresponding encrypted AMI in the mobile account:

<img width="1300" alt="Screenshot 2023-04-12 at 15 25 53" src="https://user-images.githubusercontent.com/45561419/231488725-57301095-76fd-41f4-97af-8cf6433cd97a.png">

## How to test

I updated the riff-raff configuration for the 3 EC2 services in this repo and deployed to CODE:

`notification`: I sent a test notification, the service returns an expected 201 response and I subsequently received the notification.

`registration`: I sent a POST request to register a sample device token. I received a 200 OK response and could subsequently retrieve the device token from the CODE database.

`report`: I was able to retrieve the report for the sent notification via a GET request to this service.

After this, and other associated PRs, are merged we should see that the existing non-encrypted AMI isn't being used, at which point I'll delete it from amigo.