### PR TITLE
Remove netty from common

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,6 @@ lazy val commontest = project
     ),
   ))
 
-
 lazy val common = project
   .dependsOn(commoneventconsumer)
   .settings(LocalDynamoDBCommon.settings)
@@ -119,11 +118,6 @@ lazy val common = project
       "org.tpolecat" %% "doobie-h2"        % doobieVersion % Test,
       "com.gu" %% "mobile-logstash-encoder" % "1.1.8",
       "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
-      "io.netty" % "netty-handler" % nettyVersion,
-      "io.netty" % "netty-codec" % nettyVersion,
-      "io.netty" % "netty-codec-http" % nettyVersion,
-      "io.netty" % "netty-codec-http2" % nettyVersion,
-      "io.netty" % "netty-common" % nettyVersion,
       "org.postgresql" % "postgresql" % "42.7.5",
       "ch.qos.logback" % "logback-core" % logbackVersion,
       "ch.qos.logback" % "logback-classic" % logbackVersion,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This removes the netty library from notification worker lambda because an [upgrade](https://github.com/guardian/mobile-n10n/pull/1445) caused our service to break. Since netty is pulled in by the pushy library, we will use their version of netty so to avoid getting version conflicts

## How to test

Deployed to CODE and tested that notifications send on iOS Devices

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
