### PR TITLE
Revert "chore(deps): Non-AWS dependency updates"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ val jacksonCbor: String = "2.18.3"
 val jacksonScalaModule: String = "2.18.3"
 val simpleConfigurationVersion: String = "1.5.7"
 val googleOAuthClient: String = "1.39.0"
-val nettyVersion: String = "4.2.0.Final"
+val nettyVersion: String = "4.1.119.Final"
 val slf4jVersion: String = "1.7.36"
 val logbackVersion: String = "1.5.18"
 
@@ -264,7 +264,7 @@ def lambda(projectName: String, directoryName: String, mainClassName: Option[Str
       "com.gu" %% "simple-configuration-core" % simpleConfigurationVersion,
       "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
       "ch.qos.logback" % "logback-classic" % logbackVersion,
-      "net.logstash.logback" % "logstash-logback-encoder" % "8.1",
+      "net.logstash.logback" % "logstash-logback-encoder" % "8.0",
       specs2 % Test
     ),
     assemblyJarName := s"$projectName.jar",


### PR DESCRIPTION
Reverts guardian/mobile-n10n#1433

We think this may be the cause of broken iOS notifications in the latest main 