### PR TITLE
LIVE-6468 Reuse http client across invocations

### DIFF
--- a/notificationworkerlambda/cdk/lib/senderworker.ts
+++ b/notificationworkerlambda/cdk/lib/senderworker.ts
@@ -108,7 +108,6 @@ class SenderWorker extends cdkcore.Construct  {
         Stack: scope.stack,
         App: id,
         Platform: props.platform,
-        JAVA_TOOL_OPTIONS: "-Djdk.httpclient.connectionPoolSize=2"
       },
       memorySize: 10240,
       description: `sends notifications for ${id}`,

--- a/notificationworkerlambda/cdk/lib/senderworker.ts
+++ b/notificationworkerlambda/cdk/lib/senderworker.ts
@@ -107,7 +107,8 @@ class SenderWorker extends cdkcore.Construct  {
         Stage: scope.stage,
         Stack: scope.stack,
         App: id,
-        Platform: props.platform
+        Platform: props.platform,
+        JAVA_TOOL_OPTIONS: "-Djdk.httpclient.connectionPoolSize=2"
       },
       memorySize: 10240,
       description: `sends notifications for ${id}`,

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -95,7 +95,7 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
     }
     input
       .fold(SendingResults.empty) { case (acc, resp) => SendingResults.aggregateBatch(acc, chunkedTokens.tokens.size, resp) }
-      .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform, sqsMessageBatchSize), prefix = s"Results $notificationLog: ").andThen(_.map(cloudwatch.sendPerformanceMetrics(env.stage, enableAwsMetric))))
+      .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform, sqsMessageBatchSize, messagingApi = Some("Batch")), prefix = s"Results $notificationLog: ").andThen(_.map(cloudwatch.sendPerformanceMetrics(env.stage, enableAwsMetric))))
       .through(cloudwatch.sendResults(env.stage, Configuration.platform))
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -8,7 +8,7 @@ import com.gu.notifications.worker.delivery.DeliveryException.InvalidToken
 import com.gu.notifications.worker.delivery.{BatchDeliverySuccess, DeliveryClient, DeliveryException}
 import com.gu.notifications.worker.delivery.fcm.{Fcm, FcmClient}
 import com.gu.notifications.worker.models.{LatencyMetrics, SendingResults}
-import com.gu.notifications.worker.tokens.{BatchNotification, ChunkedTokens}
+import com.gu.notifications.worker.tokens.{BatchNotification, ChunkedTokens, IndividualNotification}
 import com.gu.notifications.worker.utils.{Cloudwatch, CloudwatchImpl, Reporting}
 import fs2.{Pipe, Stream}
 
@@ -40,18 +40,24 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
   override implicit val timer: Timer[IO] = IO.timer(ec)
 
   val fcmFirebase: Try[FcmFirebase] = FcmFirebase(config.fcmConfig, firebaseAppName)
+
+  val fcmClients: Seq[Try[FcmClient]] = Seq.fill(20)(fcmFirebase).map(firebase => firebase.map(FcmClient(_)))
+
+  val deliveryServiceStream: Stream[IO, Fcm[IO]] = 
+    Stream.emits(fcmClients).covary[IO].flatMap(_.fold(e => Stream.raiseError[IO](e), c => Stream.eval[IO, Fcm[IO]]( IO.delay(new Fcm(c)))))
+
   override val deliveryService: IO[Fcm[IO]] = 
-    fcmFirebase.fold(e => IO.raiseError(e), c => IO.delay(new Fcm(FcmClient(c))))
+    fcmFirebase.map(FcmClient(_)).fold(e => IO.raiseError(e), c => IO.delay(new Fcm(c)))
 
   override val maxConcurrency = config.concurrencyForIndividualSend
   override val batchConcurrency = 100
     
   //override the deliverChunkedTokens method to validate the success of sending batch notifications to the FCM client. This implementation could be refactored in the future to make it more streamlined with APNs
   override def deliverChunkedTokens(chunkedTokenStream: Stream[IO, (ChunkedTokens, Long, Instant, Int)]): Stream[IO, Unit] = {
-    chunkedTokenStream.map {
-      case (chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize) =>
+    chunkedTokenStream.parZip(deliveryServiceStream.repeat).map {
+      case ((chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize), deliveryServiceForInd) =>
         if (config.isIndividualSend(chunkedTokens.notification.topic.map(_.toString()))) 
-          deliverIndividualNotificationStream(Stream.emits(chunkedTokens.toNotificationToSends).covary[IO])
+          deliverIndividualNotificationStream(Stream.emits(chunkedTokens.toNotificationToSends).covary[IO], deliveryServiceForInd)
                       .broadcastTo(
                         reportSuccesses(chunkedTokens, sentTime, functionStartTime, sqsMessageBatchSize),
                         cleanupFailures,
@@ -67,6 +73,12 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
           }
     }.parJoin(batchConcurrency)
   }
+
+  def deliverIndividualNotificationStream(individualNotificationStream: Stream[IO, IndividualNotification], deliveryService: Fcm[IO]): Stream[IO, Either[DeliveryException, FcmClient#Success]] = for {
+    resp <- individualNotificationStream.map(individualNotification => deliveryService.send(individualNotification.notification, individualNotification.token))
+      .parJoin(maxConcurrency)
+      .evalTap(Reporting.log(s"Sending failure: "))
+  } yield resp
 
   def deliverBatchNotificationStream[C <: FcmClient](batchNotificationStream: Stream[IO, BatchNotification]): Stream[IO, Either[DeliveryException, C#BatchSuccess]] = for {
     deliveryService <- Stream.eval(deliveryService)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
@@ -43,7 +43,7 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
     }
 
     input.fold(SendingResults.empty) { case (acc, resp) => SendingResults.aggregate(acc, resp) }
-      .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform, sqsMessageBatchSize = sqsMessageBatchSize), prefix = s"Results $notificationLog: ").andThen(_.map(cloudwatch.sendPerformanceMetrics(env.stage, enableAwsMetric))))
+      .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform, sqsMessageBatchSize = sqsMessageBatchSize, messagingApi = Some("Individual")), prefix = s"Results $notificationLog: ").andThen(_.map(cloudwatch.sendPerformanceMetrics(env.stage, enableAwsMetric))))
       .through(cloudwatch.sendResults(env.stage, Configuration.platform))
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -76,7 +76,7 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
           logger.info(Map(
             "worker.individualRequestLatency" -> Duration.between(start, requestCompletionTime).toMillis,
             "notificationId" -> notificationId,
-          ), "Individual send request completed")
+          ), s"Individual send request completed - ${this.toString()}")
           onAPICallComplete(parseSendResponse(notificationId, token, response, requestCompletionTime))
         }
     }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Logging.scala
@@ -51,6 +51,7 @@ trait Logging {
     functionStartTime: Instant,
     maybePlatform: Option[Platform],
     sqsMessageBatchSize: Int,
+    messagingApi: Option[String] = None
   )(end: Instant): Map[String, Any] = {
     val processingTime = Duration.between(functionStartTime, end).toMillis
     val processingRate = numberOfTokens.toDouble / processingTime * 1000
@@ -67,7 +68,7 @@ trait Logging {
       "worker.notificationProcessingEndTime.millis" -> end.toEpochMilli,
       "sqsMessageBatchSize" -> sqsMessageBatchSize,
       "worker.chunkTokenSize" -> numberOfTokens,
-    )
+    ) ++ messagingApi.map(s => Map("worker.messagingApi" -> s)).getOrElse(Map())
   }
 
   def logStartAndCount(acc: Int, chunkedTokens: ChunkedTokens): Int = {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The PR #1217 creates a `HttpClient` instance for the processing of each SQS client so that we don't send too many requests over the same connection.

However, the AWS lambda service reuses execution environment when it needs to invoke a lambda shortly after one has finished.  So it is possible that within the same Java runtime, the `AndroidSender` instance is used to process SQS messages many times and, as a result, creates too many `HttpClient` instances and the connections that are left idle.  The connections consume the limit on the file descriptors, which is [1024](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html#function-configuration-deployment-and-execution) for Java lambda runtime.  It is likely to happen when we send a huge notification (more than 100,000).

What we really want is that we have dedicated `HttpClient` instances for each SQS message, but we want to reuse these instances in the subsequent invocation if the same runtime environment is reused.

This PR creates 20 `HttpClient` instances upfront (we process at most 20 SQS messages at a time) and uses them when processing the stream of SQS messages.

This PR also creates a new configuration to control the max connection pool size to avoid "too-many-opened-files" exception.

## How to test

We invoked the Android sender locally with two batches of SQS messages (with 3 messages in each batch).  We printed the instance in the log message [here](https://github.com/guardian/mobile-n10n/blob/LIVE-6468-reuse-http-client-across-invocations/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala#L79) and we saw from the logs that the three `FcmClient` instances were reused across invocation:

First batch of SQS messages:
```Individual send request completed - com.gu.notifications.worker.delivery.fcm.FcmClient@19d807f9```

```Individual send request completed - com.gu.notifications.worker.delivery.fcm.FcmClient@591354dd```

```Individual send request completed - com.gu.notifications.worker.delivery.fcm.FcmClient@13fa8ac```

Second batch of SQS messages:

```Individual send request completed - com.gu.notifications.worker.delivery.fcm.FcmClient@19d807f9```

```Individual send request completed - com.gu.notifications.worker.delivery.fcm.FcmClient@591354dd```

```Individual send request completed - com.gu.notifications.worker.delivery.fcm.FcmClient@13fa8ac```

The service was also tested on `CODE` and notification was sent successfully to android app on emulator.
