### PR TITLE
LIVE-5319 Bump simple-configuration to 1.5.7

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -14,8 +14,8 @@ updates.pin = [
   { groupId = "org.scanamo", artifactId="scanamo-testkit", version = "1.0.0-M12-1" },
 
 # A separate task to bump simple-configuration
-  { groupId = "com.gu", artifactId = "simple-configuration-ssm", version = "1.5.6" },
-  { groupId = "com.gu", artifactId = "simple-configuration-core", version = "1.5.6" },
+  { groupId = "com.gu", artifactId = "simple-configuration-ssm", version = "1.5.7" },
+  { groupId = "com.gu", artifactId = "simple-configuration-core", version = "1.5.7" },
 
 # A separate task to bump slf4j from version 1 to version 2
   { groupId = "org.slf4j", artifactId = "slf4j-api", version = "1.7.36" },

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val apacheThrift: String = "0.15.0"
 val jacksonDatabind: String = "2.15.3"
 val jacksonCbor: String = "2.15.3"
 val jacksonScalaModule: String = "2.15.3"
-val simpleConfigurationVersion: String = "1.5.6"
+val simpleConfigurationVersion: String = "1.5.7"
 val googleOAuthClient: String = "1.34.1"
 val nettyVersion: String = "4.1.100.Final"
 val slf4jVersion: String = "1.7.36"
@@ -100,7 +100,7 @@ lazy val common = project
       "org.tpolecat" %% "doobie-specs2"    % doobieVersion % Test,
       "org.tpolecat" %% "doobie-scalatest" % doobieVersion % Test,
       "org.tpolecat" %% "doobie-h2"        % doobieVersion % Test,
-      "com.gu" %% "mobile-logstash-encoder" % "1.1.6",
+      "com.gu" %% "mobile-logstash-encoder" % "1.1.7",
       "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
       "io.netty" % "netty-handler" % nettyVersion,
       "io.netty" % "netty-codec" % nettyVersion,

--- a/common/src/main/scala/utils/CustomApplicationLoader.scala
+++ b/common/src/main/scala/utils/CustomApplicationLoader.scala
@@ -2,11 +2,12 @@ package utils
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
-import com.gu.{AppIdentity, AwsIdentity}
+import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
 import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
 import play.api.ApplicationLoader.Context
 import play.api._
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain => AwsCredentialsProviderChainV2, DefaultCredentialsProvider => DefaultCredentialsProviderV2, ProfileCredentialsProvider => ProfileCredentialsProviderV2}
+import software.amazon.awssdk.regions.Region.EU_WEST_1
 
 abstract class CustomApplicationLoader extends ApplicationLoader {
   def buildComponents(identity: AppIdentity, context: Context): BuiltInComponents
@@ -23,9 +24,16 @@ abstract class CustomApplicationLoader extends ApplicationLoader {
 
   override def load(context: Context): Application = {
     LoggerConfigurator(context.environment.classLoader) foreach { _.configure(context.environment) }
-    val identity = AppIdentity.whoAmI("notifications")
+    val defaultAppName = "notifications"
+    val identity = Option(System.getenv("MOBILE_LOCAL_DEV")) match {
+      case Some(_) => DevIdentity(defaultAppName)
+      case None =>
+        AppIdentity
+          .whoAmI(defaultAppName, credentialsv2)
+          .getOrElse(DevIdentity(defaultAppName))
+    }
     val config = ConfigurationLoader.load(identity, credentialsv2) {
-      case AwsIdentity(app, stack, stage, _) => SSMConfigurationLocation(s"/notifications/$stage/$stack")
+      case AwsIdentity(app, stack, stage, region) => SSMConfigurationLocation(s"/notifications/$stage/$stack", region)
     }
     val loadedConfig = Configuration(config)
     val newContext = context.copy(initialConfiguration = loadedConfig.withFallback(context.initialConfiguration))

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -5,10 +5,12 @@ import com.typesafe.config.Config
 import db.JdbcConfig
 import com.gu.notifications.worker.delivery.fcm.models.FcmConfig
 import _root_.models.{Android, AndroidBeta, AndroidEdition, Ios, IosEdition, Platform}
-import com.gu.{AppIdentity, AwsIdentity}
+import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
 import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.regions.Region.EU_WEST_1
 
 case class HarvesterConfiguration(
   jdbcConfig: JdbcConfig,
@@ -48,9 +50,16 @@ case class TopicCountsConfiguration (
 object Configuration {
 
   private def fetchConfiguration(workerName: String): Config = {
-    val identity = AppIdentity.whoAmI(defaultAppName = "notification-worker")
+    val defaultAppName = "notification-worker"
+    val identity = Option(System.getenv("MOBILE_LOCAL_DEV")) match {
+      case Some(_) => DevIdentity(defaultAppName)
+      case None =>
+        AppIdentity
+          .whoAmI(defaultAppName, DefaultCredentialsProvider.builder().build())
+          .getOrElse(DevIdentity(defaultAppName))
+    }
     ConfigurationLoader.load(identity) {
-      case AwsIdentity(_, _, stage, _) => SSMConfigurationLocation(s"/notifications/$stage/workers/$workerName")
+      case AwsIdentity(_, _, stage, region) => SSMConfigurationLocation(s"/notifications/$stage/workers/$workerName", region)
     }
   }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR bumps the [simple-configuration](https://github.com/guardian/simple-configuration) library to a newer version 1.5.7 from version 1.5.6

There are API breaking changes in `simple-configuration` between version 1.5.6 and version 1.5.7.  Please refer to guardian/mobile-apps-api#2797 for details.

This PR makes the following code changes for this new version of `simple-configuration`:
1.   In order to detect whether the service is running locally, I added a check on the environment variable "MOBILE_LOCAL_DEV" - if this environment variable is present, it assumes DevIdentity and bypassed the AppIdentity.whoAmI call (bypassing `AppIdentity.whoAmI` in local deployment was recommended in https://github.com/guardian/simple-configuration/pull/28). Otherwise it invoked AppIdentity.whoAmI and it is still able to return a DevIdentity if `whoAmI` fails to load the identity from EC2 tags / lambda environment variables.
2. Pass in the `region` to `SSMConfigurationLocation constructor`
 using the `region` from `AwsIdentity`
3. The simple-configuration library has to be bumped in mobile-logstash-encoder as well (https://github.com/guardian/mobile-logstash-encoder/pull/17). Otherwise, the microservice fails to start up because the mobile-logstash-encoder throws fatal exception due to the breaking API change.

## How to test
It was deployed to `CODE`, and we validated the service by registering a token and sending a notification to debug build.

Logs were written properly:
<img width="720px" src="https://github.com/guardian/mobile-n10n/assets/89925410/d3f525e7-7c13-49f5-b550-2ac63115a315" />
<img width="720px" src="https://github.com/guardian/mobile-n10n/assets/89925410/aecc0077-d2b5-45bc-897f-eaf6c5b18751" />
<img width="720px" src="https://github.com/guardian/mobile-n10n/assets/89925410/0c2028a8-ac01-458d-9bc6-78768ec8597e" />
<img width="720px" src="https://github.com/guardian/mobile-n10n/assets/89925410/9e1a2e11-bd88-4fb8-8f0a-9771bcd98e8a" />
<img width="720px" src="https://github.com/guardian/mobile-n10n/assets/89925410/c11cbf64-d806-4fa8-a464-18fe6557f66a" />
<img width="720px" src="https://github.com/guardian/mobile-n10n/assets/89925410/d4995bbc-7751-4497-86ae-c3a99a25d2d7" />