### PR TITLE
LIVE-6627 Fix the handling of unregistered token errors from Firebase API

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/models/payload/FcmResponse.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/models/payload/FcmResponse.scala
@@ -1,23 +1,32 @@
 package com.gu.notifications.worker.delivery.fcm.models.payload
 
-import play.api.libs.json.{Format, Json, JsError, JsValue, JsSuccess}
+import play.api.libs.json.{JsPath, Json, JsError, JsValue, JsSuccess, Reads}
+import play.api.libs.json.Reads._
+import play.api.libs.functional.syntax._
 
 case class FcmResponse(name: String)
 
 object FcmResponse {
-  implicit val fcmResponseJf: Format[FcmResponse] = Json.format[FcmResponse]
+  implicit val fcmResponseJf: Reads[FcmResponse] = Json.reads[FcmResponse]
 }
 
-case class FcmErrorPayload(code: Int, message: String, status: String) {
-  override def toString() = s"Code [$code] Status [$status] - $message"
+case class FcmErrorPayload(code: Int, message: String, status: String, fcmErrorCode: Option[String]) {
+  override def toString() = s"Code [$code] Status [$status] FcmCode[$fcmErrorCode] - $message"
 }
 
 object FcmErrorPayload {
-  implicit val fcmErrorPayloadJf: Format[FcmErrorPayload] = Json.format[FcmErrorPayload]
+  implicit val fcmErrorPayloadJf: Reads[FcmErrorPayload] = {
+    ((JsPath \ "code").read[Int] and
+      (JsPath \ "message").read[String] and
+      (JsPath \ "status").read[String] and
+      ((JsPath \ "details")(0) \ "errorCode").readNullable[String]
+    )(FcmErrorPayload.apply _)   
+  }
 }
 
 case class FcmError(error: FcmErrorPayload)
 
 object FcmError {
-  implicit val fcmErrorJf: Format[FcmError] = Json.format[FcmError]
+  implicit val fcmErrorJf: Reads[FcmError] = Json.reads[FcmError]
 }
+

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/fcm/FcmClientTest.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/fcm/FcmClientTest.scala
@@ -37,7 +37,7 @@ class FcmClientTest extends Specification with Mockito {
     }
 
     "Parse errors with an invalid token error code as an InvalidToken" in new FcmScope {
-      val fcmException = InvalidTokenException(FcmErrorPayload(500, "Invalid", MessagingErrorCode.INVALID_ARGUMENT.name()))
+      val fcmException = InvalidTokenException(FcmErrorPayload(500, "Invalid", MessagingErrorCode.INVALID_ARGUMENT.name(), None))
       val now = Instant.now()
       val response = fcmClient.parseSendResponse(notification.id, token, Failure(fcmException), now)
 
@@ -45,7 +45,7 @@ class FcmClientTest extends Specification with Mockito {
     }
 
     "Parse errors with NOT_FOUND error code and 'Requested entity was not found.' error message as an InvalidToken" in new FcmScope {
-      val fcmException = InvalidTokenException(FcmErrorPayload(500, "Requested entity was not found.", MessagingErrorCode.UNREGISTERED.name()))
+      val fcmException = InvalidTokenException(FcmErrorPayload(500, "Requested entity was not found.", MessagingErrorCode.UNREGISTERED.name(), None))
 
       val now = Instant.now()
       val response = fcmClient.parseSendResponse(notification.id, token, Failure(fcmException), now)

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/fcm/FcmTransportJdkImplSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/fcm/FcmTransportJdkImplSpec.scala
@@ -1,0 +1,113 @@
+package com.gu.notifications.worker.delivery.fcm
+
+import org.specs2.matcher.Matchers
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import org.specs2.mock.Mockito
+import play.api.libs.json.{Json, JsValue, JsSuccess, JsError}
+import java.net.http.HttpResponse
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.api.client.json.JsonFactory
+import com.gu.notifications.worker.delivery.fcm.models.payload.FcmErrorPayload
+
+class FcmTransporttJdkImplSpec extends Specification with Matchers with Mockito {
+
+  "FcmTransporttJdkImpl" should {
+    "parse an invalid token error response correctly from from Firebase API" in new FcmTransportTestScope {
+      val responseBody = 
+        """
+        |{
+        |  "error": {
+        |    "code": 404,
+        |    "message": "The registration token is not a valid FCM registration token",
+        |    "status": "NOT_FOUND",
+        |    "details": [
+        |      {
+        |        "@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError",
+        |        "errorCode": "UNREGISTERED"
+        |      }
+        |    ]
+        |  }
+        |}""".stripMargin
+
+      val response = mock[HttpResponse[String]]
+      response.statusCode() returns 404
+      response.body() returns responseBody
+      fcmTransport.handleResponse(response) must beFailedTry(
+        InvalidTokenException(FcmErrorPayload(404, "The registration token is not a valid FCM registration token", "NOT_FOUND", Some("UNREGISTERED")))
+      )
+   }
+
+    "parse an unexpected error response with general details field from Firebase API" in new FcmTransportTestScope {
+      val responseBody = 
+        """
+        |{
+        |  "error": {
+        |    "code": 404,
+        |    "message": "The registration token is not a valid FCM registration token",
+        |    "status": "NOT_FOUND",
+        |    "details": [
+        |    {
+        |      "@type": "type.googleapis.com/google.rpc.BadRequest",
+        |      "fieldViolations": [
+        |        {
+        |          "field": "message.data[0].value",
+        |          "description": "Invalid value at 'message.data[0].value' (TYPE_STRING), 12"
+        |        }
+        |      ]
+        |    }
+        |    ]
+        |  }
+        |}""".stripMargin
+
+      val response = mock[HttpResponse[String]]
+      response.statusCode() returns 404
+      response.body() returns responseBody
+      fcmTransport.handleResponse(response) must beFailedTry(
+        UnknownException(FcmErrorPayload(404, "The registration token is not a valid FCM registration token", "NOT_FOUND", None))
+      )
+   }
+
+    "parse an internal error object from the error response without details field from Firebase API" in new FcmTransportTestScope {
+      val responseBody = 
+        """
+        |{
+        |  "error": {
+        |    "code": 500,
+        |    "message": "The registration token is not a valid FCM registration token",
+        |    "status": "INTERNAL"
+        |  }
+        |}""".stripMargin
+
+      val response = mock[HttpResponse[String]]
+      response.statusCode() returns 500
+      response.body() returns responseBody
+      fcmTransport.handleResponse(response) must beFailedTry(
+        FcmServerException(FcmErrorPayload(500, "The registration token is not a valid FCM registration token", "INTERNAL", None))
+      )
+    }
+
+    "handle unsupported error response from Firebase API gracefully" in new FcmTransportTestScope {
+      val responseBody = 
+        """
+        | it is a invalid JSON 
+        |  "error": {
+        |    "code": 500,
+        |    }{}{}{}{}
+        |  }
+        |}""".stripMargin
+
+      val response = mock[HttpResponse[String]]
+      response.statusCode() returns 505
+      response.body() returns responseBody
+      fcmTransport.handleResponse(response) must beFailedTry
+    }
+  }
+}
+
+trait FcmTransportTestScope extends Scope {
+
+  val mockCredential = Mockito.mock[GoogleCredentials]
+  val mockJsonFactory = Mockito.mock[JsonFactory]
+  val fcmTransport: FcmTransportJdkImpl = new FcmTransportJdkImpl(mockCredential, "TEST_URL", mockJsonFactory, 10, 10)
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We often receive alerts from android sender lambda about Firebase API returning 404 `Requested entity not found` errors.

From the [documentation](https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode), the error is raised when the device token we want to send a notification to is invalid, is unregistered, or has expired.  A device token becomes unregistered when, for example, the user uninstalls / reinstalls the app.  So it happens in normal situation.

This PR checks the `details` field of error messages from Firebase API and identifies invalid token errors.  The notification service already has a component to delete invalid tokens from the registration database.

## How to test

We deployed to CODE and sent a test notification.  A notification was received successfully on my Android emulator.  The logs showed that some invalid token errors were returned by Firebase APIs and those tokens were then sent to a SQS for cleanup lambda to pick up.
![Screenshot 2024-06-10 at 10 17 16](https://github.com/guardian/mobile-n10n/assets/89925410/e704ba4e-deb1-47df-a462-327e258c9159)

The log message also showed that we were able to identify invalid tokens from the 404 response, where the FCM error code is `Unregistered` and the message is `Requested entity not found`.

![Screenshot 2024-06-10 at 10 17 33](https://github.com/guardian/mobile-n10n/assets/89925410/7dcaf2aa-9ac5-4d73-bfdb-bd82a4cb88c6)






