### PR TITLE
Revert "LIVE-6160 Upgrade firebase to v9.2.0"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -410,7 +410,7 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
     dockerAlias := DockerAlias(registryHost = dockerRepository.value, username = None, name = (Docker / packageName).value, tag = buildNumber),
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
-      "com.google.firebase" % "firebase-admin" % "9.2.0",
+      "com.google.firebase" % "firebase-admin" % "9.1.1",
       "com.google.protobuf" % "protobuf-java" % "3.25.3",
       "com.amazonaws" % "aws-lambda-java-events" % "2.2.9",
       "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -99,7 +99,7 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
       import FirebaseHelpers._
       val start = Instant.now
       firebaseMessaging
-        .sendEachForMulticastAsync(message)
+        .sendMulticastAsync(message)
         .asScala
         .onComplete { response =>
           val requestCompletionTime = Instant.now

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
@@ -17,9 +17,6 @@ case class BatchNotification(notification: Notification, token: List[String])
 
 case class ChunkedTokens(notification: Notification, tokens: List[String], range: ShardRange, metadata: NotificationMetadata) {
   def toNotificationToSends: List[IndividualNotification] = tokens.map(IndividualNotification(notification, _))
-
-  // the Firebase sendEachForMulticast API has a maximum limit of 500 tokens for each request
-  // so this grouping of 500 tokens must not be increased further
   def toBatchNotificationToSends: List[BatchNotification] = tokens.grouped(500).map(BatchNotification(notification, _)).toList
 }
 


### PR DESCRIPTION
Reverts guardian/mobile-n10n#1206

We saw the following exception on Android sender:

```
com.gu.notifications.worker.delivery.DeliveryException$BatchCallFailedRequest: Entire batch request failed (Notification: 55b49b62-f93c-3ed9-abbc-4b3726f669c7, Multicast Async Response Failure: java.lang.OutOfMemoryError: unable to create native thread: possibly out of memory or process/resource limits reached)
```

We need to study how we should configure