### PR TITLE
Update channel mapping dyanamo table key name

### DIFF
--- a/liveactivities/src/main/scala/com/gu/liveactivities/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/LiveActivityChannelRepository.scala
@@ -44,7 +44,7 @@ object LiveActivityData {
 }
 
 case class LiveActivityMapping(
-    liveActivityId: String,
+    id: String,
     channelId: String,
     data: Option[LiveActivityData]
 )
@@ -68,7 +68,7 @@ class LiveActivityChannelRepository(client: AsyncDynamo, tableName: String)(
 ) extends ChannelMappingsRepository {
 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
-  private val IdField = "liveActivityId"
+  private val IdField = "id"
 
   override def saveMapping(
       mapping: LiveActivityMapping

--- a/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivityChannelRepositorySpec.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivityChannelRepositorySpec.scala
@@ -5,7 +5,6 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import tracking.Repository.RepositoryResult
 import tracking.RepositoryError
-import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 
 class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
@@ -23,7 +22,7 @@ class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
     "save a new channel mapping for an id if it does not exist" in new RepositoryScope
       with ExampleData {
       repository.saveMapping(footballMapping).flatMap { _ =>
-        repository.getMappingByActivityId(footballMapping.liveActivityId)
+        repository.getMappingByActivityId(footballMapping.id)
       } must beEqualTo(Right(footballMapping)).await
     }
 
@@ -42,14 +41,14 @@ class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
       with ExampleData {
 
       repository.saveMapping(footballMapping).flatMap { _ =>
-        repository.deleteMappingByActivityId(footballMapping.liveActivityId)
+        repository.deleteMappingByActivityId(footballMapping.id)
       } must beEqualTo(Right(())).await
     }
 
     "get a channel mapping for an activity id if it exists" in new RepositoryScope
       with ExampleData {
       repository.saveMapping(footballMapping).flatMap { _ =>
-        repository.getMappingByActivityId(footballMapping.liveActivityId)
+        repository.getMappingByActivityId(footballMapping.id)
       } must beEqualTo(Right(footballMapping)).await
     }
   }
@@ -66,14 +65,14 @@ class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
     )
 
     val footballMapping = LiveActivityMapping(
-      liveActivityId = "football-1234567",
+      id = "football-1234567",
       channelId = "test-channel-id",
       data = Some(footballData)
     )
   }
 
   override def createTableRequest: CreateTableRequest = {
-    val IdField = "liveActivityId"
+    val IdField = "id"
 
     new CreateTableRequest(
       TableName,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
