### PR TITLE
Add stale PR handler

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,37 @@
+# Automatically mark any pull requests that have been inactive for 30 days as "Stale"
+# then close them 3 days later if there is still no activity.
+name: "Stale PR Handler"
+
+on:
+  schedule:
+    # Check for Stale PRs every Monday to Thursday morning
+    # Don't check on Fridays as it wouldn't be very nice to have a bot mark your PR as Stale on Friday and then close it on Monday morning!
+    - cron: "0 6 * * MON-THU"
+
+permissions:
+  pull-requests: write
+  contents: write
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        id: stale
+        # Read about options here: https://github.com/actions/stale#all-options
+        with:
+          # never automatically mark issues as stale
+          days-before-issue-stale: -1
+
+          # Wait 30 days before marking a PR as stale
+          days-before-stale: 30
+          stale-pr-message: >
+            This PR is stale because it has been open 30 days with no activity.
+            Unless a comment is added or the “stale” label removed, this will be closed in 3 days
+          # Wait 3 days after a PR has been marked as stale before closing
+          days-before-close: 3
+          close-pr-message: This PR was closed because it has been stalled for 3 days with no activity.
+
+          # Ignore PR's raised by Dependabot
+          exempt-pr-labels: "dependencies"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Automatically mark any pull requests that have been inactive for 30 days as "Stale" then close them 3 days later if there is still no activity.