### PR TITLE
Revert "Revert AWS dependency updates"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ ThisBuild / scalacOptions ++= compilerOptions
 
 val playJsonVersion = "3.0.4"
 val specsVersion: String = "4.8.3"
-val awsSdkVersion: String = "1.12.761"
+val awsSdkVersion: String = "1.12.767"
 val doobieVersion: String = "0.13.4"
 val catsVersion: String = "2.12.0"
 val okHttpVersion: String = "4.12.0"


### PR DESCRIPTION
Reverts guardian/mobile-n10n#1279 since we've found out that the set of Snyk upgrades did not cause the notifications issues