### PR TITLE
Set mobile-notifications-api-models version to 1.0.17

### DIFF
--- a/api-models/README.markdown
+++ b/api-models/README.markdown
@@ -85,3 +85,8 @@ Because of the incompatibility of the play-json module between version 2.3 and 2
 Each change that has been merged into ````main```` MUST be merged into the ````play-2.4```` branch
 
 Once this is done, make sure to run ````sbt release```` on both branches
+
+### When to release version changes?
+When there's been changes to the model, and a new version of the library has been released in Maven, the `version.sbt` file needs to be updated with the next available version.
+
+NB: As the main branch is protected, we cannot push directly from main, so we need to do this through a development branch (create a PR).

--- a/api-models/README.markdown
+++ b/api-models/README.markdown
@@ -86,6 +86,10 @@ Each change that has been merged into ````main```` MUST be merged into the ````p
 
 Once this is done, make sure to run ````sbt release```` on both branches
 
+# Mobile Notifications API Models
+[![Maven Central](https://img.shields.io/maven-metadata/v.svg?label=maven-central&metadataUrl=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fcom%2Fgu%2Fmobile-notifications-api-models_2.13%2Fmaven-metadata.xml)](https://maven-badges.herokuapp.com/maven-central/com.gu/mobile-notifications-api-models_1.0.16)
+[![Project status](https://img.shields.io/badge/status-active-brightgreen.svg)](#status)
+
 ### When to release version changes?
 When there's been changes to the model, and a new version of the library has been released in Maven, the `version.sbt` file needs to be updated with the next available version.
 

--- a/api-models/version.sbt
+++ b/api-models/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.0.15"
+ThisBuild / version := "1.0.17"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

### Updates version of mobile-notifications-api-models:

The mobile-notifications-api-model has changed, and the version was bumped in Maven:
<img width="400" alt="Screenshot 2023-04-14 at 15 02 24" src="https://user-images.githubusercontent.com/55602675/232066849-e62bbaa9-6661-40f4-8a6a-43bc9074ac27.png">
Now we need to update the version.sbt file to the next version, which is 1.0.17.

### Updates the readme file:
<img width="834" alt="Screenshot 2023-04-17 at 15 31 13" src="https://user-images.githubusercontent.com/55602675/232517648-a9ea69aa-51c4-490d-a896-ef17d5f58959.png">



## When to release version changes?

**If**: The model has changed and the latest version has been released in Maven

**Then**: This version in version.sbt has to be updated to the next available version

**But**: The main branch is protected and we cannot push directly from main, so we need to do this through a separate branch

