### PR TITLE
Dependency updates 2023-05-23

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,6 +1,4 @@
 updates.pin = [
-  { groupId = "org.scala-sbt", artifactId = "sbt", version="1.7.1" },
-
 # Pin the specs2 library to version 4.8.3 to align it with the specs2 library
 # used in Play-specs1 modules.  It was found that the internal classes were 
 # incompatible between minor versions

--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,9 @@ val nettyVersion: String = "4.1.91.Final"
 val slf4jVersion: String = "1.7.36"
 
 val standardSettings = Seq[Setting[_]](
+  // We should remove this when all transitive dependencies use the same version of scala-xml
+  // For now this isn't considered an issue due to the compatability between 1.2.x and 2.1.x of the library
+  libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always,
   resolvers ++= Seq(
     "Guardian GitHub Releases" at "https://guardian.github.com/maven/repo-releases",
     "Guardian GitHub Snapshots" at "https://guardian.github.com/maven/repo-snapshots"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.8.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,3 +26,20 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+
+/*
+   Without setting VersionScheme.Always here on `scala-xml`, sbt 1.8.0 will raise fatal 'version conflict' errors when
+   used with sbt plugins like `sbt-native-packager`, which currently use sort-of-incompatible versions of the `scala-xml`
+   library. sbt 1.8.0 has upgraded to Scala 2.12.17, which has itself upgraded to `scala-xml` 2.1.0
+   (see https://github.com/sbt/sbt/releases/tag/v1.8.0), but `sbt-native-packager` is currently using `scala-xml` 1.1.1,
+    and the `scala-xml` library declares that it uses specifically 'early-semver' version compatibility (see
+    https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html#versionscheme-librarydependencyschemes-and-sbt-150 ),
+    meaning that for version x.y.z, `x` & `y` *must match exactly* for versions to be considered compatible by sbt.
+
+    By setting VersionScheme.Always here on `scala-xml`, we're overriding its declared version-compatability scheme,
+    choosing to tolerate the risk of binary incompatibility. We consider this a safe operation because when set under
+    `projects/` (ie *not* in `build.sbt` itself) it only affects the compilation of build.sbt, not of the application
+    build itself. Once the build has succeeded, there is no further risk (ie of a runtime exception due to clashing
+    versions of `scala-xml`).
+ */
+libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always


### PR DESCRIPTION
## What does this change?

This bumps the sbt version to the latest as well as a number of dependencies. 

The [latest](https://github.com/guardian/pa-football-client/releases/tag/v7.0.7) version of the pa-client makes use of scala-xml 2.1.0 (to allow cross compilation across scala versions 2.12, 2.13 and 3) but this introduced binary incompatibility errors in n10n. From the scala-xml release notes there aren't actually breaking changes between 1.2.x and 2.1.x so we override these warnings using a dependency scheme rule. Note that these rules are required during both build and compilation (hence why it's repeated across both plugins.sbt and build.sbt).