### PR TITLE
WIP broadcast and football payloads for live activiites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ dynamodb-local-schedule-lambda/
 project/.bloop/
 project/metals.sbt
 .bsp/
+
+*.p8

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastApiClient.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastApiClient.scala
@@ -8,9 +8,11 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import scala.concurrent.Future
 import scala.concurrent.Promise
+import com.turo.pushy.apns.auth.ApnsSigningKey
+import com.turo.pushy.apns.auth.AuthenticationToken
+import play.api.libs.json.Json
+import com.gu.liveactivities.BroadcastFixtures._
 
-import com.turo.pushy.apns.auth.ApnsSigningKey;
-import com.turo.pushy.apns.auth.AuthenticationToken;
 import java.time.Instant
 import java.util.Date
 
@@ -51,6 +53,8 @@ class BroadcastApiClient {
     |  }
     }"""
 
+  private val startPayload: String = Json.stringify(Json.toJson(broadcastStartBodyFixture))
+
   private def getAccessToken(): String = {
     return "invalid-token-for-testing"
   }
@@ -77,13 +81,16 @@ class BroadcastApiClient {
       .header("apns-expiration", expiration.getOrElse(Instant.now().plusSeconds(5 * 60)).getEpochSecond.toString)
       .header("apns-priority", priority.map(_.toString).getOrElse("1"))
       .header("apns-push-type", "Liveactivity")
+
+      // add channel id
       .header("apns-channel-id", channelId)
-      .POST(HttpRequest.BodyPublishers.ofString(message, charSet))
+      .POST(HttpRequest.BodyPublishers.ofString(startPayload, charSet))
+
       .timeout(Duration.ofSeconds(60))
       .build()
+
     val p = Promise[String]()
     httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).whenComplete((response, err) => {
-
       println(s"Received response: $response, error: $err")
 
       if (err != null) {

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastApiClient.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastApiClient.scala
@@ -13,7 +13,6 @@ import com.turo.pushy.apns.auth.ApnsSigningKey;
 import com.turo.pushy.apns.auth.AuthenticationToken;
 import java.time.Instant
 import java.util.Date
-import scala.concurrent.duration.DurationInt
 
 class BroadcastApiClient {
   
@@ -27,7 +26,7 @@ class BroadcastApiClient {
 
   private val bundleId = "uk.co.guardian.iphone2.debug"
   
-  private val url = s"https://api.sandbox.push.apple.com:443//4/broadcasts/apps/$bundleId"
+  private val url = s"https://api.sandbox.push.apple.com:443/4/broadcasts/apps/$bundleId"
 
   private val message = 
     """{ 
@@ -78,15 +77,23 @@ class BroadcastApiClient {
       .header("apns-expiration", expiration.getOrElse(Instant.now().plusSeconds(5 * 60)).getEpochSecond.toString)
       .header("apns-priority", priority.map(_.toString).getOrElse("1"))
       .header("apns-push-type", "Liveactivity")
+      .header("apns-channel-id", channelId)
       .POST(HttpRequest.BodyPublishers.ofString(message, charSet))
       .timeout(Duration.ofSeconds(60))
       .build()
     val p = Promise[String]()
     httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).whenComplete((response, err) => {
-      if (response == null) {
+
+      println(s"Received response: $response, error: $err")
+
+      if (err != null) {
         p.failure(err)
+      } else if (response.statusCode() != 200) {
+        p.failure(new RuntimeException(s"Failed to send broadcast with status code ${response.statusCode()} and body ${response.body()}"))
       } else {
-        println(s"Received response with status code ${response.statusCode()} and body ${response.body()}")
+        val apnsUniqueId = response.headers().firstValue("apns-unique-id").orElse("not found") // SANDBOX only header for debugging
+        println(s"Received response with status code ${response.statusCode()} and apns-unique-id ${apnsUniqueId}")
+
         p.success(response.body())
       }
     })

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastFixtures.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastFixtures.scala
@@ -1,0 +1,126 @@
+package com.gu.liveactivities
+
+
+object BroadcastFixtures {
+  def fifteenMinutesFromNowEpochSeconds: Long = (System.currentTimeMillis() / 1000L) + 15 * 60
+  def nowEpochSeconds: Long = System.currentTimeMillis() / 1000L
+
+
+  val broadcastStartBodyFixture = BroadcastStartBody(
+    aps = BroadcastStartAps(
+      timestamp = fifteenMinutesFromNowEpochSeconds,
+      event = "start",
+      `content-state` = FootballMatchContentState(
+        matchStatus = Scheduled, // "New Match" will be mapped to Scheduled as an example
+        kickOffTimestamp = fifteenMinutesFromNowEpochSeconds,
+        homeTeam = TeamState(
+          name = "Brentford",
+          score = 0,
+          logoAssetName = None,
+          teamUrl = None,
+          penaltyScore = None,
+          redCards = None
+        ),
+        awayTeam = TeamState(
+          name = "Wolverhampton",
+          score = 0,
+          logoAssetName = None,
+          teamUrl = None,
+          penaltyScore = None,
+          redCards = None
+        ),
+        competition = Competition(
+          id = "100",
+          name = "League 1",
+          round = Some("1")
+        ),
+        commentary = None,
+        lineupsAvailable = Some(false),
+        currentMinute = None,
+        currentPeriodStartTime = None,
+        articleUrl = None
+      ),
+      `attributes-type` = FootballMatchAttributesType,
+      `attributes` = FootballMatchAttributes(
+        matchId = "4540277"
+      )
+    )
+  )
+
+
+  val broadcastUpdateBodyFixture = BroadcastUpdateBody(
+    aps = BroadcastUpdateAps(
+      timestamp = nowEpochSeconds,
+      event = "update",
+      `content-state` = FootballMatchContentState(
+        matchStatus = SecondHalf,
+        kickOffTimestamp = 1742131800L, // 2025-03-16T13:30:00 as epoch seconds
+        homeTeam = TeamState(
+          name = "Arsenal",
+          score = 0,
+          logoAssetName = None,
+          teamUrl = None,
+          penaltyScore = None,
+          redCards = Some(0)
+        ),
+        awayTeam = TeamState(
+          name = "Chelsea",
+          score = 0,
+          logoAssetName = None,
+          teamUrl = None,
+          penaltyScore = None,
+          redCards = Some(0)
+        ),
+        competition = Competition(
+          id = "100",
+          name = "League 1",
+          round = Some("1")
+        ),
+        commentary = Some("A closely fought match so far..."),
+        lineupsAvailable = Some(true),
+        currentMinute = Some(75),
+        currentPeriodStartTime = None,
+        articleUrl = None
+      ),
+      `stale-date` = nowEpochSeconds + 3600 // 1 hour from now
+    )
+  )
+
+  val broadcastEndBodyFixture = BroadcastEndBody(
+    aps = BroadcastEndAps(
+      timestamp = nowEpochSeconds,
+      event = "end",
+      `content-state` = FootballMatchContentState(
+        matchStatus = FullTime,
+        kickOffTimestamp = 1742131800L, // 2025-03-16T13:30:00 as epoch seconds
+        homeTeam = TeamState(
+          name = "Arsenal",
+          score = 1,
+          logoAssetName = None,
+          teamUrl = None,
+          penaltyScore = None,
+          redCards = Some(0)
+        ),
+        awayTeam = TeamState(
+          name = "Chelsea",
+          score = 0,
+          logoAssetName = None,
+          teamUrl = None,
+          penaltyScore = None,
+          redCards = Some(1)
+        ),
+        competition = Competition(
+          id = "100",
+          name = "League 1",
+          round = Some("1")
+        ),
+        commentary = Some("Arsenal takes the win thanks to a late goal."),
+        lineupsAvailable = Some(true),
+        currentMinute = Some(90),
+        currentPeriodStartTime = None,
+        articleUrl = None
+      ),
+      `dismissal-date` = nowEpochSeconds + 3600 // 1 hour from now
+    )
+  )
+}

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -1,0 +1,17 @@
+package com.gu.liveactivities
+
+object BroadcastLambda {
+
+  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  def handleRequest(): Unit = {
+    val client = new BroadcastApiClient()
+    val broadcastFuture = client.sendToChannel("test-channel-id", None, None)
+    broadcastFuture.onComplete {
+      case scala.util.Success(apnResponse) => println(s"Sent broadcast successfully with Response: $apnResponse")
+      case scala.util.Failure(exception) => println(s"Failed to send broadcast: ${exception.getMessage}")
+    }
+    // Keep the main thread alive to allow the async operation to complete
+    Thread.sleep(5000)
+  }
+}

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastPayloads.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastPayloads.scala
@@ -104,6 +104,50 @@ object FootballMatchContentState {
 
 // BROADCAST PAYLOADS //////////////////////////////////////////////////
 
+// Start Live Activity (via broadcast)
+sealed trait ActivityAttributesType { val `type`: String }
+case object FootballMatchAttributesType extends ActivityAttributesType { val `type` = "FootballMatchAttributes" }
+
+object ActivityAttributesTypes {
+  implicit val format: Format[ActivityAttributesType] = Format(
+    Reads {
+      case JsString(s) => s match {
+        case "FootballMatchAttributes"  => JsSuccess(FootballMatchAttributesType)
+        case other                      => JsError(s"Unknown match status: $other")
+      }
+      case _ => JsError("Expected a JSON string for ActitivyAttributes")
+    },
+    Writes(ms => JsString(ms.`type`))
+  )
+}
+
+sealed trait ActivityAttributes
+case class FootballMatchAttributes(matchId: String) extends ActivityAttributes
+object FootballMatchAttributes {
+  implicit val jf: OFormat[FootballMatchAttributes] = Json.format[FootballMatchAttributes]
+}
+
+// Update Live Activity (broadcast)
+case class BroadcastStartAps(
+                               timestamp: Long,
+                               event: String = "start",
+                               `content-state`: ContentState,
+                               `attributes-type`: ActivityAttributesType,
+                               `attributes`: ActivityAttributes
+                             )
+object BroadcastStartAps {
+  implicit val jf: OFormat[BroadcastStartAps] = Json.format[BroadcastStartAps]
+}
+
+
+case class BroadcastStartBody(
+                                aps: BroadcastUpdateAps
+                              )
+object BroadcastStartBody {
+  implicit val jf: OFormat[BroadcastStartBody] = Json.format[BroadcastStartBody]
+}
+
+
 // Update Live Activity (broadcast)
 case class BroadcastUpdateAps(
                       timestamp: Long,

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastPayloads.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastPayloads.scala
@@ -1,0 +1,149 @@
+package com.gu.liveactivities
+
+import play.api.libs.json._
+
+// GENERIC CONTENT STATE //////////////////////////////////////////////////
+
+sealed trait ContentState
+object ContentState {
+  implicit val format: OFormat[ContentState] = new OFormat[ContentState] {
+    def writes(cs: ContentState): JsObject = cs match {
+      case f: FootballMatchContentState =>
+        FootballMatchContentState.jf.writes(f).as[JsObject] + ("type" -> JsString("football"))
+      // Add cases for other ContentState subtypes here
+    }
+
+    def reads(json: JsValue): JsResult[ContentState] = {
+      (json \ "type").validate[String].flatMap {
+        case "football" => FootballMatchContentState.jf.reads(json)
+        // Add cases for other ContentState subtypes here
+        case other      => JsError(s"Unknown ContentState type: $other")
+      }
+    }
+  }
+}
+
+// FOOTBALL CONTENT STATE //////////////////////////////////////////////////
+
+sealed trait MatchStatus { val status: String }
+case object Scheduled           extends MatchStatus { val status = "SCHEDULED" }
+case object PreMatch            extends MatchStatus { val status = "PRE_MATCH" }
+case object FirstHalf           extends MatchStatus { val status = "FIRST_HALF" }
+case object HalfTime            extends MatchStatus { val status = "HALF_TIME" }
+case object SecondHalf          extends MatchStatus { val status = "SECOND_HALF" }
+case object ExtraTimeFirstHalf  extends MatchStatus { val status = "EXTRA_TIME_FIRST_HALF" }
+case object ExtraTimeHalfTime   extends MatchStatus { val status = "EXTRA_TIME_HALF_TIME" }
+case object ExtraTimeSecondHalf extends MatchStatus { val status = "EXTRA_TIME_SECOND_HALF" }
+case object Penalties           extends MatchStatus { val status = "PENALTIES" }
+case object FullTime            extends MatchStatus { val status = "FULL_TIME" }
+case object Postponed           extends MatchStatus { val status = "POSTPONED" }
+case object Abandoned           extends MatchStatus { val status = "ABANDONED" }
+object MatchStatus {
+  implicit val format: Format[MatchStatus] = Format(
+    Reads {
+      case JsString(s) => s match {
+        case "SCHEDULED"               => JsSuccess(Scheduled)
+        case "PRE_MATCH"               => JsSuccess(PreMatch)
+        case "FIRST_HALF"              => JsSuccess(FirstHalf)
+        case "HALF_TIME"               => JsSuccess(HalfTime)
+        case "SECOND_HALF"             => JsSuccess(SecondHalf)
+        case "EXTRA_TIME_FIRST_HALF"   => JsSuccess(ExtraTimeFirstHalf)
+        case "EXTRA_TIME_HALF_TIME"    => JsSuccess(ExtraTimeHalfTime)
+        case "EXTRA_TIME_SECOND_HALF"  => JsSuccess(ExtraTimeSecondHalf)
+        case "PENALTIES"               => JsSuccess(Penalties)
+        case "FULL_TIME"               => JsSuccess(FullTime)
+        case "POSTPONED"               => JsSuccess(Postponed)
+        case "ABANDONED"               => JsSuccess(Abandoned)
+        case other                     => JsError(s"Unknown match status: $other")
+      }
+      case _ => JsError("Expected a JSON string for MatchStatus")
+    },
+    Writes(ms => JsString(ms.status))
+  )
+}
+
+case class Competition(
+                        id: String, // PA has a competition ID but separate season id.
+                        name: String, // Ful competition name with season
+                        // stage: Option[String] = None, // TBC
+                        round: Option[String] = None
+                      )
+object Competition {
+  implicit val jf: OFormat[Competition] = Json.format[Competition]
+}
+
+case class TeamState(
+                      name: String,
+                      score: Int,
+                      logoAssetName: Option[String] = None, // Bundled asset catalog image name for the team logo
+                      teamUrl: Option[String] = None, // Deep link URL
+                      penaltyScore: Option[Int] = None,
+                      redCards: Option[Int] = None
+                    )
+object TeamState {
+  implicit val jf: OFormat[TeamState] = Json.format[TeamState]
+}
+
+case class FootballMatchContentState(
+                         matchStatus: MatchStatus,
+                         kickOffTimestamp: Long,
+                         homeTeam: TeamState,
+                         awayTeam: TeamState,
+                         competition: Competition,
+                         commentary: Option[String] = None,
+                         lineupsAvailable: Option[Boolean] = None,
+                         currentMinute: Option[Int] = None,
+                         currentPeriodStartTime: Option[Long] = None,
+                         articleUrl: Option[String] = None // not optional?? We must have an article?
+                       ) extends ContentState
+
+object FootballMatchContentState {
+  implicit val jf: OFormat[FootballMatchContentState] = Json.format[FootballMatchContentState]
+}
+
+
+// BROADCAST PAYLOADS //////////////////////////////////////////////////
+
+// Update Live Activity (broadcast)
+case class BroadcastUpdateAps(
+                      timestamp: Long,
+                      event: String = "update",
+                      `content-state`: ContentState,
+                      `stale-date`: Long
+                      // alert: Optional noticiation alert to show when the update is received
+                    )
+object BroadcastUpdateAps {
+  implicit val jf: OFormat[BroadcastUpdateAps] = Json.format[BroadcastUpdateAps]
+}
+
+
+case class BroadcastUpdateBody(
+                       aps: BroadcastUpdateAps
+                     )
+object BroadcastUpdateBody {
+  implicit val jf: OFormat[BroadcastUpdateBody] = Json.format[BroadcastUpdateBody]
+}
+
+
+// End Live Activity (broadcast)
+case class BroadcastEndAps(
+                   timestamp: Long,
+                   event: String = "end",
+                   `content-state`: ContentState,
+                   // Optional unix timestamp to set when the Live Activity is dismissed from Lock Screen (default: up to 4hrs after end). Use a past date to dismiss immediately.
+                   `dismissal-date`: Long
+                 )
+object BroadcastEndAps {
+  implicit val jf: OFormat[BroadcastEndAps] = Json.format[BroadcastEndAps]
+}
+
+
+case class BroadcastEndBody(
+                    aps: BroadcastEndAps
+                  )
+object BroadcastEndBody {
+  implicit val jf: OFormat[BroadcastEndBody] = Json.format[BroadcastEndBody]
+}
+
+
+

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastPayloads.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastPayloads.scala
@@ -107,21 +107,36 @@ object FootballMatchContentState {
 // Start Live Activity (via broadcast)
 sealed trait ActivityAttributesType { val `type`: String }
 case object FootballMatchAttributesType extends ActivityAttributesType { val `type` = "FootballMatchAttributes" }
-
-object ActivityAttributesTypes {
+object ActivityAttributesType {
   implicit val format: Format[ActivityAttributesType] = Format(
     Reads {
       case JsString(s) => s match {
         case "FootballMatchAttributes"  => JsSuccess(FootballMatchAttributesType)
         case other                      => JsError(s"Unknown match status: $other")
       }
-      case _ => JsError("Expected a JSON string for ActitivyAttributes")
+      case _ => JsError("Expected a JSON string for ActivityAttributes")
     },
     Writes(ms => JsString(ms.`type`))
   )
 }
 
 sealed trait ActivityAttributes
+object ActivityAttributes {
+  implicit val format: OFormat[ActivityAttributes] = new OFormat[ActivityAttributes] {
+    def writes(a: ActivityAttributes): JsObject = a match {
+      case f: FootballMatchAttributes =>
+        FootballMatchAttributes.jf.writes(f).as[JsObject] + ("type" -> JsString("football"))
+      // Add cases for other ActivityAttributes subtypes here
+    }
+    def reads(json: JsValue): JsResult[ActivityAttributes] = {
+      (json \ "type").validate[String].flatMap {
+        case "football" => FootballMatchAttributes.jf.reads(json)
+        // Add cases for other ActivityAttributes subtypes here
+        case other      => JsError(s"Unknown ActivityAttributes type: $other")
+      }
+    }
+  }
+}
 case class FootballMatchAttributes(matchId: String) extends ActivityAttributes
 object FootballMatchAttributes {
   implicit val jf: OFormat[FootballMatchAttributes] = Json.format[FootballMatchAttributes]
@@ -141,7 +156,7 @@ object BroadcastStartAps {
 
 
 case class BroadcastStartBody(
-                                aps: BroadcastUpdateAps
+                                aps: BroadcastStartAps
                               )
 object BroadcastStartBody {
   implicit val jf: OFormat[BroadcastStartBody] = Json.format[BroadcastStartBody]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add draft models for Broadcast update json payloads and football matches. 
https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications
Football content start wip schema
https://docs.google.com/document/d/1sBVTPYKtOiD30CpCw92Jw5SfrzxtZDD3WiU3lyIKsHU/edit?tab=t.104c2vr8y8r5