### PR TITLE
Add timeout to HTTP requests to Firebase API in Android sender lambda

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -37,6 +37,8 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
   logger.info(s"Concurrency for individual send: ${config.concurrencyForIndividualSend}")
   logger.info(s"Concurrency for message processing: ${config.concurrencyForMessages}")
   logger.info(s"HttpClient object pool: ${config.httpClientPoolSize}")
+  logger.info(s"HttpClient connect timeout in sec: ${config.fcmConfig.connectTimeout}")
+  logger.info(s"HttpClient request timeout in sec: ${config.fcmConfig.requestTimeout}")
 
   override implicit val ioContextShift: ContextShift[IO] = IO.contextShift(ec)
   override implicit val timer: Timer[IO] = IO.timer(ec)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/Configuration.scala
@@ -134,6 +134,8 @@ object Configuration {
       config.getString("cleaningSqsUrl"),
       FcmConfig(
         serviceAccountKey = config.getString("fcm.serviceAccountKey"),
+        connectTimeout = getOptionalInt("fcm.connectTimeout", 10),
+        requestTimeout = getOptionalInt("fcm.requestTimeout", 10),
         debug = config.getBoolean("fcm.debug"),
         dryRun = config.getBoolean("dryrun")
       ),

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -44,7 +44,7 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
 
   private final val FCM_URL: String = s"https://fcm.googleapis.com/v1/projects/${projectId}/messages:send";
 
-  private val fcmTransport: FcmTransport = new FcmTransportJdkImpl(credential, FCM_URL, jsonFactory)
+  private val fcmTransport: FcmTransport = new FcmTransportJdkImpl(credential, FCM_URL, jsonFactory, config.connectTimeout, config.requestTimeout)
 
   def payloadBuilder: Notification => Option[FcmPayload] = n => FcmPayloadBuilder(n, config.debug)
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/models/FcmConfig.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/models/FcmConfig.scala
@@ -2,6 +2,8 @@ package com.gu.notifications.worker.delivery.fcm.models
 
 case class FcmConfig(
   serviceAccountKey: String,
+  connectTimeout: Int,
+  requestTimeout: Int,
   debug: Boolean = false,
-  dryRun: Boolean = true
+  dryRun: Boolean = true,
 )

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/ConfigurationSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/ConfigurationSpec.scala
@@ -53,7 +53,7 @@ class FcmWorkerConfigurationSpec extends Specification with Matchers {
     def createConfiguration(selectedTopics: List[String]): FcmWorkerConfiguration =
       FcmWorkerConfiguration(
         cleaningSqsUrl = "cleaning-sqs-url",
-        fcmConfig = FcmConfig(serviceAccountKey = "key", debug = false, dryRun = false),
+        fcmConfig = FcmConfig(serviceAccountKey = "key", connectTimeout = 10, requestTimeout = 10, debug = false, dryRun = false),
         threadPoolSize = 50,
         allowedTopicsForIndividualSend = selectedTopics,
         concurrencyForIndividualSend = 200,

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/fcm/FcmClientTest.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/fcm/FcmClientTest.scala
@@ -168,7 +168,7 @@ trait FcmScope extends Scope {
   val mockFirebaseMessaging = Mockito.mock[FirebaseMessaging]
   val mockApiFuture = Mockito.mock[ApiFuture[String]]
 
-  val config: FcmConfig = FcmConfig("serviceAccountKey")
+  val config: FcmConfig = FcmConfig("serviceAccountKey", 10, 10)
   val mockCredential = Mockito.mock[GoogleCredentials]
   val mockJsonFactory = Mockito.mock[JsonFactory]
   val fcmClient = new FcmClient(mockFirebaseMessaging, app, config, "TEST-PROJECT-ID", mockCredential, mockJsonFactory)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We notice that occasionally the Firebase API returns an internal error of service unavailable and then our Android sender lambda appears to stop working until it is terminated due to timeout:

<img width="1234" alt="Screenshot 2024-05-16 at 13 38 45" src="https://github.com/guardian/mobile-n10n/assets/89925410/c4121095-7d63-4f06-973e-bad8f4c6505b">


<img width="1231" alt="Screenshot 2024-05-16 at 13 39 37" src="https://github.com/guardian/mobile-n10n/assets/89925410/99a1a7cf-05f5-4316-8410-4990ca8e4763">

It appears that the lambda may be waiting for responses from Firebase API who may have become _unavailable_.

At the moment, we do not set any timeout configuration for requests we send to Firebase API.  According to [API doc](https://docs.oracle.com/en%2Fjava%2Fjavase%2F11%2Fdocs%2Fapi%2F%2F/java.net.http/java/net/http/HttpRequest.Builder.html#timeout(java.time.Duration)), the HTTP client waits indefinitely for responses by default.

This PR adds configurable parameters (`fcm.connectTimeout` and `fcm.requestTimeout`) to set the timeout (in seconds) of making HTTP connections and waiting for responses.

We did a sanity test on `CODE` and we were able to receive notification via Android simulator.