### PR TITLE
Use bigger EC2 instance for notification

### DIFF
--- a/notification/conf/notification.yaml
+++ b/notification/conf/notification.yaml
@@ -18,7 +18,7 @@ Mappings:
       NewsstandNotificationAlarmThreshold: 0
       NotificationAlarmPeriod: 1200
       ScheduleApp: schedule
-      InstanceType: "t4g.micro"
+      InstanceType: "t4g.small"
     PROD:
       CPUAlarmPeriodLower: 300
       CPUAlarmPeriodUpper: 60
@@ -30,7 +30,7 @@ Mappings:
       NewsstandNotificationAlarmThreshold: 1
       NotificationAlarmPeriod: 1200
       ScheduleApp: schedule
-      InstanceType: "t4g.micro"
+      InstanceType: "t4g.small"
 
 Outputs:
   LoadBalancerUrl:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Editorials reported that they sent a breaking news notification via ed tools but no notifications were received.  The notification record was not found on Ophan dashboard either.

After investigation, it was found that the breaking news tool sent a HTTP request to our notification endpoint but received a 503 exception.  

The cloudwatch metric (ELB 5xx) for the load balancer of the notification API suggested that a 5xx response had been served from the load balancer at that time.  One of the EC2 instances was also terminated due to health check failure around that minute.

<img width="720px" src="https://github.com/guardian/mobile-n10n/assets/89925410/596d658b-860b-4cac-8195-cd30fda521e6" />

We noticed that EC2 instances of notification service failed health check from time to time.  The application logs of an unhealthy instance did not show any exception or error message, but the syslog of the OS indicated that there was out-of-memory error on OS process level.

<img width="720px" src="https://github.com/guardian/mobile-n10n/assets/89925410/bb752ff5-a336-4ef7-9c0e-1c96abc6116b" />

I believe that the JVM of the service ran out of system memory when it was expanding its heap, given that we are using `t4g.micro` instance which has 1G memory only but the notification service and the AWS kinesis agent have a max heap size of 256M and 512M respectively.

This PR changes the cloudformation stack to use bigger EC2 instance, `t4g.small`, which has 2G memory.

## How to test

I applied this bigger EC2 instance on CODE and the instance has stayed healthy for more than 1 day.  It may be good to apply it on PROD too, and see if the problem with instances becoming unhealthy ceases to exist.

## How can we measure success?

No instances become unhealthy.
