### PR TITLE
Add Github action and riffraff configuration for live activities

### DIFF
--- a/.github/workflows/liveactivities.yml
+++ b/.github/workflows/liveactivities.yml
@@ -1,0 +1,80 @@
+name: Live activities
+
+on:
+  push:
+    paths:
+      - cdk/**
+      - liveactivities/**
+      - api-models/**
+      - project/**
+      - build.sbt
+      - .github/workflows/liveactivities.yml
+  workflow_dispatch:
+
+# allow queued workflows to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Setup JDK and sbt
+        uses: guardian/setup-scala@v1
+
+      - name: Compile, test and assembly
+        run: sbt "project api-models" "compile" "test" "project liveactivities" "compile" "test" "assembly"
+
+      - name: Test Report
+        uses: dorny/test-reporter@v2
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: Tests
+          path: liveactivities/target/test-reports/TEST-*.xml
+          reporter: java-junit
+          only-summary: 'false'
+          fail-on-error: 'true'
+
+      - name: Copy jar to root
+        run: cp liveactivities/target/scala-*/liveactivities.jar .
+
+      - run: corepack enable
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 #v6.2.0
+        with:
+          cache: yarn
+          cache-dependency-path: cdk/yarn.lock
+          node-version-file: .nvmrc
+
+      - name: CDK synth
+        run: |
+          cd cdk
+          yarn install --immutable
+          yarn lint
+          yarn test
+          yarn synth
+
+      - name: Upload to riff-raff
+        uses: guardian/actions-riff-raff@v4
+        with:
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          projectName: mobile-n10n:liveactivities
+          buildNumberOffset: 4147
+          configPath: liveactivities/riff-raff.yaml
+
+          contentDirectories: |
+            liveactivities:
+              - liveactivities.jar
+            mobile-notifications-liveactivities-cfn:
+              - cdk/cdk.out/LiveActivities-CODE.template.json
+              - cdk/cdk.out/LiveActivities-PROD.template.json

--- a/.github/workflows/liveactivities.yml
+++ b/.github/workflows/liveactivities.yml
@@ -77,4 +77,3 @@ jobs:
               - liveactivities.jar
             mobile-notifications-liveactivities-cfn:
               - cdk/cdk.out/LiveActivities-CODE.template.json
-              - cdk/cdk.out/LiveActivities-PROD.template.json

--- a/liveactivities/riff-raff.yaml
+++ b/liveactivities/riff-raff.yaml
@@ -1,0 +1,10 @@
+stacks: [mobile-notifications]
+regions: [eu-west-1]
+
+deployments:
+  mobile-notifications-liveactivities-cfn:
+    type: cloud-formation
+    app: liveactivities
+    parameters:
+      templateStagePaths:
+        CODE: LiveActivities-CODE.template.json

--- a/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivitiesSpec.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivitiesSpec.scala
@@ -1,0 +1,17 @@
+package com.gu.liveactivities
+
+import java.net.URI
+import java.time.ZonedDateTime
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import pa.{Competition, MatchDay, MatchDayTeam, Round, Stage, Venue}
+
+class LiveActivitiesSpec extends Specification {
+
+  "A LiveActivities" should {
+
+    "create a channel" in {
+      1 must beEqualTo(1)
+    }
+  }
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request adds the github action and the riffraff configuration to `liveactivities` to support CI/CD.  At the moment we expect a cloudformation stack for CODE environment only.

It also adds an empty test case as a placeholder so that the github action can check the test result before building the Java archive.
<img width="1179" height="538" alt="Screenshot 2026-03-17 at 10 35 04" src="https://github.com/user-attachments/assets/5e1c21f5-6bc5-46e3-a8b5-3c727e44d958" />

