### PR TITLE
Update job permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/mss-admins

--- a/.github/workflows/dependency-updates-sync-default-branch.yml
+++ b/.github/workflows/dependency-updates-sync-default-branch.yml
@@ -7,5 +7,8 @@ on:
 
 jobs:
   update-dependency-update-branch:
+    permissions:
+      id-token: write
+      contents: write
     name: Keep tracking branch up to date with main
     uses: guardian/.github/.github/workflows/pr-batching_tracking-branch.yml@v1.0.1


### PR DESCRIPTION
## What does this change?

Since the move the github enterprise a number of our workflows have been failing due to permissions errors.

This change fixes the permissions necessary to update our dependency-updates branch. Other teams across the department had similar issues and applied this https://github.com/guardian/riff-raff/pull/1160 to correct the permissions.

After this change is merged we should see the corresponding action succeeding again. If this works, I'll also raise an equivalent PR for n10n. Note that the workflow to create the PR is still broken, I think some org-wide settings need to be adjusted before actions/workflows can create PRs (I've raised this with DevX).

A similar [fix](https://github.com/guardian/mobile-apps-api/pull/2534) was applied to MAPI and the solution [worked](https://github.com/guardian/mobile-apps-api/pull/2534#issuecomment-1562617426).

## Added bonus

I've also added a CODEOWNERS file. This will help increase visibility of changes within the team and also remove any ambiguity about who to ask for reviews from. An easy way to achieve this is by defining a repo's [codeowners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).

For now I've assumed that any change made to n10n is something the admins would like to know about. If this becomes tiresome, we can add some rules later on.

