### PR TITLE
Remove unused dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -313,22 +313,18 @@ lazy val football = lambda("football", "football")
   .settings(
     resolvers += "Guardian GitHub Releases" at "https://guardian.github.com/maven/repo-releases",
     libraryDependencies ++= Seq(
-      "org.slf4j" % "slf4j-simple" % "1.7.36",
-      "com.typesafe" % "config" % "1.3.2",
-      "org.scanamo" %% "scanamo" % "1.0.0-M12",
-      "org.scanamo" %% "scanamo-testkit" % "1.0.0-M12" % "test",
+      "org.scanamo" %% "scanamo" % "1.0.0-M12-1",
+      "org.scanamo" %% "scanamo-testkit" % "1.0.0-M12-1" % "test",
       "com.gu" %% "content-api-client-default" % "15.9",
-      "org.apache.thrift" % "libthrift" % apacheThrift,
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
       "com.gu" %% "pa-client" % paClientVersion,
       "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
-      "com.google.code.findbugs" % "jsr305" % "3.0.2",
       "org.specs2" %% "specs2-core" % specsVersion % "test",
       "org.specs2" %% "specs2-mock" % specsVersion % "test",
-      "io.netty" % "netty-codec-http2" % nettyVersion
     ),
     excludeDependencies ++= Seq(
-      ExclusionRule("com.typesafe.play", "play-ahc-ws_2.13")
+      ExclusionRule("com.typesafe.play", "play-ahc-ws_2.13"),
+      ExclusionRule("software.amazon.awssdk", "ec2")
     ),
     riffRaffArtifactResources += (baseDirectory.value / "cfn.yaml", "mobile-notifications-football-cfn/cfn.yaml")
   )


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We attempted to bump some dependencies in #1018 , but the football lambda failed to be deployed because it hit the maximum size of AWS Java lambda archive, which is 250MB.

This PR aims to reduce the size of the football lambda.

Before the changes, the archive is around 250MB and the biggest bundles are:

|  Bundle  | Size | Remark |
| ------------- | ------------- | ------------- |
| AWS EC2 SDK  | 40.7MB | Transitive dependency via `simple-configuration`  |
| Scala runtime | 55.1MB | Indispensible |
| Cats library | 34.2 MB | Transitive dependency via `scanamo` |
| scalatest | 20.4 MB | Transitive dependency via `scanamo` |
| AWS SSM SDK | 14.9 MB | Transitive dependency via `simple-configuration` |

Apparently the EC2 SDK is not really required by `simple-configuration` after guardian/simple-configuration#8 and the library can compile without the EC2 SDK dependency.

The library `scanamo` also has a patch version bump which moved `scalatest` dependency to `test` scope.

This PR makes the following changes:
1. bump `scanamo` so that the `scalatest` is not included in the Java archive
2. explicitly exclude AWS EC2 SDK from football
3. remove some unused direct dependencies of `football`

After the changes, the compressed output JAR is 71 MB and after decompression it is 187.6 MB

## How to test

I made use of football-time-machine to play back a football, registered for notifications on the football team on Android simulator, and enabled the football lambda schedule on `CODE`

I was able to receive the notifications:

|   |   | 
| ------------- | ------------- | 
| <img src="https://user-images.githubusercontent.com/89925410/234818741-25ebe990-23a5-4acb-8fae-56bef183acd9.png" width="300"> | <img src="https://user-images.githubusercontent.com/89925410/234818815-b7c23180-7adc-44b0-ad4b-a6ae99326785.png" width="300"> |

Logs were also made properly:

<img src="https://user-images.githubusercontent.com/89925410/234819860-15f930a9-8567-498c-84cc-af12a0a318f6.png" width="600">

## How can we measure success?

The football lambda archive is reduced in size significantly, and it is working properly.

## Have we considered potential risks?

The AWS EC2 SDK may be needed by other dependencies.  To mitigate the risk, I checked the dependency tree to confirm that it was depended on by `simple-configuration` only.  I also ran a test to validate the football lambda.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

