### PR TITLE
LIVE-6506 parameter for concurrent message processing

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -36,7 +36,9 @@ case class FcmWorkerConfiguration(
   fcmConfig: FcmConfig,
   threadPoolSize: Int,
   allowedTopicsForIndividualSend: List[String],
-  concurrencyForIndividualSend: Int
+  concurrencyForIndividualSend: Int,
+  concurrencyForMessages: Int,
+  httpClientPoolSize: Int,
 ) extends WorkerConfiguration {
   def isIndividualSend(topics: List[String]): Boolean = 
       topics.forall(topic => allowedTopicsForIndividualSend.exists(topic.startsWith(_)))
@@ -137,7 +139,9 @@ object Configuration {
       ),
       config.getInt("fcm.threadPoolSize"),
       getStringList("fcm.allowedTopicsForIndividualSend"),
-      getOptionalInt("fcm.concurrencyForIndividualSend", 100)
+      getOptionalInt("fcm.concurrencyForIndividualSend", 100),
+      concurrencyForMessages = getOptionalInt("fcm.concurrencyForMessages", 20),
+      httpClientPoolSize = getOptionalInt("fcm.httpClientPoolSize", 10)
     )
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/NotificationWorkerLocalRun.scala
@@ -12,6 +12,10 @@ import play.api.libs.json.Json
 import java.util.UUID
 import scala.jdk.CollectionConverters._
 import java.time.Instant
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.CognitoIdentity
+import com.amazonaws.services.lambda.runtime.ClientContext
+import com.amazonaws.services.lambda.runtime.LambdaLogger
 object NotificationWorkerLocalRun extends App {
   val notification = BreakingNewsNotification(
     id = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),
@@ -27,7 +31,7 @@ object NotificationWorkerLocalRun extends App {
     ),
     imageUrl = None,
     importance = Major,
-    topic = List(Topic(Breaking, "international")),
+    topic = List(Topic(Breaking, "uk")),
     // topic = List(Topic(Breaking, "uk"), Topic(Breaking, "us"), Topic(Breaking, "au"), Topic(Breaking, "international"), Topic(Breaking, "europe")),
     dryRun = None
   )
@@ -35,7 +39,7 @@ object NotificationWorkerLocalRun extends App {
   val tokens = ChunkedTokens(
     notification = notification,
     range = ShardRange(0, 1),
-    tokens = List("token"),
+    tokens = List.fill(5)("token"),
     metadata = NotificationMetadata(Instant.now(), Some(1234))
   )
 
@@ -44,13 +48,26 @@ object NotificationWorkerLocalRun extends App {
     val sqsMessage = new SQSMessage()
     sqsMessage.setBody(Json.stringify(Json.toJson(tokens)))
     sqsMessage.setAttributes((Map("SentTimestamp" -> s"${Instant.now.toEpochMilli}").asJava))
-    event.setRecords(List(sqsMessage).asJava)
+    event.setRecords(List.fill(4)(sqsMessage).asJava)
     event
+  }
+  val localTestContext: Context = new Context{
+    override def getAwsRequestId(): String = "LOCAL-RUN-REQUEST-ID"
+    override def getLogGroupName(): String = ???
+    override def getLogStreamName(): String = ???
+    override def getFunctionName(): String = ???
+    override def getFunctionVersion(): String = ???
+    override def getInvokedFunctionArn(): String = ???
+    override def getIdentity(): CognitoIdentity = ???
+    override def getClientContext(): ClientContext = ???
+    override def getRemainingTimeInMillis(): Int = ???
+    override def getMemoryLimitInMB(): Int = ???
+    override def getLogger(): LambdaLogger = ???
   }
 
   args.lastOption.map(_.toLowerCase) foreach {
-    case "android" => new AndroidSender().handleChunkTokens(sqsEvent, null)
-    case "ios"     => new IOSSender().handleChunkTokens(sqsEvent, null)
+    case "android" => new AndroidSender().handleChunkTokens(sqsEvent, localTestContext)
+    case "ios"     => new IOSSender().handleChunkTokens(sqsEvent, localTestContext)
     case _         => println("invalid option")
   }
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/SenderRequestHandler.scala
@@ -35,6 +35,9 @@ trait SenderRequestHandler[C <: DeliveryClient] extends Logging {
   implicit val timer: Timer[IO] = IO.timer(ec)
   implicit val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
+  logger.info("Java version: " + System.getProperty("java.version"))
+  logger.info(s"Max heap size: ${Runtime.getRuntime().maxMemory()}")
+
   def reportSuccesses[C <: DeliveryClient](chunkedTokens: ChunkedTokens, sentTime: Long, functionStartTime: Instant, sqsMessageBatchSize: Int): Pipe[IO, Either[DeliveryException, DeliverySuccess], Unit] = { input =>
     val notificationLog = s"(notification: ${chunkedTokens.notification.id} ${chunkedTokens.range})"
     val enableAwsMetric = chunkedTokens.notification.dryRun match {

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/ConfigurationSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/ConfigurationSpec.scala
@@ -56,6 +56,9 @@ class FcmWorkerConfigurationSpec extends Specification with Matchers {
         fcmConfig = FcmConfig(serviceAccountKey = "key", debug = false, dryRun = false),
         threadPoolSize = 50,
         allowedTopicsForIndividualSend = selectedTopics,
-        concurrencyForIndividualSend = 200)
+        concurrencyForIndividualSend = 200,
+        concurrencyForMessages = 10,
+        httpClientPoolSize = 10,
+        )
   }
 }

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -25,12 +25,14 @@ import java.util.UUID
 import scala.jdk.CollectionConverters._
 import java.time.Instant
 import com.gu.notifications.worker.models.PerformanceMetrics
+import com.amazonaws.services.lambda.runtime.Context
+import org.specs2.mock.Mockito
 
-class SenderRequestHandlerSpec extends Specification with Matchers {
+class SenderRequestHandlerSpec extends Specification with Matchers with Mockito  {
 
   "the SenderRequestHandler" should {
     "Send one notification" in new WRHSScope {
-      workerRequestHandler.handleChunkTokens(chunkedTokensNotification, null)
+      workerRequestHandler.handleChunkTokens(chunkedTokensNotification, mockedContext)
 
       deliveryCallsCount shouldEqual 1
       cloudwatchCallsCount shouldEqual 1
@@ -45,7 +47,7 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
           Left(InvalidToken(UUID.randomUUID, "invalid token", "test"))
         )
 
-      workerRequestHandler.handleChunkTokens(chunkedTokensNotification, null)
+      workerRequestHandler.handleChunkTokens(chunkedTokensNotification, mockedContext)
 
       deliveryCallsCount shouldEqual 1
       cloudwatchCallsCount shouldEqual 1
@@ -60,7 +62,7 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
           Right(ApnsDeliverySuccess("token", Instant.now(), dryRun = true))
         )
 
-      workerRequestHandler.handleChunkTokens(chunkedTokensNotification, null)
+      workerRequestHandler.handleChunkTokens(chunkedTokensNotification, mockedContext)
 
       deliveryCallsCount shouldEqual 1
       cloudwatchCallsCount shouldEqual 1
@@ -72,6 +74,9 @@ class SenderRequestHandlerSpec extends Specification with Matchers {
 
 
   trait WRHSScope extends Scope {
+
+    val mockedContext = mock[Context]
+    mockedContext.getAwsRequestId() returns "UNIT-TEST-CONTEXT"
 
     val notification = BreakingNewsNotification(
       id = UUID.fromString("068b3d2b-dc9d-482b-a1c9-bd0f5dd8ebd7"),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are evaluating the throughput of our new implementation with Firebase individual send operation on PROD.

When we tested it on fairly large notifications (with more than 40,000 subscribers), we saw that the Android sender lambda function threw an exception when it attempted to create threads.  In these cases, the lambda was invoked with nearly 20 SQS messages and when it processed the 17th or 18th messages, it threw the exceptions and stopped working.  It was terminated by AWS lambda service when it went over the 3 minute timeout.  It appears that the lambda runtime may be have sufficient resources / file descriptor space to support 20 HttpClient instances.

This PR addresses this problem by -
1. make it configurable to change the number of HttpClient instances so we can adjust this number in our experiments
2. make it configurable to change the number of messages to process concurrently
3. spread out our requests evenly over the pool of HttpClient instances within a message
4. display Java runtime version and maximum heap size in log
5. add AWS request ID to some logs which have throughput data, which make us easier to compare the throughput

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
