### PR TITLE
 Correct typo in scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -17,5 +17,5 @@ updates.pin = [
   { groupId = "com.gu", artifactId = "simple-configuration-ssm", version = "1.5.6" },
 
 # A separate task to bump slf4j from version 1 to version 2
-  { groupdId = "org.slf4j", artifactId = "slf4j-api", version = "1.7.36" },
+  { groupId = "org.slf4j", artifactId = "slf4j-api", version = "1.7.36" },
 ]


### PR DESCRIPTION
## What does this change?

This corrects a small typo in the scala-steward configuration file that was causing the entire file to be thrown away, meaning some dependencies we'd explicitly pinned were attempting to be bumped. See #1129 for more details.

## How to test

After this change has been merged scala steward should not attempt to bump dependencies specified in the config file.