### PR TITLE
LiveActivities - pa messages eventbus setup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -466,6 +466,7 @@ lazy val liveactivities = lambda("liveactivities", "liveactivities", Some("com.g
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
       "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
+      "software.amazon.awssdk" % "eventbridge" % "2.20.0"
     ),
     excludeDependencies ++= Seq(
       ExclusionRule("org.playframework", "play-ahc-ws_2.13"),

--- a/cdk/lib/__snapshots__/liveactivities.test.ts.snap
+++ b/cdk/lib/__snapshots__/liveactivities.test.ts.snap
@@ -18,102 +18,11 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
     },
   },
   "Resources": {
-    "liveactivitiesbroadcastlambdaC288C367": {
-      "DependsOn": [
-        "liveactivitiesbroadcastlambdaServiceRoleDefaultPolicyB2BCF85A",
-        "liveactivitiesbroadcastlambdaServiceRoleB0F7837A",
-      ],
+    "EventsD32975C2": {
       "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DistributionBucketName",
-          },
-          "S3Key": "mobile-notifications/CODE/liveactivities/liveactivities.jar",
-        },
-        "Description": "Broadcasts messages for live activities",
-        "Environment": {
-          "Variables": {
-            "APP": "liveactivities",
-            "App": "liveactivities",
-            "DYNAMODB_TABLE_NAME": "mobile-notifications-liveactivities-CODE",
-            "STACK": "mobile-notifications",
-            "STAGE": "CODE",
-            "Stack": "mobile-notifications",
-            "Stage": "CODE",
-          },
-        },
-        "FunctionName": "liveactivities-broadcast-CODE",
-        "Handler": "com.gu.liveactivities.BroadcastLambda::handleRequest",
-        "LoggingConfig": {
-          "LogFormat": "JSON",
-        },
-        "MemorySize": 1024,
-        "Role": {
-          "Fn::GetAtt": [
-            "liveactivitiesbroadcastlambdaServiceRoleB0F7837A",
-            "Arn",
-          ],
-        },
-        "Runtime": "java11",
+        "Description": "CODE event routing for live activities",
+        "Name": "liveactivities-eventbus-CODE",
         "Tags": [
-          {
-            "Key": "App",
-            "Value": "liveactivities",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/mobile-n10n",
-          },
-          {
-            "Key": "Stack",
-            "Value": "mobile-notifications",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "Timeout": 120,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "liveactivitiesbroadcastlambdaServiceRoleB0F7837A": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "liveactivities",
-          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -132,141 +41,51 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
           },
         ],
       },
-      "Type": "AWS::IAM::Role",
+      "Type": "AWS::Events::EventBus",
     },
-    "liveactivitiesbroadcastlambdaServiceRoleDefaultPolicyB2BCF85A": {
+    "liveGameEventsTargetingA85C7B8B": {
       "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/mobile-notifications/CODE/liveactivities/liveactivities.jar",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/CODE/mobile-notifications/liveactivities",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/CODE/mobile-notifications/liveactivities/*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "dynamodb:PutItem",
-                "dynamodb:UpdateItem",
-                "dynamodb:Query",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "liveactivitiesdynamotable87F336D2",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/notifications/CODE/liveactivities/ios",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
+        "Description": "Deliver live game events from PA polling lambda CODE to liveGameTestingQueue",
+        "EventBusName": {
+          "Ref": "EventsD32975C2",
         },
-        "PolicyName": "liveactivitiesbroadcastlambdaServiceRoleDefaultPolicyB2BCF85A",
-        "Roles": [
+        "EventPattern": {
+          "source": [
+            "pa-live-game-updates",
+          ],
+        },
+        "State": "DISABLED",
+        "Tags": [
           {
-            "Ref": "liveactivitiesbroadcastlambdaServiceRoleB0F7837A",
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "liveactivitiesfootballlivegamesCODE6EBEFF14",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
           },
         ],
       },
-      "Type": "AWS::IAM::Policy",
+      "Type": "AWS::Events::Rule",
     },
     "liveactivitieschannelmanagerlambda398DC149": {
       "DependsOn": [
@@ -560,6 +379,300 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
+    },
+    "liveactivitiesfootballlivegamesCODE6EBEFF14": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 604800,
+        "QueueName": "liveactivities-football-live-games-CODE",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "liveactivitiesfootballlivegamesCODEPolicy00A91D6E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Fn::GetAtt": [
+                      "liveGameEventsTargetingA85C7B8B",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "liveactivitiesfootballlivegamesCODE6EBEFF14",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Queues": [
+          {
+            "Ref": "liveactivitiesfootballlivegamesCODE6EBEFF14",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::QueuePolicy",
+    },
+    "liveactivitieslivegamespapollinglambda16BDC7D1": {
+      "DependsOn": [
+        "liveactivitieslivegamespapollinglambdaServiceRoleDefaultPolicy24985231",
+        "liveactivitieslivegamespapollinglambdaServiceRoleA3EF1A84",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "mobile-notifications/CODE/liveactivities/liveactivities.jar",
+        },
+        "Description": "Polls PA for live game updates and routes to event bus",
+        "Environment": {
+          "Variables": {
+            "APP": "liveactivities",
+            "App": "liveactivities",
+            "STACK": "mobile-notifications",
+            "STAGE": "CODE",
+            "Stack": "mobile-notifications",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "liveactivities-live-games-pa-polling-CODE",
+        "Handler": "com.gu.liveactivities.PollingLiveGamesDataLambda::handleRequest",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "liveactivitieslivegamespapollinglambdaServiceRoleA3EF1A84",
+            "Arn",
+          ],
+        },
+        "Runtime": "java11",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "liveactivities",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 120,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "liveactivitieslivegamespapollinglambdaServiceRoleA3EF1A84": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "liveactivities",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "liveactivitieslivegamespapollinglambdaServiceRoleDefaultPolicy24985231": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/mobile-notifications/CODE/liveactivities/liveactivities.jar",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/mobile-notifications/liveactivities",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/mobile-notifications/liveactivities/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "events:PutEvents",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "EventsD32975C2",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "liveactivitieslivegamespapollinglambdaServiceRoleDefaultPolicy24985231",
+        "Roles": [
+          {
+            "Ref": "liveactivitieslivegamespapollinglambdaServiceRoleA3EF1A84",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
   },
 }

--- a/cdk/lib/__snapshots__/liveactivities.test.ts.snap
+++ b/cdk/lib/__snapshots__/liveactivities.test.ts.snap
@@ -7,6 +7,7 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -86,6 +87,256 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
         ],
       },
       "Type": "AWS::Events::Rule",
+    },
+    "liveactivitiesbroadcastlambdaC288C367": {
+      "DependsOn": [
+        "liveactivitiesbroadcastlambdaServiceRoleDefaultPolicyB2BCF85A",
+        "liveactivitiesbroadcastlambdaServiceRoleB0F7837A",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "mobile-notifications/CODE/liveactivities/liveactivities.jar",
+        },
+        "Description": "Broadcasts messages for live activities",
+        "Environment": {
+          "Variables": {
+            "APP": "liveactivities",
+            "App": "liveactivities",
+            "DYNAMODB_TABLE_NAME": "mobile-notifications-liveactivities-CODE",
+            "STACK": "mobile-notifications",
+            "STAGE": "CODE",
+            "Stack": "mobile-notifications",
+            "Stage": "CODE",
+          },
+        },
+        "FunctionName": "liveactivities-broadcast-CODE",
+        "Handler": "com.gu.liveactivities.BroadcastLambda::handleRequest",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "liveactivitiesbroadcastlambdaServiceRoleB0F7837A",
+            "Arn",
+          ],
+        },
+        "Runtime": "java11",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "liveactivities",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 120,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "liveactivitiesbroadcastlambdaServiceRoleB0F7837A": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "liveactivities",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "liveactivitiesbroadcastlambdaServiceRoleDefaultPolicyB2BCF85A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/mobile-notifications/CODE/liveactivities/liveactivities.jar",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/mobile-notifications/liveactivities",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/mobile-notifications/liveactivities/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:Query",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "liveactivitiesdynamotable87F336D2",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/notifications/CODE/liveactivities/ios",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "liveactivitiesbroadcastlambdaServiceRoleDefaultPolicyB2BCF85A",
+        "Roles": [
+          {
+            "Ref": "liveactivitiesbroadcastlambdaServiceRoleB0F7837A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "liveactivitieschannelmanagerlambda398DC149": {
       "DependsOn": [

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -70,8 +70,9 @@ export class LiveActivities extends GuStack {
 			`${app}-live-games-pa-polling-lambda`,
 			{
 				app: app,
-				description:
-				handler: 'com.gu.liveactivities.PollingLiveGamesDataLambda::handleRequest', // TODO
+				description: 'Polls PA for live game updates and routes to event bus',
+				handler:
+					'com.gu.liveactivities.PollingLiveGamesDataLambda::handleRequest',
 				functionName: `${app}-live-games-pa-polling-${stage}`,
 				fileName: `${app}.jar`,
 				runtime: Runtime.JAVA_11,
@@ -85,17 +86,17 @@ export class LiveActivities extends GuStack {
 			},
 		);
 
-    const eventBus = new EventBus(this, 'Events', {
+		const eventBus = new EventBus(this, 'Events', {
 			eventBusName: `${app}-eventbus-${scope.stage}`,
 			description: `${scope.stage} event routing for live activities`,
 		});
 
-    liveGamesPaPollingLambda.addToRolePolicy(
-      new PolicyStatement({
-        actions: ['events:PutEvents'],
-        resources: [eventBus.eventBusArn],
-      })
-    );
+		liveGamesPaPollingLambda.addToRolePolicy(
+			new PolicyStatement({
+				actions: ['events:PutEvents'],
+				resources: [eventBus.eventBusArn],
+			}),
+		);
 
 		// Development SQS to capture and inspect events from PA polling during development
 		const liveGameTestingQueue = new Queue(
@@ -113,10 +114,8 @@ export class LiveActivities extends GuStack {
 			eventPattern: {
 				source: ['pa-live-game-updates'],
 			},
-			enabled: false, // only enable if we want to inspect events in the testDevQueue
+			enabled: false, // only enable if we want to inspect events in the development queue
 			targets: [new SqsQueue(liveGameTestingQueue)],
-		})
-
-
-  }
+		});
+	}
 }

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -14,7 +14,7 @@ export class LiveActivities extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
 
-		const { stack, stage } = this;
+		const { stack, stage, region, account } = this;
 		const app = 'liveactivities';
 
 		const dynamoTableName = `${stack}-liveactivities-${stage}`;
@@ -59,7 +59,45 @@ export class LiveActivities extends GuStack {
 				actions: ['ssm:GetParametersByPath'],
 				effect: Effect.ALLOW,
 				resources: [
-					`arn:aws:ssm:${this.region}:${this.account}:parameter/notifications/${this.stage}/liveactivities/ios`,
+					`arn:aws:ssm:${region}:${account}:parameter/notifications/${stage}/liveactivities/ios`,
+				],
+			}),
+		);
+
+		const broadcastLambda = new GuLambdaFunction(
+			this,
+			`${app}-broadcast-lambda`,
+			{
+				app: app,
+				description: 'Broadcasts messages for live activities',
+				handler: 'com.gu.liveactivities.BroadcastLambda::handleRequest',
+				functionName: `${app}-broadcast-${stage}`,
+				fileName: `${app}.jar`,
+				runtime: Runtime.JAVA_11,
+				memorySize: 1024,
+				timeout: Duration.seconds(120),
+				environment: {
+					Stack: stack,
+					Stage: stage,
+					App: app,
+					DYNAMODB_TABLE_NAME: dynamoTableName,
+				},
+			},
+		);
+
+		broadcastLambda.addToRolePolicy(
+			new PolicyStatement({
+				actions: ['dynamodb:PutItem', 'dynamodb:UpdateItem', 'dynamodb:Query'],
+				effect: Effect.ALLOW,
+				resources: [dynamoTable.tableArn],
+			}),
+		);
+		broadcastLambda.addToRolePolicy(
+			new PolicyStatement({
+				actions: ['ssm:GetParametersByPath'],
+				effect: Effect.ALLOW,
+				resources: [
+					`arn:aws:ssm:${region}:${account}:parameter/notifications/${stage}/liveactivities/ios`,
 				],
 			}),
 		);

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -87,8 +87,8 @@ export class LiveActivities extends GuStack {
 		);
 
 		const eventBus = new EventBus(this, 'Events', {
-			eventBusName: `${app}-eventbus-${scope.stage}`,
-			description: `${scope.stage} event routing for live activities`,
+			eventBusName: `${app}-eventbus-${stage}`,
+			description: `${stage} event routing for live activities`,
 		});
 
 		liveGamesPaPollingLambda.addToRolePolicy(
@@ -101,16 +101,16 @@ export class LiveActivities extends GuStack {
 		// Development SQS to capture and inspect events from PA polling during development
 		const liveGameTestingQueue = new Queue(
 			this,
-			`${app}-football-live-games-${scope.stage}`,
+			`${app}-football-live-games-${stage}`,
 			{
-				queueName: `${app}-football-live-games-${scope.stage}`,
+				queueName: `${app}-football-live-games-${stage}`,
 				retentionPeriod: Duration.days(7),
 			},
 		);
 
 		new Rule(this, 'liveGameEventsTargeting', {
 			eventBus: eventBus,
-			description: `Deliver live game events from PA polling lambda ${scope.stage} to liveGameTestingQueue`,
+			description: `Deliver live game events from PA polling lambda ${stage} to liveGameTestingQueue`,
 			eventPattern: {
 				source: ['pa-live-game-updates'],
 			},

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -4,8 +4,11 @@ import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
 import { Duration, Tags } from 'aws-cdk-lib';
 import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { EventBus, Rule } from 'aws-cdk-lib/aws-events';
+import { SqsQueue } from 'aws-cdk-lib/aws-events-targets';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
 
 export class LiveActivities extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
@@ -61,14 +64,15 @@ export class LiveActivities extends GuStack {
 			}),
 		);
 
-		const broadcastLambda = new GuLambdaFunction(
+		//////////// PA POLLING INFRASTRUCTURE //////////////
+		const liveGamesPaPollingLambda = new GuLambdaFunction(
 			this,
-			`${app}-broadcast-lambda`,
+			`${app}-live-games-pa-polling-lambda`,
 			{
 				app: app,
-				description: 'Broadcasts messages for live activities',
-				handler: 'com.gu.liveactivities.BroadcastLambda::handleRequest',
-				functionName: `${app}-broadcast-${stage}`,
+				description:
+				handler: 'com.gu.liveactivities.PollingLiveGamesDataLambda::handleRequest', // TODO
+				functionName: `${app}-live-games-pa-polling-${stage}`,
 				fileName: `${app}.jar`,
 				runtime: Runtime.JAVA_11,
 				memorySize: 1024,
@@ -77,26 +81,42 @@ export class LiveActivities extends GuStack {
 					Stack: stack,
 					Stage: stage,
 					App: app,
-					DYNAMODB_TABLE_NAME: dynamoTableName,
 				},
 			},
 		);
 
-		broadcastLambda.addToRolePolicy(
-			new PolicyStatement({
-				actions: ['dynamodb:PutItem', 'dynamodb:UpdateItem', 'dynamodb:Query'],
-				effect: Effect.ALLOW,
-				resources: [dynamoTable.tableArn],
-			}),
+    const eventBus = new EventBus(this, 'Events', {
+			eventBusName: `${app}-eventbus-${scope.stage}`,
+			description: `${scope.stage} event routing for live activities`,
+		});
+
+    liveGamesPaPollingLambda.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['events:PutEvents'],
+        resources: [eventBus.eventBusArn],
+      })
+    );
+
+		// Development SQS to capture and inspect events from PA polling during development
+		const liveGameTestingQueue = new Queue(
+			this,
+			`${app}-football-live-games-${scope.stage}`,
+			{
+				queueName: `${app}-football-live-games-${scope.stage}`,
+				retentionPeriod: Duration.days(7),
+			},
 		);
-		broadcastLambda.addToRolePolicy(
-			new PolicyStatement({
-				actions: ['ssm:GetParametersByPath'],
-				effect: Effect.ALLOW,
-				resources: [
-					`arn:aws:ssm:${this.region}:${this.account}:parameter/notifications/${this.stage}/liveactivities/ios`,
-				],
-			}),
-		);
-	}
+
+		new Rule(this, 'liveGameEventsTargeting', {
+			eventBus: eventBus,
+			description: `Deliver live game events from PA polling lambda ${scope.stage} to liveGameTestingQueue`,
+			eventPattern: {
+				source: ['pa-live-game-updates'],
+			},
+			enabled: false, // only enable if we want to inspect events in the testDevQueue
+			targets: [new SqsQueue(liveGameTestingQueue)],
+		})
+
+
+  }
 }

--- a/liveactivities/riff-raff.yaml
+++ b/liveactivities/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     type: aws-lambda
     parameters:
       bucketSsmLookup: true
-      functionNames: [liveactivities-channel-manager-, liveactivities-broadcast-]
+      functionNames: [liveactivities-channel-manager-, liveactivities-broadcast-, liveactivities-live-games-pa-polling-]
       fileName: liveactivities.jar
       prefixStack: false
     dependencies: [mobile-notifications-liveactivities-cfn]

--- a/liveactivities/src/main/scala/com/gu/liveactivities/PollingLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/PollingLambda.scala
@@ -1,0 +1,58 @@
+package com.gu.liveactivities
+
+import com.amazonaws.services.lambda.runtime.Context
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient
+import software.amazon.awssdk.services.eventbridge.model.{
+  PutEventsRequest,
+  PutEventsRequestEntry
+}
+
+import scala.util.Try
+
+object PollingLiveGamesDataLambda {
+
+  private val eventBusName = "liveactivities-eventbus-CODE" // TODO - move to config
+  private val eventBridgeClient = EventBridgeClient.builder().build() // credentials? is cdk policy roll enough?
+
+  def handleRequest(context: Context): Unit = {
+
+    // TODO
+    // schedule lambda to run every 15seconds via cdk.
+    // Step 1 read liveActivity channel mapping dynamo table to get any match ids that are live.
+    // live match no? - do nothing.
+    // live match yes?
+    // Step 2 - publish event to event bridge with match id
+    // - collect unique competition ids for live matches
+    // - call PA /liveGames for all those competition ids that have live matches
+    // - send event to eventbus with match id and channel id.
+
+    // iteration:  tbc diff pa events to check if we need to send event or not??
+
+    val result = Try {
+
+      val entry = PutEventsRequestEntry
+        .builder()
+        .source("pa-live-game-updates")
+        .detailType("football-live-game")
+        .detail(
+          """{"matchId": "12345", "status": "live", "homeScore": 1, "awayScore": 0}""" // dummy data PA data will go heare
+        )
+        .eventBusName(eventBusName)
+        .build()
+
+      val request = PutEventsRequest
+        .builder()
+        .entries(entry)
+        .build()
+
+      val response = eventBridgeClient.putEvents(request)
+      println(
+        s"Event published. Failed entry count: ${response.failedEntryCount()}"
+      )
+    }
+
+    result.failed.foreach(e =>
+      println(s"Failed to publish event: ${e.getMessage}")
+    )
+  }
+}

--- a/liveactivities/src/main/scala/com/gu/liveactivities/PollingLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/PollingLambda.scala
@@ -2,21 +2,31 @@ package com.gu.liveactivities
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient
-import software.amazon.awssdk.services.eventbridge.model.{PutEventsRequest, PutEventsRequestEntry}
+import software.amazon.awssdk.services.eventbridge.model.{
+  PutEventsRequest,
+  PutEventsRequestEntry
+}
 
 import scala.util.Try
 
-class PollingLiveGamesDataLambda extends RequestHandler[java.util.Map[String, Any], Unit] {
+class PollingLiveGamesDataLambda
+    extends RequestHandler[java.util.Map[String, Any], Unit] {
 
-  override def handleRequest(input: java.util.Map[String, Any], context: Context): Unit =
+  override def handleRequest(
+      input: java.util.Map[String, Any],
+      context: Context
+  ): Unit =
     PollingLiveGamesDataLambda.handleRequest()
 }
 
-
 object PollingLiveGamesDataLambda {
 
-  private val eventBusName = "liveactivities-eventbus-CODE" // TODO - move to config
-  private val eventBridgeClient = EventBridgeClient.builder().build() // credentials? is cdk policy roll enough?
+  private val eventBusName =
+    "liveactivities-eventbus-CODE" // TODO - move to config
+  private val eventBridgeClient =
+    EventBridgeClient
+      .builder()
+      .build() // credentials? is cdk policy roll enough?
 
   def handleRequest(): Unit = {
 
@@ -31,6 +41,7 @@ object PollingLiveGamesDataLambda {
     // - send event to eventbus with match id and channel id.
 
     // iteration:  tbc diff pa events to check if we need to send event or not??
+    println("running PollingLiveGamesDataLambda -------------------")
 
     val result = Try {
 

--- a/liveactivities/src/main/scala/com/gu/liveactivities/PollingLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/PollingLambda.scala
@@ -1,20 +1,24 @@
 package com.gu.liveactivities
 
-import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient
-import software.amazon.awssdk.services.eventbridge.model.{
-  PutEventsRequest,
-  PutEventsRequestEntry
-}
+import software.amazon.awssdk.services.eventbridge.model.{PutEventsRequest, PutEventsRequestEntry}
 
 import scala.util.Try
+
+class PollingLiveGamesDataLambda extends RequestHandler[java.util.Map[String, Any], Unit] {
+
+  override def handleRequest(input: java.util.Map[String, Any], context: Context): Unit =
+    PollingLiveGamesDataLambda.handleRequest()
+}
+
 
 object PollingLiveGamesDataLambda {
 
   private val eventBusName = "liveactivities-eventbus-CODE" // TODO - move to config
   private val eventBridgeClient = EventBridgeClient.builder().build() // credentials? is cdk policy roll enough?
 
-  def handleRequest(context: Context): Unit = {
+  def handleRequest(): Unit = {
 
     // TODO
     // schedule lambda to run every 15seconds via cdk.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Creates a liveactivities eventbus that sends source messages to testing q. 
Creates a placeholder polling lambda to putEvents on the bus. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
