### PR TITLE
(DO NOT MERGE) Test fake breaking news alert lambda and cloudwatch metrics

### DIFF
--- a/fakebreakingnewslambda/fakebreakingnewslambda-cfn.yaml
+++ b/fakebreakingnewslambda/fakebreakingnewslambda-cfn.yaml
@@ -93,7 +93,7 @@ Resources:
       - FakeBreakingNewsFunction
     Type: AWS::Events::Rule
     Properties:
-      ScheduleExpression: "cron(5 * * * ? *)"
+      ScheduleExpression: "rate(10 minutes)"
       Targets:
         - Id: !Sub ${Stack}-${App}-${Stage}
           Arn: !GetAtt FakeBreakingNewsFunction.Arn
@@ -122,7 +122,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: dryrun
       Namespace: !Sub Notifications/${Stage}/workers
-      Period: 7200
+      Period: 600 # 10 minutes
       Statistic: Sum
       Threshold: 1
       TreatMissingData: breaching
@@ -140,7 +140,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: dryrun
       Namespace: !Sub Notifications/${Stage}/workers
-      Period: 7200
+      Period: 600 # 10 minutes
       Statistic: Sum
       Threshold: 1
       TreatMissingData: breaching

--- a/fakebreakingnewslambda/fakebreakingnewslambda-cfn.yaml
+++ b/fakebreakingnewslambda/fakebreakingnewslambda-cfn.yaml
@@ -93,7 +93,7 @@ Resources:
       - FakeBreakingNewsFunction
     Type: AWS::Events::Rule
     Properties:
-      ScheduleExpression: "rate(10 minutes)"
+      ScheduleExpression: 'rate(5 minutes)'
       Targets:
         - Id: !Sub ${Stack}-${App}-${Stage}
           Arn: !GetAtt FakeBreakingNewsFunction.Arn


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Make the lambda fire dry alerts every 5 minutes instead of every hour.
The alarm should be invoked if there has not been any dry run every 10 minutes.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Deploy this to fake breaking news lambda CODE
Deploy the breaking netty change (#1479) to notification worker to CODE

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
