### PR TITLE
Run tests in common and api models as part of CI

### DIFF
--- a/.github/workflows/event-consumer.yml
+++ b/.github/workflows/event-consumer.yml
@@ -38,7 +38,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Compile, test and assembly
-        run: sbt "project eventconsumer" "compile" "test" "assembly"
+        run: sbt "project commoneventconsumer" "compile" "test" "project eventconsumer" "compile" "test" "assembly"
 
       - name: Copy jar to root
         run: cp eventconsumer/target/scala-*/eventconsumer.jar .

--- a/.github/workflows/fake-breaking-news.yml
+++ b/.github/workflows/fake-breaking-news.yml
@@ -40,7 +40,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Compile, test and assembly
-        run: sbt "project" "common" "compile" "test" "project apiModels" "compile" "test" "project fakebreakingnewslambda" "compile" "test" "assembly"
+        run: sbt "project common" "compile" "test" "project apiModels" "compile" "test" "project fakebreakingnewslambda" "compile" "test" "assembly"
 
       - name: Copy jar to root
         run: cp fakebreakingnewslambda/target/scala-*/fakebreakingnewslambda.jar .

--- a/.github/workflows/fake-breaking-news.yml
+++ b/.github/workflows/fake-breaking-news.yml
@@ -40,7 +40,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Compile, test and assembly
-        run: sbt "project common" "compile" "test" "project apiModels" "compile" "test" "project fakebreakingnewslambda" "compile" "test" "assembly"
+        run: sbt "project common" "compile" "test" "project api-models" "compile" "test" "project fakebreakingnewslambda" "compile" "test" "assembly"
 
       - name: Copy jar to root
         run: cp fakebreakingnewslambda/target/scala-*/fakebreakingnewslambda.jar .

--- a/.github/workflows/fake-breaking-news.yml
+++ b/.github/workflows/fake-breaking-news.yml
@@ -40,7 +40,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Compile, test and assembly
-        run: sbt "project fakebreakingnewslambda" "compile" "test" "assembly"
+        run: sbt "project" "common" "compile" "test" "project apiModels" "compile" "test" "project fakebreakingnewslambda" "compile" "test" "assembly"
 
       - name: Copy jar to root
         run: cp fakebreakingnewslambda/target/scala-*/fakebreakingnewslambda.jar .

--- a/.github/workflows/football.yml
+++ b/.github/workflows/football.yml
@@ -38,7 +38,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Compile, test and assembly
-        run: sbt "project football" "compile" "test" "assembly"
+        run: sbt "project apiModels" "compile" "test" "project football" "compile" "test" "assembly"
 
       - name: Copy jar to root
         run: cp football/target/scala-*/football.jar .

--- a/.github/workflows/football.yml
+++ b/.github/workflows/football.yml
@@ -38,7 +38,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Compile, test and assembly
-        run: sbt "project apiModels" "compile" "test" "project football" "compile" "test" "assembly"
+        run: sbt "project api-models" "compile" "test" "project football" "compile" "test" "assembly"
 
       - name: Copy jar to root
         run: cp football/target/scala-*/football.jar .

--- a/.github/workflows/notification-worker-lambdas.yml
+++ b/.github/workflows/notification-worker-lambdas.yml
@@ -51,7 +51,7 @@ jobs:
           mask-password: 'true'
 
       - name: Compile and test
-        run: sbt "project notificationworkerlambda" "compile" "test"
+        run: sbt "project common" "compile" "test" "project notificationworkerlambda" "compile" "test"
 
       - name: Build docker image
         run: sbt docker:publishLocal

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -40,7 +40,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Compile, test and package
-        run: sbt "project notification" "compile" "test" "debian:packageBin"
+        run: sbt "project common" "compile" "test" "project commonscheduledynamodb" "compile" "test" "project notification" "compile" "test" "debian:packageBin"
 
       - name: Upload to riff-raff
         uses: guardian/actions-riff-raff@v3

--- a/.github/workflows/registration.yml
+++ b/.github/workflows/registration.yml
@@ -55,7 +55,7 @@ jobs:
           npm run synth
 
       - name: Compile, test and package
-        run: sbt "project registration" "compile" "test" "debian:packageBin"
+        run: sbt "project common" "compile" "test" "project registration" "compile" "test" "debian:packageBin"
 
       - name: Upload to riff-raff
         uses: guardian/actions-riff-raff@v3

--- a/.github/workflows/report-extractor.yml
+++ b/.github/workflows/report-extractor.yml
@@ -39,7 +39,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Compile, test and assembly
-        run: sbt "project reportextractor" "compile" "test" "assembly"
+        run: sbt "project common" "compile" "test" "project reportextractor" "compile" "test" "assembly"
 
       - name: Copy jar to root
         run: cp reportextractor/target/scala-*/reportextractor.jar .

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -40,7 +40,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Compile, test and package
-        run: sbt "project report" "compile" "test" "debian:packageBin"
+        run: sbt "project common" "compile" "test" "project report" "compile" "test" "debian:packageBin"
 
       - name: Upload to riff-raff
         uses: guardian/actions-riff-raff@v3

--- a/.github/workflows/schedule-lambda.yml
+++ b/.github/workflows/schedule-lambda.yml
@@ -38,7 +38,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Compile, test and assembly
-        run: sbt "project schedule" "compile" "test" "assembly"
+        run: sbt "project commonscheduledynamodb" "compile" "test" "project schedule" "compile" "test" "assembly"
 
       - name: Copy jar to root
         run: cp schedulelambda/target/scala-*/schedule.jar .

--- a/.github/workflows/slo-monitor.yml
+++ b/.github/workflows/slo-monitor.yml
@@ -45,7 +45,7 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Compile, test and assembly
-        run: sbt "project slomonitor" "compile" "test" "assembly"
+        run: sbt "project commoneventconsumer" "compile" "test" "project slomonitor" "compile" "test" "assembly"
 
       - name: Copy jar to root
         run: cp slomonitor/target/scala-*/slomonitor.jar .


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

It was reported that the tests in the common projects such as `common` and `api-models` were not executed as part of CI.

This PR changes the GHA workflows to run tests in the common projects on which the target project depends.

## How to test

The Github action works successfully as expected.

No changes to the source code or build configuration were made.
