### PR TITLE
Downgrade logstash

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -32,4 +32,7 @@ updates.pin = [
 
  # Pin Play framework to 2.9 until we've migrated the code from Akka to Pekko
   { groupId = "com.typesafe.play", artifactId = "sbt-plugin", version = "2.9.1" },
+
+ # Pin logstash to 1.8 until we have bumped simple-configuration
+   { groupId = "com.gu", artifactId = "mobile-logstash-encoder", version = "1.1.8" },
 ]

--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ lazy val common = project
       "org.tpolecat" %% "doobie-specs2"    % doobieVersion % Test,
       "org.tpolecat" %% "doobie-scalatest" % doobieVersion % Test,
       "org.tpolecat" %% "doobie-h2"        % doobieVersion % Test,
-      "com.gu" %% "mobile-logstash-encoder" % "1.1.9",
+      "com.gu" %% "mobile-logstash-encoder" % "1.1.8",
       "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
       "io.netty" % "netty-handler" % nettyVersion,
       "io.netty" % "netty-codec" % nettyVersion,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This downgrades the logstash library as introducing the latest version causes a build error: 

```
[error] java.lang.RuntimeException: found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error] 	* com.gu:simple-configuration-core_2.13:2.0.0 (early-semver) is selected over 1.5.7
[error] 	    +- com.gu:mobile-logstash-encoder_2.13:1.1.9          (depends on 2.0.0)
[error] 	    +- com.gu:simple-configuration-ssm_2.13:1.5.7         (depends on 1.5.7)
```

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
