### PR TITLE
Adopt GHA Scala Library Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
+      GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}

--- a/api-models/version.sbt
+++ b/api-models/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "1.0.17"

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import ReleaseTransformations.*
+import sbtversionpolicy.withsbtrelease.ReleaseVersion
 import play.sbt.PlayImport.specs2
 import sbt.Keys.{libraryDependencies, mainClass}
 import sbtassembly.AssemblyPlugin.autoImport.{assemblyJarName, assemblyMergeStrategy}
@@ -5,8 +7,20 @@ import sbtassembly.MergeStrategy
 import com.typesafe.sbt.packager.docker.{Cmd, ExecCmd}
 
 val projectVersion = "1.0-latest"
-
-organization := "com.gu"
+ThisBuild / publish / skip := true
+releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
+releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  setNextVersion,
+  commitNextVersion
+)
 ThisBuild / scalaVersion := "2.13.13"
 
 val compilerOptions = Seq(
@@ -14,7 +28,8 @@ val compilerOptions = Seq(
   "-Xfatal-warnings",
   "-feature",
   "-language:postfixOps",
-  "-language:implicitConversions"
+  "-language:implicitConversions",
+  "-release:11"
 )
 
 ThisBuild / scalacOptions ++= compilerOptions
@@ -203,6 +218,7 @@ lazy val apiModels = {
   import ReleaseStateTransformations._
   Project("api-models", file("api-models")).settings(Seq(
     name := "mobile-notifications-api-models",
+    publish / skip := false,
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "org.specs2" %% "specs2-core" % specsVersion % "test",
@@ -212,39 +228,8 @@ lazy val apiModels = {
       "com.fasterxml.jackson.module" % "jackson-module-scala_2.13" % jacksonScalaModule
     ),
     organization := "com.gu",
-    publishTo := sonatypePublishToBundle.value,
-
-    scmInfo := Some(ScmInfo(
-      url("https://github.com/guardian/mobile-n10n"),
-      "scm:git:git@github.com:guardian/mobile-n10n.git"
-    )),
-
-    homepage := Some(url("https://github.com/guardian/mobile-n10n")),
-
-    developers := List(Developer(
-      id = "Guardian",
-      name = "Guardian",
-      email = null,
-      url = url("https://github.com/guardian")
-    )),
     description := "Scala models for the Guardian Push Notifications API",
-    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-    releaseVersionFile := file("api-models/version.sbt"),
-    licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-    releaseProcess := Seq[ReleaseStep](
-      checkSnapshotDependencies,
-      inquireVersions,
-      runClean,
-      runTest,
-      setReleaseVersion,
-      commitReleaseVersion,
-      tagRelease,
-      publishArtifacts,
-      releaseStepCommand("sonatypeBundleRelease"),
-      setNextVersion,
-      commitNextVersion,
-      pushChanges
-    )
+    licenses := Seq(License.Apache2),
   ))
 }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,11 +19,11 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")
 
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
-
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
 
 /*
    Without setting VersionScheme.Always here on `scala-xml`, sbt 1.8.0 will raise fatal 'version conflict' errors when

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.0.10"
+ThisBuild / version := "1.0.18-SNAPSHOT"


### PR DESCRIPTION
This replaces the old release process which had developers manually running sbt release on their own laptops - each developer had to obtain their own PGP key and Sonatype credentials, which was an elaborate & fiddly process.

This PR adopts [gha-scala-library-release-workflow](https://github.com/guardian/gha-scala-library-release-workflow), which provides an automated release process that uses single shared set of release credentials, available through GitHub Organisation Secrets (like we already do with NPM) - this workflow allows you to [release a new library version](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md) with the click of a button!

Most of the changes made here are documented in gha-scala-library-release-workflow's [configuration.md](https://github.com/guardian/gha-scala-library-release-workflow/blob/add-configuration-guidence/docs/configuration.md).

We've granted access to release credentials via [this PR](https://github.com/guardian/github-secret-access/pull/52).