### PR TITLE
LIVE-6160 Upgrade firebase to v9.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -410,7 +410,7 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
     dockerAlias := DockerAlias(registryHost = dockerRepository.value, username = None, name = (Docker / packageName).value, tag = buildNumber),
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
-      "com.google.firebase" % "firebase-admin" % "9.1.1",
+      "com.google.firebase" % "firebase-admin" % "9.2.0",
       "com.google.protobuf" % "protobuf-java" % "3.25.3",
       "com.amazonaws" % "aws-lambda-java-events" % "2.2.9",
       "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -99,7 +99,7 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
       import FirebaseHelpers._
       val start = Instant.now
       firebaseMessaging
-        .sendMulticastAsync(message)
+        .sendEachForMulticastAsync(message)
         .asScala
         .onComplete { response =>
           val requestCompletionTime = Instant.now

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
@@ -17,6 +17,9 @@ case class BatchNotification(notification: Notification, token: List[String])
 
 case class ChunkedTokens(notification: Notification, tokens: List[String], range: ShardRange, metadata: NotificationMetadata) {
   def toNotificationToSends: List[IndividualNotification] = tokens.map(IndividualNotification(notification, _))
+
+  // the Firebase sendEachForMulticast API has a maximum limit of 500 tokens for each request
+  // so this grouping of 500 tokens must not be increased further
   def toBatchNotificationToSends: List[BatchNotification] = tokens.grouped(500).map(BatchNotification(notification, _)).toList
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Google is going to discontinue some of its legacy Firebase Cloud Messaging (FCM) APIs and some of them are being used by our notification service.

We do not invoke the APIs directly.  These APIs are REST APIs where clients have to make HTTP requests directly to the FCM server endpoints.  Instead, we interact with FCM servers [via the Firebase Admin SDK](https://firebase.google.com/docs/cloud-messaging/server),  which provides a programming interface over the REST API.

To migrate from the old APIs being discontinued, we need to upgrade the Firebase Admin SDK to version 9.2.0, and replace our deprecated API call with the new APIs.  ([Firebase Admin Java SDK Release Notes](https://firebase.google.com/support/release-notes/admin/java) ).  Specifically we may have to replace our `sendMulticastAsync` with the new `sendEachForMulticastAysnc` API.  The new API does not allow more than 500 devices to send in one invocation.

This PR upgrades the firebase to version 9.2.0

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
The change was verified on `CODE` where we was able to send notifications successfully.

However, we cannot verify its performance on CODE.  The changes were in the API call which does the actual operation of sending notifications to real devices.  To check the performance impact, we can only run it as an experiment on PROD which has more than 1 million subscribed users.

## How can we measure success?

We expect the performance to be comparable to that before the upgrade.

## Have we considered potential risks?

The new API may have negative impact on the performance.