### PR TITLE
Build a CODE stack for live activities with a dynamo table

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -3,6 +3,7 @@ import { App, Duration } from 'aws-cdk-lib';
 import 'source-map-support/register';
 import { FakeBreakingNewsLambda } from '../lib/fakebreakingnewslambda';
 import { FootballNotificationsLambda } from '../lib/footballnotificationslambda';
+import { LiveActivities } from '../lib/liveactivities';
 import type { NotificationProps } from '../lib/notification';
 import { Notification } from '../lib/notification';
 import type { RegistrationProps } from '../lib/registration';
@@ -186,3 +187,10 @@ new FootballNotificationsLambda(
 	'FootballNotificationsLambda-PROD',
 	footballNotificationsProdProps,
 );
+
+export const liveActivitiesCodeProps: GuStackProps = {
+	stack: 'mobile-notifications',
+	stage: 'CODE',
+};
+
+new LiveActivities(app, 'LiveActivities-CODE', liveActivitiesCodeProps);

--- a/cdk/lib/__snapshots__/liveactivities.test.ts.snap
+++ b/cdk/lib/__snapshots__/liveactivities.test.ts.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [],
+    "gu:cdk:version": "TEST",
+  },
+  "Resources": {
+    "liveactivitiesdynamotable87F336D2": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "id",
+            "AttributeType": "S",
+          },
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "id",
+            "KeyType": "HASH",
+          },
+        ],
+        "TableName": "mobile-notifications-liveactivities-CODE",
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::DynamoDB::Table",
+      "UpdateReplacePolicy": "Retain",
+    },
+  },
+}
+`;

--- a/cdk/lib/liveactivities.test.ts
+++ b/cdk/lib/liveactivities.test.ts
@@ -1,0 +1,17 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { liveActivitiesCodeProps } from '../bin/cdk';
+import { LiveActivities } from './liveactivities';
+
+describe('The LiveActivities stack', () => {
+	it('matches the snapshot for CODE', () => {
+		const app = new App();
+		const stack = new LiveActivities(
+			app,
+			'LiveActivities-CODE',
+			liveActivitiesCodeProps,
+		);
+		const template = Template.fromStack(stack);
+		expect(template.toJSON()).toMatchSnapshot();
+	});
+});

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -1,0 +1,23 @@
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import type { App } from 'aws-cdk-lib';
+import { Tags } from 'aws-cdk-lib';
+import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
+
+export class LiveActivities extends GuStack {
+	constructor(scope: App, id: string, props: GuStackProps) {
+		super(scope, id, props);
+
+		const { stack, stage } = this;
+		const app = 'liveactivities';
+
+		const dynamoTableName = `${stack}-liveactivities-${stage}`;
+
+		const dynamoTable = new Table(this, `${app}-dynamo-table`, {
+			tableName: dynamoTableName,
+			partitionKey: { name: 'id', type: AttributeType.STRING },
+			billingMode: BillingMode.PAY_PER_REQUEST,
+		});
+		Tags.of(dynamoTable).add('devx-backup-enabled', 'true');
+	}
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add a cloudformation stack for live activities CODE with a dynamo table.
