### PR TITLE
Add DynamoDB LiveActivityChannelRepository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ project/plugins/project/
 dynamodb-local/
 dynamodb-local-common/
 dynamodb-local-schedule-lambda/
+dynamodb-local-live-activities/
 
 # Scala-IDE specific
 .scala_dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -461,6 +461,7 @@ lazy val reportExtractor = lambda("reportextractor", "reportextractor", Some("co
 lazy val liveactivities = lambda("liveactivities", "liveactivities", Some("com.gu.liveactivities.LambdaLocalRun"))
   .dependsOn(common)
   .dependsOn(apiModels  % "test->test", apiModels  % "compile->compile")
+  .settings(LocalDynamoDBLiveActivities.settings)
   .settings(
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
@@ -472,4 +473,10 @@ lazy val liveactivities = lambda("liveactivities", "liveactivities", Some("com.g
       // Hopefully this workaround can be removed once play-json-extensions either updates to Play 3.0 or is merged into play-json
       ExclusionRule(organization = "com.typesafe.play")
     ),
+    fork := true,
+    startDynamoDBLocal := startDynamoDBLocal.dependsOn(Test / compile).value,
+    Test / test := (Test / test).dependsOn(startDynamoDBLocal).value,
+    Test / testOnly := (Test / testOnly).dependsOn(startDynamoDBLocal).evaluated,
+    Test / testQuick := (Test / testQuick).dependsOn(startDynamoDBLocal).evaluated,
+    Test / testOptions += dynamoDBLocalTestCleanup.value,
   )

--- a/common/src/main/scala/aws/AsyncDynamo.scala
+++ b/common/src/main/scala/aws/AsyncDynamo.scala
@@ -41,4 +41,5 @@ class AsyncDynamo(val client: AmazonDynamoDBAsync) {
   def query(request: QueryRequest): Future[QueryResult] = wrapAsyncMethod(client.queryAsync, request)
   def get(request: GetItemRequest): Future[GetItemResult] = wrapAsyncMethod(client.getItemAsync, request)
   def updateItem(request: UpdateItemRequest): Future[UpdateItemResult] = wrapAsyncMethod(client.updateItemAsync, request)
+  def deleteItem(request: DeleteItemRequest): Future[DeleteItemResult] = wrapAsyncMethod(client.deleteItemAsync, request)
 }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/LiveActivityChannelRepository.scala
@@ -12,44 +12,46 @@ import tracking.RepositoryError
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 
-
 // MODELS /////////////////////////////////////////////
 
 sealed trait LiveActivityData
 case class FootballLiveActivity(
-                                 homeTeam: String,
-                                 awayTeam: String,
-                                 articleUrl: String
-                               ) extends LiveActivityData
+    homeTeam: String,
+    awayTeam: String,
+    articleUrl: String
+) extends LiveActivityData
 
 object FootballLiveActivity {
-  implicit val format: OFormat[FootballLiveActivity] = Json.format[FootballLiveActivity]
+  implicit val format: OFormat[FootballLiveActivity] =
+    Json.format[FootballLiveActivity]
 }
 
 object LiveActivityData {
-  implicit val format: OFormat[LiveActivityData] = new OFormat[LiveActivityData] {
-    def writes(data: LiveActivityData): JsObject = data match {
-      case f: FootballLiveActivity =>
-        FootballLiveActivity.format.writes(f) + ("type" -> JsString("football"))
-    }
-    def reads(json: JsValue): JsResult[LiveActivityData] =
-      (json \ "type").validate[String].flatMap {
-        case "football" => FootballLiveActivity.format.reads(json)
-        case other      => JsError(s"Unknown LiveActivityData type: $other")
+  implicit val format: OFormat[LiveActivityData] =
+    new OFormat[LiveActivityData] {
+      def writes(data: LiveActivityData): JsObject = data match {
+        case f: FootballLiveActivity =>
+          FootballLiveActivity.format.writes(f) + ("type" -> JsString(
+            "football"
+          ))
       }
-  }
+      def reads(json: JsValue): JsResult[LiveActivityData] =
+        (json \ "type").validate[String].flatMap {
+          case "football" => FootballLiveActivity.format.reads(json)
+          case other      => JsError(s"Unknown LiveActivityData type: $other")
+        }
+    }
 }
 
 case class LiveActivityMapping(
-                                liveActivityId: String,
-                                channelId: String,
-                                data: Option[LiveActivityData]
-                              )
+    liveActivityId: String,
+    channelId: String,
+    data: Option[LiveActivityData]
+)
 object LiveActivityMapping {
-  implicit val format: OFormat[LiveActivityMapping] = Json.format[LiveActivityMapping]
+  implicit val format: OFormat[LiveActivityMapping] =
+    Json.format[LiveActivityMapping]
 }
-
-
 
 // REPOSITORY /////////////////////////////////////////////
 
@@ -68,12 +70,28 @@ class LiveActivityChannelRepository(client: AsyncDynamo, tableName: String)(
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
   private val IdField = "liveActivityId"
 
-  override def saveMapping(mapping: LiveActivityMapping): Future[RepositoryResult[Unit]] = {
-    val putItemRequest = new PutItemRequest(tableName, toAttributeMap(mapping).asJava)
-    client.putItem(putItemRequest) map { _ => Right(()) }
+  override def saveMapping(
+      mapping: LiveActivityMapping
+  ): Future[RepositoryResult[Unit]] = {
+    val putItemRequest =
+      new PutItemRequest()
+        .withTableName(tableName)
+        .withItem(toAttributeMap(mapping).asJava)
+        .withConditionExpression(s"attribute_not_exists($IdField)")
+
+    client
+      .putItem(putItemRequest)
+      .map(_ => Right(()): RepositoryResult[Unit])
+      .recover { case ex: Exception =>
+        println("Error saving live activity mapping: " + ex.getMessage)
+        val errorClass = ex.getClass.getName
+        Left(RepositoryError(errorClass.toString))
+      }
   }
 
-  override def getMappingByActivityId(id: String): Future[RepositoryResult[LiveActivityMapping]] = {
+  override def getMappingByActivityId(
+      id: String
+  ): Future[RepositoryResult[LiveActivityMapping]] = {
     val getItemRequest = new GetItemRequest()
       .withTableName(tableName)
       .withKey(Map(IdField -> new AttributeValue().withS(id)).asJava)
@@ -81,13 +99,21 @@ class LiveActivityChannelRepository(client: AsyncDynamo, tableName: String)(
 
     client.get(getItemRequest) map { result =>
       for {
-        item <- Either.fromOption(Option(result.getItem), RepositoryError("Live Activity not found"))
-        parsed <- Either.fromOption(fromAttributeMap[LiveActivityMapping](item.asScala.toMap).asOpt, RepositoryError("Unable to parse live activity mapping"))
+        item <- Either.fromOption(
+          Option(result.getItem),
+          RepositoryError("Live Activity not found")
+        )
+        parsed <- Either.fromOption(
+          fromAttributeMap[LiveActivityMapping](item.asScala.toMap).asOpt,
+          RepositoryError("Unable to parse live activity mapping")
+        )
       } yield parsed
     }
   }
 
-  override def deleteMappingByActivityId(id: String): Future[RepositoryResult[Unit]] = {
+  override def deleteMappingByActivityId(
+      id: String
+  ): Future[RepositoryResult[Unit]] = {
     val deleteItemRequest = new DeleteItemRequest()
       .withTableName(tableName)
       .withKey(Map(IdField -> new AttributeValue().withS(id)).asJava)

--- a/liveactivities/src/main/scala/com/gu/liveactivities/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/LiveActivityChannelRepository.scala
@@ -9,7 +9,6 @@ import play.api.libs.json._
 import tracking.Repository.RepositoryResult
 import tracking.RepositoryError
 
-import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 
@@ -42,8 +41,8 @@ object LiveActivityData {
 }
 
 case class LiveActivityMapping(
-                                liveActivityId: UUID,
-                                channelId: UUID,
+                                liveActivityId: String,
+                                channelId: String,
                                 data: Option[LiveActivityData]
                               )
 object LiveActivityMapping {
@@ -56,9 +55,9 @@ object LiveActivityMapping {
 
 trait ChannelMappingsRepository {
   def saveMapping(mapping: LiveActivityMapping): Future[RepositoryResult[Unit]]
-  def deleteMappingByActivityId(id: UUID): Future[RepositoryResult[Unit]]
+  def deleteMappingByActivityId(id: String): Future[RepositoryResult[Unit]]
   def getMappingByActivityId(
-      uuid: UUID
+      id: String
   ): Future[RepositoryResult[LiveActivityMapping]]
 }
 
@@ -74,10 +73,10 @@ class LiveActivityChannelRepository(client: AsyncDynamo, tableName: String)(
     client.putItem(putItemRequest) map { _ => Right(()) }
   }
 
-  override def getMappingByActivityId(uuid: UUID): Future[RepositoryResult[LiveActivityMapping]] = {
+  override def getMappingByActivityId(id: String): Future[RepositoryResult[LiveActivityMapping]] = {
     val getItemRequest = new GetItemRequest()
       .withTableName(tableName)
-      .withKey(Map(IdField -> new AttributeValue().withS(uuid.toString)).asJava)
+      .withKey(Map(IdField -> new AttributeValue().withS(id)).asJava)
       .withConsistentRead(true)
 
     client.get(getItemRequest) map { result =>
@@ -88,10 +87,10 @@ class LiveActivityChannelRepository(client: AsyncDynamo, tableName: String)(
     }
   }
 
-  override def deleteMappingByActivityId(uuid: UUID): Future[RepositoryResult[Unit]] = {
+  override def deleteMappingByActivityId(id: String): Future[RepositoryResult[Unit]] = {
     val deleteItemRequest = new DeleteItemRequest()
       .withTableName(tableName)
-      .withKey(Map(IdField -> new AttributeValue().withS(uuid.toString)).asJava)
+      .withKey(Map(IdField -> new AttributeValue().withS(id)).asJava)
     client.deleteItem(deleteItemRequest) map { _ => Right(()) }
   }
 

--- a/liveactivities/src/main/scala/com/gu/liveactivities/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/LiveActivityChannelRepository.scala
@@ -1,0 +1,98 @@
+package com.gu.liveactivities
+
+import aws.AsyncDynamo
+import aws.DynamoJsonConversions.{fromAttributeMap, toAttributeMap}
+import cats.syntax.all._
+import com.amazonaws.services.dynamodbv2.model._
+import org.slf4j.{Logger, LoggerFactory}
+import play.api.libs.json._
+import tracking.Repository.RepositoryResult
+import tracking.RepositoryError
+
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
+
+
+// MODELS /////////////////////////////////////////////
+
+sealed trait LiveActivityData
+case class FootballLiveActivity(
+                                 homeTeam: String,
+                                 awayTeam: String,
+                                 articleUrl: String
+                               ) extends LiveActivityData
+
+object FootballLiveActivity {
+  implicit val format: OFormat[FootballLiveActivity] = Json.format[FootballLiveActivity]
+}
+
+object LiveActivityData {
+  implicit val format: OFormat[LiveActivityData] = new OFormat[LiveActivityData] {
+    def writes(data: LiveActivityData): JsObject = data match {
+      case f: FootballLiveActivity =>
+        FootballLiveActivity.format.writes(f) + ("type" -> JsString("football"))
+    }
+    def reads(json: JsValue): JsResult[LiveActivityData] =
+      (json \ "type").validate[String].flatMap {
+        case "football" => FootballLiveActivity.format.reads(json)
+        case other      => JsError(s"Unknown LiveActivityData type: $other")
+      }
+  }
+}
+
+case class LiveActivityMapping(
+                                liveActivityId: UUID,
+                                channelId: UUID,
+                                data: Option[LiveActivityData]
+                              )
+object LiveActivityMapping {
+  implicit val format: OFormat[LiveActivityMapping] = Json.format[LiveActivityMapping]
+}
+
+
+
+// REPOSITORY /////////////////////////////////////////////
+
+trait ChannelMappingsRepository {
+  def saveMapping(mapping: LiveActivityMapping): Future[RepositoryResult[Unit]]
+  def deleteMappingByActivityId(id: UUID): Future[RepositoryResult[Unit]]
+  def getMappingByActivityId(
+      uuid: UUID
+  ): Future[RepositoryResult[LiveActivityMapping]]
+}
+
+class LiveActivityChannelRepository(client: AsyncDynamo, tableName: String)(
+    implicit ec: ExecutionContext
+) extends ChannelMappingsRepository {
+
+  private val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  private val IdField = "liveActivityId"
+
+  override def saveMapping(mapping: LiveActivityMapping): Future[RepositoryResult[Unit]] = {
+    val putItemRequest = new PutItemRequest(tableName, toAttributeMap(mapping).asJava)
+    client.putItem(putItemRequest) map { _ => Right(()) }
+  }
+
+  override def getMappingByActivityId(uuid: UUID): Future[RepositoryResult[LiveActivityMapping]] = {
+    val getItemRequest = new GetItemRequest()
+      .withTableName(tableName)
+      .withKey(Map(IdField -> new AttributeValue().withS(uuid.toString)).asJava)
+      .withConsistentRead(true)
+
+    client.get(getItemRequest) map { result =>
+      for {
+        item <- Either.fromOption(Option(result.getItem), RepositoryError("Live Activity not found"))
+        parsed <- Either.fromOption(fromAttributeMap[LiveActivityMapping](item.asScala.toMap).asOpt, RepositoryError("Unable to parse live activity mapping"))
+      } yield parsed
+    }
+  }
+
+  override def deleteMappingByActivityId(uuid: UUID): Future[RepositoryResult[Unit]] = {
+    val deleteItemRequest = new DeleteItemRequest()
+      .withTableName(tableName)
+      .withKey(Map(IdField -> new AttributeValue().withS(uuid.toString)).asJava)
+    client.deleteItem(deleteItemRequest) map { _ => Right(()) }
+  }
+
+}

--- a/liveactivities/src/test/scala/com/gu/liveactivities/DynamodbSpecification.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/DynamodbSpecification.scala
@@ -1,0 +1,59 @@
+package com.gu.liveactivities
+
+import aws.AsyncDynamo
+import com.amazonaws.auth.{
+  AWSCredentials,
+  AWSCredentialsProvider,
+  AWSCredentialsProviderChain
+}
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder
+import com.amazonaws.services.dynamodbv2.model.{
+  CreateTableRequest,
+  DeleteTableRequest
+}
+import org.specs2.mutable.Specification
+import org.specs2.specification.{BeforeAfterAll, Scope}
+
+trait DynamodbSpecification extends Specification with BeforeAfterAll {
+
+  sequential
+
+  val TableName: String
+
+  def createTableRequest: CreateTableRequest
+
+  val TestEndpoint = "http://localhost:8002"
+
+  override def beforeAll(): Unit = {
+    awsClient.createTable(createTableRequest)
+  }
+
+  override def afterAll(): Unit = {
+    awsClient.deleteTable(new DeleteTableRequest(TableName))
+  }
+
+  private def awsClient = {
+    val chain = new AWSCredentialsProviderChain(new AWSCredentialsProvider {
+      override def refresh(): Unit = {}
+
+      override def getCredentials: AWSCredentials = new AWSCredentials {
+        override def getAWSAccessKeyId: String = ""
+
+        override def getAWSSecretKey: String = ""
+      }
+    })
+
+    val client = AmazonDynamoDBAsyncClientBuilder.standard()
+      .withCredentials(chain)
+      .withEndpointConfiguration( new EndpointConfiguration(TestEndpoint, Regions.EU_WEST_1.getName) )
+      .build
+
+    client
+  }
+
+  trait AsyncDynamoScope extends Scope {
+    val asyncClient = new AsyncDynamo(awsClient)
+  }
+}

--- a/liveactivities/src/test/scala/com/gu/liveactivities/DynamodbSpecification.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/DynamodbSpecification.scala
@@ -24,7 +24,7 @@ trait DynamodbSpecification extends Specification with BeforeAfterAll {
 
   def createTableRequest: CreateTableRequest
 
-  val TestEndpoint = "http://localhost:8002"
+  val TestEndpoint = "http://localhost:8000"
 
   override def beforeAll(): Unit = {
     awsClient.createTable(createTableRequest)
@@ -39,9 +39,8 @@ trait DynamodbSpecification extends Specification with BeforeAfterAll {
       override def refresh(): Unit = {}
 
       override def getCredentials: AWSCredentials = new AWSCredentials {
-        override def getAWSAccessKeyId: String = ""
-
-        override def getAWSSecretKey: String = ""
+        override def getAWSAccessKeyId: String = "testid"
+        override def getAWSSecretKey: String = "testkey"
       }
     })
 

--- a/liveactivities/src/test/scala/com/gu/liveactivities/DynamodbSpecification.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/DynamodbSpecification.scala
@@ -24,7 +24,7 @@ trait DynamodbSpecification extends Specification with BeforeAfterAll {
 
   def createTableRequest: CreateTableRequest
 
-  val TestEndpoint = "http://localhost:8000"
+  val TestEndpoint = "http://localhost:8002"
 
   override def beforeAll(): Unit = {
     awsClient.createTable(createTableRequest)

--- a/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivityChannelRepositorySpec.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivityChannelRepositorySpec.scala
@@ -1,16 +1,16 @@
 package com.gu.liveactivities
 
-
 import com.amazonaws.services.dynamodbv2.model._
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import tracking.Repository.RepositoryResult
-
+import tracking.RepositoryError
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 
-
-class LiveActivityChannelRepositoryTest (implicit ev: ExecutionEnv) extends DynamodbSpecification with Mockito {
+class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
+    extends DynamodbSpecification
+    with Mockito {
 
   override val TableName = "test-table"
 
@@ -20,23 +20,38 @@ class LiveActivityChannelRepositoryTest (implicit ev: ExecutionEnv) extends Dyna
       1 must beEqualTo(1)
     }
 
-    "save a new channel mapping for an id if it does not exist" in new RepositoryScope with ExampleData {
+    "save a new channel mapping for an id if it does not exist" in new RepositoryScope
+      with ExampleData {
       repository.saveMapping(footballMapping).flatMap { _ =>
         repository.getMappingByActivityId(footballMapping.liveActivityId)
-      } must beEqualTo(Right(Some(footballMapping))).await
+      } must beEqualTo(Right(footballMapping)).await
     }
 
-    "Error if trying to save a new channel mapping for an id that already exists" in new RepositoryScope with ExampleData {
+    "Error if trying to save a new channel mapping for an id that already exists" in new RepositoryScope
+      with ExampleData {
+      repository.saveMapping(footballMapping).flatMap { _ =>
+        repository.saveMapping(footballMapping)
+      } must beLike[RepositoryResult[Unit]] {
+        case Left(RepositoryError(msg))
+            if msg.contains("ConditionalCheckFailed") =>
+          ok
+      }.await
+    }
+
+    "delete a channel mapping for an activity id if it exists" in new RepositoryScope
+      with ExampleData {
+
+      repository.saveMapping(footballMapping).flatMap { _ =>
+        repository.deleteMappingByActivityId(footballMapping.liveActivityId)
+      } must beEqualTo(Right(())).await
+    }
+
+    "get a channel mapping for an activity id if it exists" in new RepositoryScope
+      with ExampleData {
       repository.saveMapping(footballMapping).flatMap { _ =>
         repository.getMappingByActivityId(footballMapping.liveActivityId)
-      } must beEqualTo(Right(Some(footballMapping))).await
+      } must beEqualTo(Right(footballMapping)).await
     }
-
-//    "delete a channel mapping for an activity id if it exists" in new RepositoryScope with ExampleData {
-//    }
-//
-//    "get a channel mapping for an activity id if it exists" in new RepositoryScope with ExampleData {
-//    }
   }
 
   trait RepositoryScope extends AsyncDynamoScope {
@@ -60,10 +75,15 @@ class LiveActivityChannelRepositoryTest (implicit ev: ExecutionEnv) extends Dyna
   override def createTableRequest: CreateTableRequest = {
     val IdField = "liveActivityId"
 
-    new CreateTableRequest(TableName, List(new KeySchemaElement(IdField, KeyType.HASH)).asJava)
-      .withAttributeDefinitions(List(
-        new AttributeDefinition(IdField, ScalarAttributeType.S)
-      ).asJava)
+    new CreateTableRequest(
+      TableName,
+      List(new KeySchemaElement(IdField, KeyType.HASH)).asJava
+    )
+      .withAttributeDefinitions(
+        List(
+          new AttributeDefinition(IdField, ScalarAttributeType.S)
+        ).asJava
+      )
       .withProvisionedThroughput(new ProvisionedThroughput(5L, 5L))
   }
 

--- a/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivityChannelRepositorySpec.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivityChannelRepositorySpec.scala
@@ -1,0 +1,70 @@
+package com.gu.liveactivities
+
+
+import com.amazonaws.services.dynamodbv2.model._
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import tracking.Repository.RepositoryResult
+
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+
+
+class LiveActivityChannelRepositoryTest (implicit ev: ExecutionEnv) extends DynamodbSpecification with Mockito {
+
+  override val TableName = "test-table"
+
+  "LiveActivityChannelRepository" should {
+    "connect to local DynamoDB and create table" in new RepositoryScope {
+      // This test will pass if the table is created successfully in beforeAll()
+      1 must beEqualTo(1)
+    }
+
+    "save a new channel mapping for an id if it does not exist" in new RepositoryScope with ExampleData {
+      repository.saveMapping(footballMapping).flatMap { _ =>
+        repository.getMappingByActivityId(footballMapping.liveActivityId)
+      } must beEqualTo(Right(Some(footballMapping))).await
+    }
+
+    "Error if trying to save a new channel mapping for an id that already exists" in new RepositoryScope with ExampleData {
+      repository.saveMapping(footballMapping).flatMap { _ =>
+        repository.getMappingByActivityId(footballMapping.liveActivityId)
+      } must beEqualTo(Right(Some(footballMapping))).await
+    }
+
+//    "delete a channel mapping for an activity id if it exists" in new RepositoryScope with ExampleData {
+//    }
+//
+//    "get a channel mapping for an activity id if it exists" in new RepositoryScope with ExampleData {
+//    }
+  }
+
+  trait RepositoryScope extends AsyncDynamoScope {
+    val repository = new LiveActivityChannelRepository(asyncClient, TableName)
+  }
+
+  trait ExampleData {
+    val footballData = FootballLiveActivity(
+      homeTeam = "HomeTeamName",
+      awayTeam = "AwayTeamName",
+      articleUrl = "https://www.theguardian.com/football/test-article-id"
+    )
+
+    val footballMapping = LiveActivityMapping(
+      liveActivityId = "football-1234567",
+      channelId = "test-channel-id",
+      data = Some(footballData)
+    )
+  }
+
+  override def createTableRequest: CreateTableRequest = {
+    val IdField = "liveActivityId"
+
+    new CreateTableRequest(TableName, List(new KeySchemaElement(IdField, KeyType.HASH)).asJava)
+      .withAttributeDefinitions(List(
+        new AttributeDefinition(IdField, ScalarAttributeType.S)
+      ).asJava)
+      .withProvisionedThroughput(new ProvisionedThroughput(5L, 5L))
+  }
+
+}

--- a/project/LocalDynamoDBLiveActivities.scala
+++ b/project/LocalDynamoDBLiveActivities.scala
@@ -7,8 +7,7 @@ object LocalDynamoDBLiveActivities {
   val settings: Seq[Setting[_]] = DynamoDBLocalKeys.baseDynamoDBSettings ++ Seq(
     dynamoDBLocalDownloadDir := file("dynamodb-local-live-activities"),
     dynamoDBLocalInMemory := true,
-    dynamoDBLocalVersion := "latest",
-//    dynamoDBLocalSharedDB := true, // Add this line
+    dynamoDBLocalVersion := "2018-04-11",
     dynamoDBLocalPort := 8002
   )
 }

--- a/project/LocalDynamoDBLiveActivities.scala
+++ b/project/LocalDynamoDBLiveActivities.scala
@@ -1,0 +1,14 @@
+import com.localytics.sbt.dynamodb.DynamoDBLocalKeys
+import com.localytics.sbt.dynamodb.DynamoDBLocalKeys._
+import sbt._
+
+object LocalDynamoDBLiveActivities {
+
+  val settings: Seq[Setting[_]] = DynamoDBLocalKeys.baseDynamoDBSettings ++ Seq(
+    dynamoDBLocalDownloadDir := file("dynamodb-local-live-activities"),
+    dynamoDBLocalInMemory := true,
+    dynamoDBLocalVersion := "latest",
+//    dynamoDBLocalSharedDB := true, // Add this line
+    dynamoDBLocalPort := 8002
+  )
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a Repository to read, write and delete live activity channel mappings, using the existing AsyncDynamoClient in Common. 

- This can probably move to Common especially if used by another server for the autostart feature. 
- We should make a call if we want one table per live activity type or one table for all ios live activities (football, cricket, liveblog, elections...) IF the latter we might want to prefix uuids from the diffierent live activity sources eg. "football-[matchId]"




## How has this change been tested?
Not tested yet, to be incorporated into channel creation step. 


## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
