### PR TITLE
Update time that dependency updates PR is created

### DIFF
--- a/.github/workflows/dependency-updates-batch-updates-PR.yml
+++ b/.github/workflows/dependency-updates-batch-updates-PR.yml
@@ -2,7 +2,7 @@ name: Create batch dependency update PR
 
 on:
   schedule:
-    - cron: "45 13 * * TUE"
+    - cron: "45 11 * * TUE"
   # Provide support for manually triggering the workflow via GitHub.
   workflow_dispatch:
 


### PR DESCRIPTION
## What does this change?

Now we're in BST the dependency updates PR is being raised after the mobbing session. This PR updates the cron schedule so that the action happens earlier in the day.

## Changes
Dependency updates PR should happen at 11.45 UTC (12.45 BST)
