### PR TITLE
Run lambda functions on CODE

### DIFF
--- a/cdk/lib/__snapshots__/liveactivities.test.ts.snap
+++ b/cdk/lib/__snapshots__/liveactivities.test.ts.snap
@@ -236,6 +236,26 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
                 ],
               },
             },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/notifications/CODE/liveactivities/ios",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -463,6 +483,26 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
                 "Fn::GetAtt": [
                   "liveactivitiesdynamotable87F336D2",
                   "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/notifications/CODE/liveactivities/ios",
+                  ],
                 ],
               },
             },

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -51,6 +51,15 @@ export class LiveActivities extends GuStack {
 				resources: [dynamoTable.tableArn],
 			}),
 		);
+		channelLambda.addToRolePolicy(
+			new PolicyStatement({
+				actions: ['ssm:GetParametersByPath'],
+				effect: Effect.ALLOW,
+				resources: [
+					`arn:aws:ssm:${this.region}:${this.account}:parameter/notifications/${this.stage}/liveactivities/ios`,
+				],
+			}),
+		);
 
 		const broadcastLambda = new GuLambdaFunction(
 			this,
@@ -78,6 +87,15 @@ export class LiveActivities extends GuStack {
 				actions: ['dynamodb:PutItem', 'dynamodb:UpdateItem', 'dynamodb:Query'],
 				effect: Effect.ALLOW,
 				resources: [dynamoTable.tableArn],
+			}),
+		);
+		broadcastLambda.addToRolePolicy(
+			new PolicyStatement({
+				actions: ['ssm:GetParametersByPath'],
+				effect: Effect.ALLOW,
+				resources: [
+					`arn:aws:ssm:${this.region}:${this.account}:parameter/notifications/${this.stage}/liveactivities/ios`,
+				],
 			}),
 		);
 	}

--- a/liveactivities/src/main/resources/logback.xml
+++ b/liveactivities/src/main/resources/logback.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -7,17 +7,41 @@ import scala.util.Success
 import scala.util.Failure
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.amazonaws.services.lambda.runtime.Context
+import play.api.libs.json.Format
+import play.api.libs.json.Json
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler
+import java.io.{InputStream, OutputStream}
+import play.api.libs.json.JsSuccess
+import play.api.libs.json.JsError
+import java.nio.charset.StandardCharsets
 
 // TODO - we should get the channel ID by looking up the match ID in the datastore
 case class BroadcastRequest(matchId: String, channelId: String, payload: String)
 
-object BroadcastLambda extends RequestHandler[BroadcastRequest, Unit]{
+object BroadcastRequest {
+	implicit val jf: Format[BroadcastRequest] = Json.format[BroadcastRequest]
+}
+
+object BroadcastLambda extends RequestStreamHandler{
 
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
 
   val broadcastApiClient = new BroadcastApiClient()
 
-  def handleRequest(request: BroadcastRequest, context: Context): Unit = {
+  def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
+    Json.parse(input).validate[BroadcastRequest] match {
+      case JsSuccess(request, _) => {
+        processRequest(request, context)
+        output.write(Json.toJson("Broadcast sent").toString().getBytes(StandardCharsets.UTF_8))
+      }
+      case JsError(errors) => {
+        println(s"Failed to parse request: $errors")
+        output.write(Json.toJson("Invalid request").toString().getBytes(StandardCharsets.UTF_8))
+      }
+    }
+  }
+
+  def processRequest(request: BroadcastRequest, context: Context): Unit = {
     // TODO - determine expiry time and priority
     val broadcastFuture = broadcastApiClient.sendToChannel(request.channelId, None, None)
     // TODO - the timeout value

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -1,6 +1,7 @@
 package com.gu.liveactivities
 
 import com.gu.liveactivities.service.BroadcastApiClient
+import com.gu.liveactivities.util.{Configuration, IosConfiguration}
 import scala.concurrent.Await
 import scala.util.Try
 import scala.util.Success
@@ -14,6 +15,7 @@ import java.io.{InputStream, OutputStream}
 import play.api.libs.json.JsSuccess
 import play.api.libs.json.JsError
 import java.nio.charset.StandardCharsets
+import com.gu.liveactivities.service.Authentication
 
 // TODO - we should get the channel ID by looking up the match ID in the datastore
 case class BroadcastRequest(matchId: String, channelId: String, payload: String)
@@ -26,7 +28,11 @@ object BroadcastLambda extends RequestStreamHandler{
 
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
 
-  val broadcastApiClient = new BroadcastApiClient()
+  val config: IosConfiguration = Configuration.fetchIos()
+
+  val authentication = new Authentication(config.teamId, config.keyId, config.certificate)
+
+  val broadcastApiClient = new BroadcastApiClient(authentication, config.bundleId, config.sendingToProdServer)
 
   def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
     Json.parse(input).validate[BroadcastRequest] match {

--- a/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
@@ -1,6 +1,7 @@
 package com.gu.liveactivities
 
 import com.gu.liveactivities.service.{ChannelApiClient, BroadcastApiClient, Authentication}
+import com.gu.liveactivities.util.{Configuration, IosConfiguration}
 import scala.concurrent.Await
 import scala.util.Success
 import scala.util.Failure
@@ -25,8 +26,11 @@ object ChannelManagerLambda extends RequestStreamHandler {
 
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
 
-  val channelApiClient = new ChannelApiClient()
-  val broadcastApiClient = new BroadcastApiClient()
+  val config: IosConfiguration = Configuration.fetchIos()
+
+  val authentication = new Authentication(config.teamId, config.keyId, config.certificate)
+
+  val channelApiClient = new ChannelApiClient(authentication, config.bundleId, config.sendingToProdServer)
 
   def onChannelCreated(matchId: String, channelId: String): String = {
     // TODO - update dynamo table

--- a/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
@@ -5,13 +5,23 @@ import scala.concurrent.Await
 import scala.util.Success
 import scala.util.Failure
 import scala.util.Try
-import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler
+import java.io.{InputStream, OutputStream}
+import play.api.libs.json.Json
+import play.api.libs.json.Format
+import play.api.libs.json.JsSuccess
+import play.api.libs.json.JsError
+import java.nio.charset.StandardCharsets
 
 // TODO - we should get the channel ID by looking up the match ID in the datastore
 case class ChannelRequest(matchId: String, channelId: String, toCreate: Boolean)
 
-object ChannelManagerLambda extends RequestHandler[ChannelRequest, String] {
+object ChannelRequest {
+  implicit val jf: Format[ChannelRequest] = Json.format[ChannelRequest]
+}
+
+object ChannelManagerLambda extends RequestStreamHandler {
 
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
 
@@ -30,7 +40,20 @@ object ChannelManagerLambda extends RequestHandler[ChannelRequest, String] {
     return channelId
   }
 
-  def handleRequest(request: ChannelRequest, context: Context): String = {
+  def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
+    Json.parse(input).validate[ChannelRequest] match {
+      case JsSuccess(request, _) => {
+        val response = processRequest(request, context)
+        output.write(Json.toJson(response).toString().getBytes(StandardCharsets.UTF_8))
+      }
+      case JsError(errors) => {
+        println(s"Failed to parse request: $errors")
+        output.write(Json.toJson("Invalid request").toString().getBytes(StandardCharsets.UTF_8))
+      }
+    }
+  }
+
+  def processRequest(request: ChannelRequest, context: Context): String = {
     if (request.toCreate) {
       println(s"Received request to create channel for match ID ${request.matchId}")
       val channelFuture = channelApiClient.createChannel()

--- a/liveactivities/src/main/scala/com/gu/liveactivities/LambdaLocalRun.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/LambdaLocalRun.scala
@@ -1,12 +1,28 @@
 package com.gu.liveactivities
 
+import play.api.libs.json.Json
+import java.nio.charset.StandardCharsets
+
 object LambdaLocalRun extends App {
 
   println("Start running ChannelManagerLambda locally")
-  val createRequest = ChannelRequest("match123", "channel123", toCreate = true)
-  val channelId = ChannelManagerLambda.handleRequest(createRequest, null)
+  val createChannelJson = Json.toJson(ChannelRequest("match123", "channel123", toCreate = true)).toString()
+
+  val createRequestStream = new java.io.ByteArrayInputStream(createChannelJson.getBytes(StandardCharsets.UTF_8))
+
+  val createResponseStream = new java.io.ByteArrayOutputStream()
+
+  ChannelManagerLambda.handleRequest(createRequestStream, createResponseStream, null)
+
+  val channelId = Json.parse(createResponseStream.toString()).as[String]
 
   val closeRequest = ChannelRequest("match123", channelId, toCreate = false)
-  ChannelManagerLambda.handleRequest(closeRequest, null)  
-  println("Finished running ChannelManagerLambda locally")
+
+  val closeRequestStream = new java.io.ByteArrayInputStream(Json.toJson(closeRequest).toString().getBytes(StandardCharsets.UTF_8))
+
+  val closeResponseStream = new java.io.ByteArrayOutputStream()
+
+  ChannelManagerLambda.handleRequest(closeRequestStream, closeResponseStream, null)
+
+  println("Finished running ChannelManagerLambda locally with response: " + closeResponseStream.toString())
 }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/Authentication.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/Authentication.scala
@@ -5,17 +5,31 @@ import java.util.concurrent.atomic._
 import com.turo.pushy.apns.auth.ApnsSigningKey
 import com.turo.pushy.apns.auth.AuthenticationToken
 import org.checkerframework.checker.units.qual.A
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
 
-object Authentication {
+class Authentication(teamId: String, keyId: String, maybeCertificate: Option[String]) {
 
   private val authenticationToken : AtomicReference[Option[AuthenticationToken]] = new AtomicReference[Option[AuthenticationToken]](None)
 
+  private def getSigningKey(): ApnsSigningKey = {
+    maybeCertificate match {
+      case Some(cert) => getSigningKeyFromString(cert)
+      case None => getSigningKeyFromKeyFile()
+    }
+  }
+
+  private def getSigningKeyFromKeyFile(): ApnsSigningKey = ApnsSigningKey.loadFromPkcs8File(
+    new java.io.File("liveactivities/src/main/resources/AuthKey_N9MYT8RFH4.p8"), teamId, keyId)
+
+  private def getSigningKeyFromString(certificate: String): ApnsSigningKey = ApnsSigningKey.loadFromInputStream(
+			new ByteArrayInputStream(certificate.getBytes(StandardCharsets.UTF_8)),
+			teamId,
+			keyId
+		)
+
   private def refreshToken(): String = {
-    val signingKey = ApnsSigningKey.loadFromPkcs8File(
-      new java.io.File("liveactivities/src/main/resources/AuthKey_N9MYT8RFH4.p8"),
-      "998P9U5NGJ",
-      "N9MYT8RFH4"
-    )
+    val signingKey = getSigningKey()
     val newToken = new AuthenticationToken(signingKey, new Date())
     this.authenticationToken.set(Some(newToken))
     newToken.getAuthorizationHeader().toString()

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/Authentication.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/Authentication.scala
@@ -7,8 +7,9 @@ import com.turo.pushy.apns.auth.AuthenticationToken
 import org.checkerframework.checker.units.qual.A
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
+import com.gu.liveactivities.util.Logging
 
-class Authentication(teamId: String, keyId: String, maybeCertificate: Option[String]) {
+class Authentication(teamId: String, keyId: String, maybeCertificate: Option[String]) extends Logging {
 
   private val authenticationToken : AtomicReference[Option[AuthenticationToken]] = new AtomicReference[Option[AuthenticationToken]](None)
 
@@ -20,7 +21,7 @@ class Authentication(teamId: String, keyId: String, maybeCertificate: Option[Str
   }
 
   private def getSigningKeyFromKeyFile(): ApnsSigningKey = ApnsSigningKey.loadFromPkcs8File(
-    new java.io.File("liveactivities/src/main/resources/AuthKey_N9MYT8RFH4.p8"), teamId, keyId)
+    new java.io.File("resources/AuthKey_N9MYT8RFH4.p8"), teamId, keyId)
 
   private def getSigningKeyFromString(certificate: String): ApnsSigningKey = ApnsSigningKey.loadFromInputStream(
 			new ByteArrayInputStream(certificate.getBytes(StandardCharsets.UTF_8)),

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/Authentication.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/Authentication.scala
@@ -8,8 +8,7 @@ import org.checkerframework.checker.units.qual.A
 
 object Authentication {
 
-  private val authenticationToken2 : AtomicReference[Option[AuthenticationToken]] = new AtomicReference[Option[AuthenticationToken]](None)
-  private var authenticationToken: Option[AuthenticationToken] = None
+  private val authenticationToken : AtomicReference[Option[AuthenticationToken]] = new AtomicReference[Option[AuthenticationToken]](None)
 
   private def refreshToken(): String = {
     val signingKey = ApnsSigningKey.loadFromPkcs8File(
@@ -18,12 +17,12 @@ object Authentication {
       "N9MYT8RFH4"
     )
     val newToken = new AuthenticationToken(signingKey, new Date())
-    this.authenticationToken = Some(newToken)
+    this.authenticationToken.set(Some(newToken))
     newToken.getAuthorizationHeader().toString()
   }
 
   def getAccessToken(): String = {
-    authenticationToken match {
+    authenticationToken.get() match {
       case Some(token) if Date.from(token.getIssuedAt().toInstant().plusSeconds(30 * 60)).after(new Date()) => 
         token.getAuthorizationHeader().toString()
       case _ => refreshToken()

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/Authentication.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/Authentication.scala
@@ -9,21 +9,11 @@ import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import com.gu.liveactivities.util.Logging
 
-class Authentication(teamId: String, keyId: String, maybeCertificate: Option[String]) extends Logging {
+class Authentication(teamId: String, keyId: String, certificate: String) extends Logging {
 
   private val authenticationToken : AtomicReference[Option[AuthenticationToken]] = new AtomicReference[Option[AuthenticationToken]](None)
 
-  private def getSigningKey(): ApnsSigningKey = {
-    maybeCertificate match {
-      case Some(cert) => getSigningKeyFromString(cert)
-      case None => getSigningKeyFromKeyFile()
-    }
-  }
-
-  private def getSigningKeyFromKeyFile(): ApnsSigningKey = ApnsSigningKey.loadFromPkcs8File(
-    new java.io.File("resources/AuthKey_N9MYT8RFH4.p8"), teamId, keyId)
-
-  private def getSigningKeyFromString(certificate: String): ApnsSigningKey = ApnsSigningKey.loadFromInputStream(
+  private def getSigningKey(): ApnsSigningKey = ApnsSigningKey.loadFromInputStream(
 			new ByteArrayInputStream(certificate.getBytes(StandardCharsets.UTF_8)),
 			teamId,
 			keyId

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/BroadcastApiClient.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/BroadcastApiClient.scala
@@ -13,16 +13,17 @@ import com.turo.pushy.apns.auth.AuthenticationToken
 import play.api.libs.json.Json
 import com.gu.liveactivities.BroadcastFixtures._
 import com.gu.liveactivities.models.BroadcastJsonFormats._
+import com.gu.liveactivities.util.Logging
 
 import java.time.Instant
 import java.util.Date
 import com.gu.liveactivities.models.BroadcastJsonFormats
 
-class BroadcastApiClient(authentication: Authentication, bundleId: String, sendingToProdServer: Boolean) {
+class BroadcastApiClient(authentication: Authentication, bundleId: String, sendingToProdServer: Boolean) extends Logging {
   
   private val httpClient: HttpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build()
 
-  println("HttpClient in BroadcastApiClient is instantiated")
+  logger.info("HttpClient in BroadcastApiClient is instantiated")
 
   private val charSet = StandardCharsets.UTF_8
 
@@ -62,10 +63,8 @@ class BroadcastApiClient(authentication: Authentication, bundleId: String, sendi
   private val endPayload: String = Json.stringify(Json.toJson(broadcastEndBodyFixture)(BroadcastJsonFormats.broadcastEndBodyFormat))
 
   def sendToChannel(channelId: String, expiration: Option[Instant], priority: Option[Int]): Future[String] = {
-    println(s"Broadcasting to channel $channelId")
+    logger.info(s"Broadcasting to channel $channelId")
     val authToken = authentication.getAccessToken()
-    println(s"Generated auth token: $authToken")
-
     val request: HttpRequest = HttpRequest.newBuilder(new URI(serviceEndpoint))
       .version(HttpClient.Version.HTTP_2)
       .header("Authorization", authToken)
@@ -81,15 +80,17 @@ class BroadcastApiClient(authentication: Authentication, bundleId: String, sendi
 
     val p = Promise[String]()
     httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).whenComplete((response, err) => {
-      println(s"Received response: $response, error: $err")
+      logger.info(s"Received response: $response, error: $err")
 
       if (err != null) {
+        logger.error("Error occurred while sending broadcast", err)
         p.failure(err)
       } else if (response.statusCode() != 200) {
+        logger.error(s"Failed to send broadcast with status code ${response.statusCode()} and body ${response.body()}")
         p.failure(new RuntimeException(s"Failed to send broadcast with status code ${response.statusCode()} and body ${response.body()}"))
       } else {
         val apnsUniqueId = response.headers().firstValue("apns-unique-id").orElse("not found") // SANDBOX only header for debugging
-        println(s"Received response with status code ${response.statusCode()} and apns-unique-id ${apnsUniqueId}")
+        logger.info(s"Received response with status code ${response.statusCode()} and apns-unique-id ${apnsUniqueId}")
 
         p.success(response.body())
       }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/BroadcastApiClient.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/BroadcastApiClient.scala
@@ -18,7 +18,7 @@ import java.time.Instant
 import java.util.Date
 import com.gu.liveactivities.models.BroadcastJsonFormats
 
-class BroadcastApiClient {
+class BroadcastApiClient(authentication: Authentication, bundleId: String, sendingToProdServer: Boolean) {
   
   private val httpClient: HttpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build()
 
@@ -27,10 +27,12 @@ class BroadcastApiClient {
   private val charSet = StandardCharsets.UTF_8
 
   private val mediaType = "application/json; charset=UTF-8"
-
-  private val bundleId = "uk.co.guardian.iphone2.debug"
   
-  private val url = s"https://api.sandbox.push.apple.com:443/4/broadcasts/apps/$bundleId"
+  // TODO - to check
+  private val serviceEndpoint = if (sendingToProdServer) 
+    s"https://api.sandbox.push.apple.com:443/4/broadcasts/apps/$bundleId"
+  else
+    s"https://api.sandbox.push.apple.com:443/4/broadcasts/apps/$bundleId"
 
   private val message = 
     """{ 
@@ -61,10 +63,10 @@ class BroadcastApiClient {
 
   def sendToChannel(channelId: String, expiration: Option[Instant], priority: Option[Int]): Future[String] = {
     println(s"Broadcasting to channel $channelId")
-    val authToken = Authentication.getAccessToken()
+    val authToken = authentication.getAccessToken()
     println(s"Generated auth token: $authToken")
 
-    val request: HttpRequest = HttpRequest.newBuilder(new URI(url))
+    val request: HttpRequest = HttpRequest.newBuilder(new URI(serviceEndpoint))
       .version(HttpClient.Version.HTTP_2)
       .header("Authorization", authToken)
       .header("Content-Type", mediaType)

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/ChannelApiClient.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/ChannelApiClient.scala
@@ -14,14 +14,7 @@ import com.turo.pushy.apns.auth.AuthenticationToken;
 import java.time.Instant
 import java.util.Date
 
-object ChannelApiClient {
-
-  var authenticationToken: Option[String] = None
-
-  var issueDate: Option[Date] = None
-}
-
-class ChannelApiClient {
+class ChannelApiClient(authentication: Authentication, bundleId: String, sendingToProdServer: Boolean) {
   
   private val httpClient: HttpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build()
 
@@ -30,16 +23,19 @@ class ChannelApiClient {
   private val charSet = StandardCharsets.UTF_8
 
   private val mediaType = "application/json; charset=UTF-8"
+ 
+  // TODO - to check
+  private val url = if (sendingToProdServer)
+    s"https://api-manage-broadcast.sandbox.push.apple.com:2195/1/apps/$bundleId/channels"
+  else
+    s"https://api-manage-broadcast.sandbox.push.apple.com:2195/1/apps/$bundleId/channels"
 
-  private val bundleId = "uk.co.guardian.iphone2.debug"
-  
-  private val url = s"https://api-manage-broadcast.sandbox.push.apple.com:2195/1/apps/$bundleId/channels"
 
   private val message = "{\"message-storage-policy\": 1, \"push-type\": \"LiveActivity\"}"
 
   def createChannel(): Future[String] = {
     println("Creating channel")
-    val authToken = Authentication.getAccessToken()
+    val authToken = authentication.getAccessToken()
     val request: HttpRequest = HttpRequest.newBuilder(new URI(url))
       .version(HttpClient.Version.HTTP_2)
       .header("Authorization", authToken)
@@ -67,7 +63,7 @@ class ChannelApiClient {
 
   def closeChannel(channelId: String): Future[Unit] = {
     println(s"Closing channel $channelId")
-    val authToken = Authentication.getAccessToken()
+    val authToken = authentication.getAccessToken()
     val request: HttpRequest = HttpRequest.newBuilder(new URI(url))
       .version(HttpClient.Version.HTTP_2)
       .header("Authorization", authToken)

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/ChannelApiClient.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/ChannelApiClient.scala
@@ -13,12 +13,13 @@ import com.turo.pushy.apns.auth.ApnsSigningKey;
 import com.turo.pushy.apns.auth.AuthenticationToken;
 import java.time.Instant
 import java.util.Date
+import com.gu.liveactivities.util.Logging
 
-class ChannelApiClient(authentication: Authentication, bundleId: String, sendingToProdServer: Boolean) {
+class ChannelApiClient(authentication: Authentication, bundleId: String, sendingToProdServer: Boolean) extends Logging {
   
   private val httpClient: HttpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build()
 
-  println("HttpClient is instantiated")
+  logger.info("HttpClient in ChannelApiClient is instantiated")
 
   private val charSet = StandardCharsets.UTF_8
 
@@ -34,7 +35,7 @@ class ChannelApiClient(authentication: Authentication, bundleId: String, sending
   private val message = "{\"message-storage-policy\": 1, \"push-type\": \"LiveActivity\"}"
 
   def createChannel(): Future[String] = {
-    println("Creating channel")
+    logger.info("Creating channel")
     val authToken = authentication.getAccessToken()
     val request: HttpRequest = HttpRequest.newBuilder(new URI(url))
       .version(HttpClient.Version.HTTP_2)
@@ -51,10 +52,10 @@ class ChannelApiClient(authentication: Authentication, bundleId: String, sending
                 response.statusCode() < 300 && 
                 response.headers().firstValue("apns-channel-id").isPresent()) {
         val channelId = response.headers().firstValue("apns-channel-id").get()
-        println(s"Channel created successfully with channel ID $channelId")
+        logger.info(s"Channel created successfully with channel ID $channelId")
         p.success(channelId)
       } else {
-        println(s"Failed to create channel with status code ${response.statusCode()} and body ${response.body()}")
+        logger.error(s"Failed to create channel with status code ${response.statusCode()} and body ${response.body()}")
         p.failure(new Exception(s"Failed to create channel with status code ${response.statusCode()} and body ${response.body()}"))
       }
     })
@@ -62,7 +63,7 @@ class ChannelApiClient(authentication: Authentication, bundleId: String, sending
   }
 
   def closeChannel(channelId: String): Future[Unit] = {
-    println(s"Closing channel $channelId")
+    logger.info(s"Closing channel $channelId")
     val authToken = authentication.getAccessToken()
     val request: HttpRequest = HttpRequest.newBuilder(new URI(url))
       .version(HttpClient.Version.HTTP_2)
@@ -75,14 +76,14 @@ class ChannelApiClient(authentication: Authentication, bundleId: String, sending
     val p = Promise[Unit]()
     httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString()).whenComplete((response, err) => {
       if (response == null) {
-        println(s"Failed to close channel $channelId due to error ${err.getMessage}")
+        logger.error(s"Failed to close channel $channelId due to error ${err.getMessage}")
         p.failure(err)
       } else if (response.statusCode() >= 200 && 
                 response.statusCode() < 300) {
-        println(s"Channel closed successfully with channel ID $channelId")
+        logger.info(s"Channel closed successfully with channel ID $channelId")
         p.success(())
       } else {
-        println(s"Failed to close channel with status code ${response.statusCode()} and body ${response.body()}")
+        logger.error(s"Failed to close channel with status code ${response.statusCode()} and body ${response.body()}")
         p.failure(new Exception(s"Failed to close channel with status code ${response.statusCode()} and body ${response.body()}"))
       }
     })

--- a/liveactivities/src/main/scala/com/gu/liveactivities/util/Configuration.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/util/Configuration.scala
@@ -16,7 +16,7 @@ case class IosConfiguration(
   sendingToProdServer: Boolean = false,
 )
 
-object Configuration {
+object Configuration extends Logging {
 
   private def fetchConfiguration(platform: String): Config = {
     val defaultAppName = s"liveactivities-$platform"
@@ -27,6 +27,7 @@ object Configuration {
           .whoAmI(defaultAppName, DefaultCredentialsProvider.builder().build())
           .getOrElse(DevIdentity(defaultAppName))
     }
+    logger.info(s"Fetching configuration for ${identity}")
     ConfigurationLoader.load(identity) {
       case AwsIdentity(_, _, stage, region) => SSMConfigurationLocation(s"/notifications/$stage/liveactivities/$platform", region)
     }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/util/Configuration.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/util/Configuration.scala
@@ -1,0 +1,45 @@
+package com.gu.liveactivities.util
+
+import com.typesafe.config.Config
+import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
+import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.regions.Region.EU_WEST_1
+
+case class IosConfiguration(
+  teamId: String,
+  bundleId: String,
+  keyId: String,
+  certificate: Option[String],
+  sendingToProdServer: Boolean = false,
+)
+
+object Configuration {
+
+  private def fetchConfiguration(platform: String): Config = {
+    val defaultAppName = s"liveactivities-$platform"
+    val identity = Option(System.getenv("MOBILE_LOCAL_DEV")) match {
+      case Some(_) => DevIdentity(defaultAppName)
+      case None =>
+        AppIdentity
+          .whoAmI(defaultAppName, DefaultCredentialsProvider.builder().build())
+          .getOrElse(DevIdentity(defaultAppName))
+    }
+    ConfigurationLoader.load(identity) {
+      case AwsIdentity(_, _, stage, region) => SSMConfigurationLocation(s"/notifications/$stage/liveactivities/$platform", region)
+    }
+  }
+
+  def fetchIos(): IosConfiguration = {
+    val config = fetchConfiguration("ios")
+    IosConfiguration(
+      teamId = config.getString("apns.teamId"),
+      bundleId = config.getString("apns.bundleId"),
+      keyId = config.getString("apns.keyId"),
+      certificate = if (config.hasPath("apns.certificate")) Some(config.getString("apns.certificate")) else None,
+      sendingToProdServer = config.getBoolean("apns.sendingToProdServer")
+    )
+  }
+}

--- a/liveactivities/src/main/scala/com/gu/liveactivities/util/Configuration.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/util/Configuration.scala
@@ -12,7 +12,7 @@ case class IosConfiguration(
   teamId: String,
   bundleId: String,
   keyId: String,
-  certificate: Option[String],
+  certificate: String,
   sendingToProdServer: Boolean = false,
 )
 
@@ -39,7 +39,7 @@ object Configuration extends Logging {
       teamId = config.getString("apns.teamId"),
       bundleId = config.getString("apns.bundleId"),
       keyId = config.getString("apns.keyId"),
-      certificate = if (config.hasPath("apns.certificate")) Some(config.getString("apns.certificate")) else None,
+      certificate = config.getString("apns.certificate"),
       sendingToProdServer = config.getBoolean("apns.sendingToProdServer")
     )
   }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/util/Logging.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/util/Logging.scala
@@ -1,0 +1,7 @@
+package com.gu.liveactivities.util
+
+import org.slf4j.{Logger, LoggerFactory}
+
+trait Logging {
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request makes the following changes to support running the lambda functions on CODE:
1. Change the lambda to use RequestStreamHandler so that it can use Play JSON to serialise / deserialise the input JSON.
2. Read the configuration including team ID, key ID and certificate from the parameter store.  For local run, it read the configuration from `~/.gu/liveactivities-ios.conf`.
3. Add logging configuration and change console messages to log.

After this change, we can execute these two lambda functions directly through AWS console.

For example, to open a channel, invoke the liveactivities-channel-manager-CODE with the input JSON:
```
{
  "matchId": "match-test",
  "channelId": "ignored",
  "toCreate": true
}
```

To close a channel, use the input JSON:
```
{
  "matchId": "match-test",
  "channelId": "copy-from-output-of-creating-channel",
  "toCreate": false
}
```

To broadcast a message, invoke the liveactivities-broadcast-CODE with the input JSON:
```
{
  "matchId": "match-test",
  "channelId": "copy-from-output-of-creating-channel",
  "payload": "test message"
}
```
