### PR TITLE
Ld/dependabot/npm and yarn/notificationworkerlambda/cdk/guardian/cdk 59.2.3

### DIFF
--- a/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
+++ b/notificationworkerlambda/cdk/lib/__snapshots__/senderworker.test.ts.snap
@@ -4,7 +4,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [],
-    "gu:cdk:version": "59.2.1",
+    "gu:cdk:version": "59.2.3",
   },
   "Outputs": {
     "NotificationSenderWorkerQueueArns": {
@@ -214,7 +214,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -242,7 +242,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -295,7 +295,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -401,7 +401,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -428,7 +428,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           "App": "android",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "59.2.1",
+          "gu:cdk:version": "59.2.3",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -459,7 +459,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -534,7 +534,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -589,7 +589,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -750,7 +750,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -778,7 +778,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -831,7 +831,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -937,7 +937,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -964,7 +964,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           "App": "android-beta",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "59.2.1",
+          "gu:cdk:version": "59.2.3",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -995,7 +995,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -1070,7 +1070,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -1125,7 +1125,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -1286,7 +1286,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -1314,7 +1314,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -1367,7 +1367,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -1473,7 +1473,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -1500,7 +1500,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           "App": "android-edition",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "59.2.1",
+          "gu:cdk:version": "59.2.3",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -1531,7 +1531,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -1606,7 +1606,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -1661,7 +1661,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -1822,7 +1822,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -1850,7 +1850,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -1903,7 +1903,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -2009,7 +2009,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -2036,7 +2036,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           "App": "ios",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "59.2.1",
+          "gu:cdk:version": "59.2.3",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -2067,7 +2067,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -2142,7 +2142,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -2197,7 +2197,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -2358,7 +2358,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -2386,7 +2386,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -2439,7 +2439,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -2545,7 +2545,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -2572,7 +2572,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           "App": "ios-edition",
           "Stack": "mobile-notifications-workers",
           "Stage": "PROD",
-          "gu:cdk:version": "59.2.1",
+          "gu:cdk:version": "59.2.3",
           "gu:repo": "guardian/mobile-n10n",
         },
         "Tier": "Standard",
@@ -2624,7 +2624,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -2678,7 +2678,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",
@@ -2733,7 +2733,7 @@ exports[`The Sender Worker stack matches the snapshot 1`] = `
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "59.2.1",
+            "Value": "59.2.3",
           },
           {
             "Key": "gu:repo",

--- a/notificationworkerlambda/cdk/package.json
+++ b/notificationworkerlambda/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@guardian/cdk": "^59.2.1",
+    "@guardian/cdk": "^59.2.3",
     "@types/jest": "^27.4.1",
     "aws-cdk": "2.148.0",
     "aws-cdk-lib": "2.148.0",

--- a/notificationworkerlambda/cdk/yarn.lock
+++ b/notificationworkerlambda/cdk/yarn.lock
@@ -601,15 +601,15 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@guardian/cdk@^59.2.1":
-  version "59.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-59.2.1.tgz#9c49148d5a30d8a6e62498982b90052e82b37db2"
-  integrity sha512-ib2hsOwUHgICs/yokTRB+bH4Q4EQ2XPTKR14/Ici0rK4xSTrNftXVgf2fNfyk7yiHoAUYZyH6KlmY2q45zYayQ==
+"@guardian/cdk@^59.2.3":
+  version "59.2.3"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-59.2.3.tgz#a93d1e3715105c53b704165826f7287423826b8b"
+  integrity sha512-kOjtMKx6TFgxVOgpZ7KEGC1G/iGSKbiYlqq/1W93qIelu+s5eug/c5Nc5GQjc8ABS4uz8uJp34fdUNb19LkqRw==
   dependencies:
     "@oclif/core" "3.26.6"
-    aws-sdk "^2.1664.0"
+    aws-sdk "^2.1670.0"
     chalk "^4.1.2"
-    codemaker "^1.101.0"
+    codemaker "^1.102.0"
     git-url-parse "^14.1.0"
     js-yaml "^4.1.0"
     lodash.camelcase "^4.3.0"
@@ -1186,10 +1186,10 @@ aws-cdk@2.148.0:
   optionalDependencies:
     fsevents "2.3.2"
 
-aws-sdk@^2.1664.0:
-  version "2.1664.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1664.0.tgz#c6fbbf87fa969c2ba547fe3b33f8cd1db1ad00eb"
-  integrity sha512-S2IA1cCGz38d8ZKsuQGwlK3LE+9cXFt7OFsSGQtKX1Mc40xFXpiqQy7jX1r0vZIiy9ZMnxeTcBPM28G/yYu2kA==
+aws-sdk@^2.1670.0:
+  version "2.1673.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1673.0.tgz#08dd3196c0f305457a184ec0e86b15de08026505"
+  integrity sha512-7tcc+y7XmCt2aq3vq46xpJTDMNqukFhJOXsQuuwsMZiydZpGG7l7wbpTOtfFhktieSjLg4V9eyznpnZNz5aooA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -1449,10 +1449,10 @@ co@^4.6.0:
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
-codemaker@^1.101.0:
-  version "1.101.0"
-  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.101.0.tgz#27e5e0311f08061618804e485a015eaa860aa718"
-  integrity sha512-bAg+N4PA8mniJrCpTYFdaFmJA+3fE1Vjgf4o1EnPc07nw6qRcJsr/D9ZZoutEsvw7UM8OmZp4qZxVzpCqRhhQQ==
+codemaker@^1.102.0:
+  version "1.102.0"
+  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.102.0.tgz#336dd6a8f7ffd64e02afcee7830c1f8d768f0efe"
+  integrity sha512-lxsbbcSMxCdT+9wUv1AvBH9791andoWDcQ6s7ZK6KsMZ+UkRLO3obzhi7Zm+RIA3lHecqzaGmOKyRnu0Dx/Zew==
   dependencies:
     camelcase "^6.3.0"
     decamelize "^5.0.1"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This is a fork of this PR https://github.com/guardian/mobile-n10n/pull/1280 to upgrade the @guardian/cdk version and update the snapshats so that the CI tests can still pass

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
