### PR TITLE
Revert "Bump @guardian/cdk from 59.1.0 to 59.2.1 in /notificationworkerlambda/cdk"

### DIFF
--- a/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
+++ b/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
@@ -4,7 +4,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [],
-    "gu:cdk:version": "59.2.1",
+    "gu:cdk:version": "59.1.0",
   },
   "Outputs": {
     "NotificationSenderWorkerQueueArns": {
@@ -214,7 +214,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -242,7 +242,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -295,7 +295,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -401,7 +401,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -428,7 +428,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           "App": "android",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "59.2.1",
+          "gu:cdk:version": "59.1.0",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -459,7 +459,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -534,7 +534,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -589,7 +589,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -750,7 +750,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -778,7 +778,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -831,7 +831,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -937,7 +937,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -964,7 +964,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           "App": "android-beta",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "59.2.1",
+          "gu:cdk:version": "59.1.0",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -995,7 +995,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -1070,7 +1070,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -1125,7 +1125,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -1286,7 +1286,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -1314,7 +1314,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -1367,7 +1367,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -1473,7 +1473,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -1500,7 +1500,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           "App": "android-edition",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "59.2.1",
+          "gu:cdk:version": "59.1.0",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -1531,7 +1531,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -1606,7 +1606,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -1661,7 +1661,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -1822,7 +1822,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -1850,7 +1850,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -1903,7 +1903,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -2009,7 +2009,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -2036,7 +2036,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           "App": "ios",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "59.2.1",
+          "gu:cdk:version": "59.1.0",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -2067,7 +2067,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -2142,7 +2142,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -2197,7 +2197,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -2358,7 +2358,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -2386,7 +2386,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -2439,7 +2439,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -2545,7 +2545,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -2572,7 +2572,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           "App": "ios-edition",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "59.2.1",
+          "gu:cdk:version": "59.1.0",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -2624,7 +2624,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -2678,7 +2678,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",
@@ -2733,7 +2733,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.1.0",
           },
           {
             "Key": "gu:repo",

--- a/notificationworkerlambda/cdk/package.json
+++ b/notificationworkerlambda/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@guardian/cdk": "^59.2.1",
+    "@guardian/cdk": "^59.1.0",
     "@types/jest": "^27.4.1",
     "aws-cdk": "2.148.0",
     "aws-cdk-lib": "2.148.0",

--- a/notificationworkerlambda/cdk/yarn.lock
+++ b/notificationworkerlambda/cdk/yarn.lock
@@ -601,16 +601,16 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@guardian/cdk@^59.2.1":
-  version "59.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-59.2.1.tgz#9c49148d5a30d8a6e62498982b90052e82b37db2"
-  integrity sha512-ib2hsOwUHgICs/yokTRB+bH4Q4EQ2XPTKR14/Ici0rK4xSTrNftXVgf2fNfyk7yiHoAUYZyH6KlmY2q45zYayQ==
+"@guardian/cdk@^59.1.0":
+  version "59.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-59.1.0.tgz#9a56d512c37c75778667aaff77aa8a326a061871"
+  integrity sha512-6QlI5V7jOetwURkfKZOVvLM/tvPbyg+QNjc0cBqkRsNQhngFhhk73sLiTY9OLORzp/VXVJcIF2fzqdOE0uN41w==
   dependencies:
     "@oclif/core" "3.26.6"
-    aws-sdk "^2.1664.0"
+    aws-sdk "^2.1649.0"
     chalk "^4.1.2"
     codemaker "^1.101.0"
-    git-url-parse "^14.1.0"
+    git-url-parse "^14.0.0"
     js-yaml "^4.1.0"
     lodash.camelcase "^4.3.0"
     lodash.kebabcase "^4.1.1"
@@ -1186,10 +1186,10 @@ aws-cdk@2.148.0:
   optionalDependencies:
     fsevents "2.3.2"
 
-aws-sdk@^2.1664.0:
-  version "2.1664.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1664.0.tgz#c6fbbf87fa969c2ba547fe3b33f8cd1db1ad00eb"
-  integrity sha512-S2IA1cCGz38d8ZKsuQGwlK3LE+9cXFt7OFsSGQtKX1Mc40xFXpiqQy7jX1r0vZIiy9ZMnxeTcBPM28G/yYu2kA==
+aws-sdk@^2.1649.0:
+  version "2.1662.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1662.0.tgz#d187d413bdd08a24e9d6142712666d9d29e95b4e"
+  integrity sha512-ISKN3yxjQtjIMOBU2b3zO8Qrxd9UqdYlJlxSQUn5/4jfqCSad/s1mF66Cwzl5UByJtvFn0xoJORIZ7K6BTLuuw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -1901,7 +1901,7 @@ git-up@^7.0.0:
     is-ssh "^1.4.0"
     parse-url "^8.1.0"
 
-git-url-parse@^14.1.0:
+git-url-parse@^14.0.0:
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-14.1.0.tgz#01cb70000666c11a7230aceec1fd518c416c224c"
   integrity sha512-8xg65dTxGHST3+zGpycMMFZcoTzAdZ2dOtu4vmgIfkTFnVHBxHMzBC2L1k8To7EmrSiHesT8JgPLT91VKw1B5g==


### PR DESCRIPTION
Reverts guardian/cdk upgrade as we suspect this may have caused some issues with app notifications. Jira ticket [here](https://theguardian.atlassian.net/browse/LIVE-6881)