### PR TITLE
LIVE-6447 Create a connection for the processing of each SQS message

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryClient.scala
@@ -12,7 +12,6 @@ trait DeliveryClient {
   type Payload <: DeliveryPayload
   type BatchSuccess <: BatchDeliverySuccess
 
-  def close(): Unit
   def sendNotification(notificationId: UUID, token: String, payload: Payload, dryRun: Boolean)
     (onComplete: Either[DeliveryException, Success] => Unit)
     (implicit ece: ExecutionContextExecutor): Unit

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
@@ -39,8 +39,6 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
     "DeviceTokenNotForTopic"
   )
 
-  def close(): Unit = underlying.close().get
-
   def payloadBuilder: Notification => Option[ApnsPayload] = apnsPayloadBuilder.apply _
 
   def sendNotification(notificationId: UUID, token: String, payload: Payload, dryRun: Boolean)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -176,8 +176,10 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
 
 }
 
-object FcmClient {
-  def apply(config: FcmConfig, firebaseAppName: Option[String]): Try[FcmClient] =
+case class FcmFirebase(firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp, config: FcmConfig, projectId: String, credential: GoogleCredentials, jsonFactory: JsonFactory)
+
+object FcmFirebase {
+  def apply(config: FcmConfig, firebaseAppName: Option[String]): Try[FcmFirebase] =
     Try {
       val credential = GoogleCredentials.fromStream(new ByteArrayInputStream(config.serviceAccountKey.getBytes))
       val firebaseOptions: FirebaseOptions = FirebaseOptions.builder()
@@ -193,8 +195,13 @@ object FcmClient {
         case s: ServiceAccountCredentials => s.getProjectId()
         case _ => ""
       }
-      new FcmClient(FirebaseMessaging.getInstance(firebaseApp), firebaseApp, config, projectId, credential, firebaseOptions.getJsonFactory())
+      new FcmFirebase(FirebaseMessaging.getInstance(firebaseApp), firebaseApp, config, projectId, credential, firebaseOptions.getJsonFactory())
     }
+}
+
+object FcmClient {
+  def apply(firebase: FcmFirebase): FcmClient =
+      new FcmClient(firebase.firebaseMessaging, firebase.firebaseApp, firebase.config, firebase.projectId, firebase.credential, firebase.jsonFactory)
 }
 
 object FirebaseHelpers {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -42,8 +42,6 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
     ErrorCode.PERMISSION_DENIED
   )
 
-  def close(): Unit = firebaseApp.delete()
-
   private final val FCM_URL: String = s"https://fcm.googleapis.com/v1/projects/${projectId}/messages:send";
 
   private val fcmTransport: FcmTransport = new FcmTransportJdkImpl(credential, FCM_URL, jsonFactory)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmTransportJdkImpl.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmTransportJdkImpl.scala
@@ -20,6 +20,7 @@ import java.net.http.HttpRequest
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpResponse
+import org.slf4j.{Logger, LoggerFactory}
 
 trait FcmTransport {
   def sendAsync(token: String, payload: FcmPayload, dryRun: Boolean): Future[String]
@@ -27,7 +28,11 @@ trait FcmTransport {
 
 class FcmTransportJdkImpl(credential: GoogleCredentials, url: String, jsonFactory: JsonFactory) extends FcmTransport {
   
+  implicit val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
   private val httpClient: HttpClient = HttpClient.newHttpClient()
+
+  logger.info("HttpClient is instantiated")
 
   private val charSet = StandardCharsets.UTF_8
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

I paired with @aracho1 on this piece of work.

## What does this change?

After merging PR #1216 , we saw IO exceptions when the android sender lambda sent notifications to a relatively larger group of device (more than several hundreds).

<img width="720px" src="https://github.com/guardian/mobile-n10n/assets/89925410/384eb4e9-addd-4ac4-8389-e5b2a251e1b7" />

We used the same `HttpClient` instance for the processing of all SQS messages within an invocation of a lambda, and it appears that the `HttpClient` sent the requests over the same connection via HTTP/2.  In larger notifications, it hit the limit on the maximum of concurrent stream over a connection.

This PR attempts to fix the problem by creating a `HttpClient` instance for the processing of each SQS message.  Within each SQS message, there is a setting on concurrency level which specifies how many device token to send concurrently.  This approach helps us to control the maximum number of concurrent stream we open when sending requests to Firebase API.

## How to test

We tested locally and confirmed that we created as many `HttpClient` instances as the messages we are processing.

We also deployed to `CODE`, tested a notification and we were able to receive it on our Android emulator.