### PR TITLE
Enable nightly backups for notification DynamoDB tables

### DIFF
--- a/dynamo.yaml
+++ b/dynamo.yaml
@@ -37,3 +37,6 @@ Resources:
         AttributeName: ttl
       StreamSpecification:
         StreamViewType: NEW_IMAGE
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true

--- a/football/cfn.yaml
+++ b/football/cfn.yaml
@@ -142,6 +142,9 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true
 
   MobileNotificationsFootballConsumedReadThrottleEvents:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## What does this change?

This PR allows us to start backing up the `mobile-notifications-reports-<stage>` and `mobile-notifications-football-notifications-<stage>` DynamoDB tables using https://github.com/guardian/aws-backup.

For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit) and this [audit](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit#gid=1523470588) that @guardian/devx-reliability have been working on with Heads of Engineering & EMs.

## How to test

* `mobile-notifications-football-notifications-<stage>` is [deployed via Riff-Raff](https://github.com/guardian/mobile-n10n/blob/6edbd98c5426a5a8c53bdd51bd85c6dba6f8736c/football/riff-raff.yaml#L12-L18), so I have tested this by [deploying to `CODE`](https://riffraff.gutools.co.uk/deployment/view/9074c540-85fe-424d-8ed0-1e1611e805b2):

```
[09:52:09] Resource - ResourceChange(Action=Modify, LogicalResourceId=DynamoTable, PhysicalResourceId=mobile-notifications-football-notifications-CODE, ResourceType=AWS::DynamoDB::Table, Replacement=False, Scope=[Properties], Details=[ResourceChangeDetail(Target=ResourceTargetDefinition(Attribute=Properties, Name=Tags, RequiresRecreation=Never), Evaluation=Static, ChangeSource=DirectModification)])
  [09:52:09] mobile-notifications-football-CODE (AWS::CloudFormation::Stack): UPDATE_IN_PROGRESS
  [09:52:09] User Initiated
  [09:52:14] DynamoTable (AWS::DynamoDB::Table): UPDATE_IN_PROGRESS
  [09:52:19] DynamoTable (AWS::DynamoDB::Table): UPDATE_COMPLETE
```

* `mobile-notifications-reports-<stage>` seems to be deployed manually (i.e. not via Riff-Raff) so I have tested this one by applying the update (in `CODE`) via the AWS console:

![image](https://github.com/guardian/mobile-n10n/assets/19384074/1a23d3a3-f66e-4cb4-a247-bb81401b2b42)

## How can we measure success?

We will be able to recover (most) of the data stored in these table in the unlikely event that they are ever deleted.

## Have we considered potential risks?

Yes, a number of risks related to performance, cost and privacy were considered. See [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.vwt7syo8ng40) for more details. 

The doc mentions that the Mobile account might have greater costs than others, but this is primarily due to one very large table (which is not affected by this PR!) - more details on this can be found [here](https://docs.google.com/spreadsheets/d/15B5ydoAFbUpIYG3KoCm20t5kxBaDEEhnF8DWvWNDV_U/edit#gid=1739863040).

## Deployment

Merging the PR should be sufficient to update `mobile-notifications-football-notifications-<stage>`.

After the PR is merged the `dynamo.yaml` template (which contains the `mobile-notifications-reports-<stage>` table) needs to be applied manually.