### PR TITLE
Send liveActivity payloads from football lambda to eventbus

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/Payloads.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/Payloads.scala
@@ -60,8 +60,11 @@ object GoalType {
   }
 }
 
-sealed trait NotificationPayload {
+trait Payload {
   def id: UUID
+}
+
+sealed trait NotificationPayload extends Payload {
   def title: Option[String]
   def `type`: NotificationPayloadType
   def message: Option[String]

--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
@@ -1,0 +1,154 @@
+package com.gu.mobile.notifications.client.models.liveActitivites
+
+import play.api.libs.json._
+
+// GENERIC CONTENT STATE //////////////////////////////////////////////////
+
+sealed trait ContentState
+object ContentState {
+  import FootballContentJsonFormats._
+
+  implicit val format: OFormat[ContentState] = new OFormat[ContentState] {
+    def writes(cs: ContentState): JsObject = cs match {
+      case f: FootballMatchContentState =>
+        footballMatchContentStateFormat
+          .writes(f)
+          .as[JsObject] + ("type" -> JsString("football"))
+      // Add cases for other ContentState subtypes here
+    }
+
+    def reads(json: JsValue): JsResult[ContentState] = {
+      (json \ "type").validate[String].flatMap {
+        case "football" => footballMatchContentStateFormat.reads(json)
+        // Add cases for other ContentState subtypes here
+        case other => JsError(s"Unknown ContentState type: $other")
+      }
+    }
+  }
+}
+
+// FOOTBALL CONTENT STATE //////////////////////////////////////////////////
+// @formatter:off
+sealed trait MatchStatus { val status: String }
+case object Scheduled extends MatchStatus { val status = "SCHEDULED" }
+case object PreMatch extends MatchStatus { val status = "PRE_MATCH" }
+case object FirstHalf extends MatchStatus { val status = "FIRST_HALF" }
+case object HalfTime extends MatchStatus { val status = "HALF_TIME" }
+case object SecondHalf extends MatchStatus { val status = "SECOND_HALF" }
+case object ExtraTimeFirstHalf extends MatchStatus { val status = "EXTRA_TIME_FIRST_HALF" }
+case object ExtraTimeHalfTime extends MatchStatus { val status = "EXTRA_TIME_HALF_TIME" }
+case object ExtraTimeSecondHalf extends MatchStatus { val status = "EXTRA_TIME_SECOND_HALF" }
+case object Penalties extends MatchStatus { val status = "PENALTIES" }
+case object FullTime extends MatchStatus { val status = "FULL_TIME" }
+case object Postponed extends MatchStatus { val status = "POSTPONED" }
+case object Abandoned extends MatchStatus { val status = "ABANDONED" }
+// @formatter:on
+
+object MatchStatus {
+  def fromString(s: String): MatchStatus = s match {
+    case "Pre-match" | "prematch"                        => PreMatch
+    case "MatchInProgress" | "1st Half" | "first_half"   => FirstHalf
+    case "HalfTime" | "Half Time" | "half_time"          => HalfTime
+    case "2nd Half" | "second_half"                      => SecondHalf
+    case "Extra Time" | "ET 1st Half"                    => ExtraTimeFirstHalf
+    case "ET Half Time"                                  => ExtraTimeHalfTime
+    case "ET 2nd Half"                                   => ExtraTimeSecondHalf
+    case "Penalties"                                     => Penalties
+    case "MatchComplete" | "MC" | "Full Time" | "Result" => FullTime
+    case "Postponed"                                     => Postponed
+    case "Abandoned"                                     => Abandoned
+    case _                                               => Scheduled
+  }
+}
+
+case class Competition(
+    id: String,
+    name: String,
+    round: Option[String] = None
+)
+
+case class TeamState(
+    name: String,
+    score: Int,
+    logoAssetName: Option[String] = None,
+    teamUrl: Option[String] = None,
+    penaltyScore: Option[Int] = None,
+    redCards: Option[Int] = None
+)
+
+//object TeamState {
+//  def fromPaMatchDayTeam(t: MatchDayTeam): TeamState = TeamState(
+//    name = t.name,
+//    score = t.score.getOrElse(0)
+//  )
+//}
+
+case class FootballMatchContentState(
+    matchStatus: MatchStatus,
+    kickOffTimestamp: Long,
+    homeTeam: TeamState,
+    awayTeam: TeamState,
+    competition: Competition,
+    commentary: Option[String] = None,
+    lineupsAvailable: Option[Boolean] = None,
+    currentMinute: Option[Int] = None,
+    currentPeriodStartTime: Option[Long] = None,
+    articleUrl: Option[String] = None
+) extends ContentState
+
+//object FootballMatchContentState {
+//
+//  /// todo
+//  // competition is not on LiveMatch — pass it in from the surrounding context (e.g. MatchDay)
+//  def apply(
+//      paLiveMatch: LiveMatch,
+//      paCompetition: pa.Competition
+//  ): FootballMatchContentState = {
+//    FootballMatchContentState(
+//      matchStatus = MatchStatus.fromString(paLiveMatch.status),
+//      kickOffTimestamp = paLiveMatch.date.toEpochSecond,
+//      homeTeam = TeamState.fromPaMatchDayTeam(paLiveMatch.homeTeam),
+//      awayTeam = TeamState.fromPaMatchDayTeam(paLiveMatch.awayTeam),
+//      competition =
+//        Competition(id = paCompetition.id, name = paCompetition.name),
+//      commentary = paLiveMatch.comments,
+//      lineupsAvailable = None, // Booliean   // not available on LiveMatch
+//      currentMinute = None, // not available on LiveMatch
+//      currentPeriodStartTime = None,
+//      articleUrl = None // not available on LiveMatch from CAPI
+//    )
+//  }
+//}
+
+object FootballContentJsonFormats {
+  // MatchStatus format must be defined first since FootballMatchContentState depends on it
+  implicit val matchStatusFormat: Format[MatchStatus] = Format(
+    Reads {
+      case JsString(s) =>
+        s match {
+          case "SCHEDULED"              => JsSuccess(Scheduled)
+          case "PRE_MATCH"              => JsSuccess(PreMatch)
+          case "FIRST_HALF"             => JsSuccess(FirstHalf)
+          case "HALF_TIME"              => JsSuccess(HalfTime)
+          case "SECOND_HALF"            => JsSuccess(SecondHalf)
+          case "EXTRA_TIME_FIRST_HALF"  => JsSuccess(ExtraTimeFirstHalf)
+          case "EXTRA_TIME_HALF_TIME"   => JsSuccess(ExtraTimeHalfTime)
+          case "EXTRA_TIME_SECOND_HALF" => JsSuccess(ExtraTimeSecondHalf)
+          case "PENALTIES"              => JsSuccess(Penalties)
+          case "FULL_TIME"              => JsSuccess(FullTime)
+          case "POSTPONED"              => JsSuccess(Postponed)
+          case "ABANDONED"              => JsSuccess(Abandoned)
+          case other                    => JsError(s"Unknown match status: $other")
+        }
+      case _ => JsError("Expected a JSON string for MatchStatus")
+    },
+    Writes(ms => JsString(ms.status))
+  )
+
+  implicit val competitionFormat: OFormat[Competition] =
+    Json.format[Competition]
+  implicit val teamStateFormat: OFormat[TeamState] = Json.format[TeamState]
+  implicit val footballMatchContentStateFormat
+      : OFormat[FootballMatchContentState] =
+    Json.format[FootballMatchContentState]
+}

--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
@@ -1,0 +1,81 @@
+package com.gu.mobile.notifications.client.models.liveActitivites
+
+import com.gu.mobile.notifications.client.models.Topic
+import play.api.libs.json.{JsString, Json, Writes}
+
+///
+/*
+1. event type e.g. START CHANNEL, START MATCH, MATCH UPDATE, REMOVE CHANNEL
+2. event ID
+3. live activity type - "football" in our case
+4. match ID
+5. data we want to keep in the datastore
+6. data we need to build the payload for broadcast messages
+7. event timestamp
+ */
+
+// life cycle of a live activity:
+sealed trait LiveActivityEventType
+case object CreateChannel extends LiveActivityEventType
+case object StartLiveActivity extends LiveActivityEventType
+case object UpdateLiveActivity extends LiveActivityEventType
+case object EndLiveActivity extends LiveActivityEventType
+case object DeleteChannel extends LiveActivityEventType
+
+sealed trait LiveActivityType
+case object FootballLiveActivity extends LiveActivityType
+// tbc cricket, elections
+
+case class dynamoData(
+    liveActivityId: String,
+    isLive: Boolean,
+    data: Option[String], // tbc
+    competitionId: Option[String], // should this move to data??
+    lastEventId: Option[String],
+    lastEventAt: Option[Long]
+)
+//
+//Column name	Description
+//id	Primary key. The match ID in the football context.
+//  channelId	the channel ID that has been created via Apple API for this live activity
+//isChannelActive	indicate whether the channel is still active or has been closed.
+//isLive	indicate whether the live activity is live i.e. the football match is taking place.
+//  data	data specific to the live activity
+//competitionId	competition ID of the match
+//lastEventId	event ID of the last message to the live activity
+//lastEventAt	timestamp of the event of the last message
+//createdAt	timestamp when the record was inserted. Not directly used by the application.
+//lastModifiedAt	timestamp when the record was last modified. Not directly used by the application.D
+
+case class LiveActivityPayload(
+    eventType: LiveActivityEventType,
+    eventId: String, // tbc uuid?
+    liveActivityType: LiveActivityType,
+    liveActivityID: String, // Match ID in the case of football, tbc for other sports/events
+    dynamoStoreData: Option[
+      String
+    ], // data not in contentstate but specific to match, election, etc TBC
+    broadcastContentStateData: Option[ContentState],
+    eventTimestamp: Long,
+    topics: List[Topic] // we will need to know topics for push to start
+)
+
+object LiveActivityPayload {
+  implicit val liveActivityEventTypeWrites: Writes[LiveActivityEventType] =
+    Writes {
+      case CreateChannel      => JsString("CreateChannel")
+      case StartLiveActivity  => JsString("StartLiveActivity")
+      case UpdateLiveActivity => JsString("UpdateLiveActivity")
+      case EndLiveActivity    => JsString("EndLiveActivity")
+      case DeleteChannel      => JsString("DeleteChannel")
+    }
+
+  implicit val liveActivityTypeWrites: Writes[LiveActivityType] = Writes {
+    case FootballLiveActivity => JsString("FootballLiveActivity")
+  }
+
+  implicit val dynamoDataWrites: Writes[dynamoData] = Json.writes[dynamoData]
+
+  implicit val liveActivityPayloadWrites: Writes[LiveActivityPayload] =
+    Json.writes[LiveActivityPayload]
+}

--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
@@ -2,6 +2,8 @@ package com.gu.mobile.notifications.client.models.liveActitivites
 
 import com.gu.mobile.notifications.client.models.Topic
 import play.api.libs.json.{JsString, Json, Writes}
+import java.util.UUID
+import com.gu.mobile.notifications.client.models.Payload
 
 ///
 /*
@@ -48,8 +50,8 @@ case class dynamoData(
 //lastModifiedAt	timestamp when the record was last modified. Not directly used by the application.D
 
 case class LiveActivityPayload(
+    id: UUID,
     eventType: LiveActivityEventType,
-    eventId: String, // tbc uuid?
     liveActivityType: LiveActivityType,
     liveActivityID: String, // Match ID in the case of football, tbc for other sports/events
     dynamoStoreData: Option[
@@ -58,7 +60,7 @@ case class LiveActivityPayload(
     broadcastContentStateData: Option[ContentState],
     eventTimestamp: Long,
     topics: List[Topic] // we will need to know topics for push to start
-)
+) extends Payload
 
 object LiveActivityPayload {
   implicit val liveActivityEventTypeWrites: Writes[LiveActivityEventType] =

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -15,6 +15,10 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, TimeoutException}
 import scala.io.Source
 import scala.util.Failure
+import com.gu.mobile.notifications.client.models.NotificationPayload
+import com.gu.mobile.notifications.client.models.liveActitivites.LiveActivityPayload
+import com.gu.mobile.notifications.football.models.MatchDataWithArticle
+import scala.concurrent.Future
 
 object Lambda extends Logging {
 
@@ -48,19 +52,13 @@ object Lambda extends Logging {
 
   val apiClient = new NotificationsApiClient(configuration)
 
-  lazy val notificationSender = new NotificationSender(apiClient)
-
-  lazy val matchStatusNotificationBuilder = new MatchStatusNotificationBuilder(configuration.mapiHost)
-
-  lazy val eventConsumer = new EventConsumer(matchStatusNotificationBuilder)
-
-  lazy val distinctCheck = new DynamoDistinctCheck(dynamoDBClient, tableName)
-
-  lazy val eventFilter = new EventFilter(distinctCheck)
-
   lazy val footballData = new FootballData(paFootballClient, syntheticMatchEventGenerator)
 
   lazy val articleSearcher = new ArticleSearcher(capiClient)
+
+  lazy val notificationHandler = new NotificationHandler(configuration, apiClient, dynamoDBClient, tableName)
+
+  lazy val liveActivityHandler = new LiveActivityHandler(configuration, dynamoDBClient, tableName)
 
   // live activities //
   lazy val liveActivityPusher = new LiveActivityPusher()
@@ -92,18 +90,16 @@ object Lambda extends Logging {
 
     logContainer()
 
-    val processing = for {
+    val articlesMatches = for {
       footballDataResult <- footballData.pollFootballData(getZonedDateTime())
       articleMatches <- articleSearcher.tryToMatchWithCapiArticle(footballDataResult)
-      liveActivities = articleMatches.flatMap(liveActivityEventConsumer.eventsToLiveActivityPayload)
-      _ = liveActivityPusher.pushToEventbus(liveActivities) // TODO this should eventually push Filtered Live Activity Payloads
-      notifications = articleMatches.flatMap(eventConsumer.eventsToNotifications)
-      filteredNotifications <- eventFilter.filterNotifications(notifications) // todo what filtering is happening exactly?
-      result <- notificationSender.sendNotifications(filteredNotifications)
-    } yield result
+    } yield articleMatches
+
+    val notificationsProcessing = articlesMatches.flatMap(notificationHandler.process)
+    val liveActivitiesProcessing = articlesMatches.flatMap(liveActivityHandler.process)
 
     // we're in a lambda so we do need to block the main thread until processing is finished
-    val result = Await.ready(processing, Duration(40, TimeUnit.SECONDS))
+    val result = Await.ready(Future.sequence(List(notificationsProcessing, liveActivitiesProcessing)), Duration(40, TimeUnit.SECONDS))
 
     result.value match {
       case Some(Failure(e: TimeoutException)) => logger.error("Task timed out", e)
@@ -124,4 +120,46 @@ object Lambda extends Logging {
     }
   }
 
+}
+
+class NotificationHandler(configuration: Configuration, apiClient: NotificationsApiClient, dynamoDBClient: AmazonDynamoDBAsync, tableName: String) extends Logging {
+
+  lazy val notificationSender = new NotificationSender(apiClient)
+
+  lazy val matchStatusNotificationBuilder = new MatchStatusNotificationBuilder(configuration.mapiHost)
+
+  lazy val eventConsumer = new EventConsumer(matchStatusNotificationBuilder)
+
+  lazy val distinctCheck = new DynamoDistinctCheck[NotificationPayload](dynamoDBClient, tableName)
+
+  lazy val eventFilter = new EventFilter[NotificationPayload](distinctCheck)
+
+  def process(rawEvents: List[MatchDataWithArticle]): Future[Unit] = {
+    val notifications = rawEvents.flatMap(eventConsumer.eventsToNotifications)
+    for {
+      filteredNotifications <- eventFilter.filterNotifications(notifications) // todo what filtering is happening exactly?
+      result <- notificationSender.sendNotifications(filteredNotifications)
+    } yield result
+  }  
+}
+
+class LiveActivityHandler(configuration: Configuration, dynamoDBClient: AmazonDynamoDBAsync, tableName: String) extends Logging {
+
+  lazy val liveActivityPusher = new LiveActivityPusher()
+
+	lazy val matchStatusLiveActivityPayloadBuilder = new MatchStatusLiveActivityPayloadBuilder(configuration.mapiHost)
+
+	lazy val liveActivityEventConsumer = new LiveActivityEventConsumer(matchStatusLiveActivityPayloadBuilder)
+
+  lazy val distinctCheck = new DynamoDistinctCheck[LiveActivityPayload](dynamoDBClient, tableName)
+
+  lazy val eventFilter = new EventFilter[LiveActivityPayload](distinctCheck)
+
+  def process(rawEvents: List[MatchDataWithArticle]): Future[Unit] = {
+    val liveActivities = rawEvents.flatMap(liveActivityEventConsumer.eventsToLiveActivityPayload)
+    for {
+      // filteredLiveActivities <- eventFilter.filterNotifications(liveActivities) // todo what filtering is happening exactly?
+      result <- liveActivityPusher.pushEvents(liveActivities) // TODO this should eventually push Filtered Live Activity Payloads
+    } yield result
+  }  
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -6,8 +6,8 @@ import java.util.concurrent.TimeUnit
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder}
 import com.gu.contentapi.client.GuardianContentClient
-import com.gu.mobile.notifications.football.lib.{ArticleSearcher, DynamoDistinctCheck, EventConsumer, EventFilter, FootballData, LiveActivityPusher, NotificationHttpProvider, NotificationSender, NotificationsApiClient, PaFootballClient, SyntheticMatchEventGenerator}
-import com.gu.mobile.notifications.football.notificationbuilders.MatchStatusNotificationBuilder
+import com.gu.mobile.notifications.football.lib.{ArticleSearcher, DynamoDistinctCheck, EventConsumer, LiveActivityEventConsumer, EventFilter, FootballData, LiveActivityPusher, NotificationHttpProvider, NotificationSender, NotificationsApiClient, PaFootballClient, SyntheticMatchEventGenerator}
+import com.gu.mobile.notifications.football.notificationbuilders.{MatchStatusLiveActivityPayloadBuilder, MatchStatusNotificationBuilder}
 import play.api.libs.json.Json
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -52,8 +52,6 @@ object Lambda extends Logging {
 
   lazy val matchStatusNotificationBuilder = new MatchStatusNotificationBuilder(configuration.mapiHost)
 
-  lazy val liveActivityPusher = new LiveActivityPusher()
-
   lazy val eventConsumer = new EventConsumer(matchStatusNotificationBuilder)
 
   lazy val distinctCheck = new DynamoDistinctCheck(dynamoDBClient, tableName)
@@ -63,6 +61,11 @@ object Lambda extends Logging {
   lazy val footballData = new FootballData(paFootballClient, syntheticMatchEventGenerator)
 
   lazy val articleSearcher = new ArticleSearcher(capiClient)
+
+  // live activities //
+  lazy val liveActivityPusher = new LiveActivityPusher()
+  lazy val matchStatusLiveActivityPayloadBuilder = new MatchStatusLiveActivityPayloadBuilder(configuration.mapiHost)
+  lazy val liveActivityEventConsumer = new LiveActivityEventConsumer(matchStatusLiveActivityPayloadBuilder)
 
   def getZonedDateTime(): ZonedDateTime = {
     val zonedDateTime = if (configuration.stage == "CODE") {
@@ -92,9 +95,10 @@ object Lambda extends Logging {
     val processing = for {
       footballDataResult <- footballData.pollFootballData(getZonedDateTime())
       articleMatches <- articleSearcher.tryToMatchWithCapiArticle(footballDataResult)
-      _ = liveActivityPusher.pushToEventbus(articleMatches)
+      liveActivities = articleMatches.flatMap(liveActivityEventConsumer.eventsToLiveActivityPayload)
+      _ = liveActivityPusher.pushToEventbus(liveActivities) // TODO this should eventually push Filtered Live Activity Payloads
       notifications = articleMatches.flatMap(eventConsumer.eventsToNotifications)
-      filteredNotifications <- eventFilter.filterNotifications(notifications) // todo what filtering is happening.
+      filteredNotifications <- eventFilter.filterNotifications(notifications) // todo what filtering is happening exactly?
       result <- notificationSender.sendNotifications(filteredNotifications)
     } yield result
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoDistinctCheck.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoDistinctCheck.scala
@@ -2,7 +2,7 @@ package com.gu.mobile.notifications.football.lib
 
 import scala.concurrent.{ExecutionContext, Future}
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
-import com.gu.mobile.notifications.client.models.{FootballMatchStatusPayload, NotificationPayload}
+import com.gu.mobile.notifications.client.models.{FootballMatchStatusPayload, Payload}
 import org.scanamo.{ScanamoAsync, Table}
 import DynamoDistinctCheck.{Distinct, DistinctStatus, Duplicate, Unknown}
 import com.gu.mobile.notifications.football.Logging
@@ -16,7 +16,7 @@ case class DynamoMatchNotification(
 )
 
 object DynamoMatchNotification {
-  def apply(notification: NotificationPayload): DynamoMatchNotification = {
+  def apply[A <: Payload](notification: A)(implicit writes: play.api.libs.json.Writes[A]): DynamoMatchNotification = {
     val matchId = PartialFunction.condOpt(notification) {
       case p: FootballMatchStatusPayload => p.matchId
     }
@@ -37,8 +37,8 @@ object DynamoDistinctCheck {
   case object Unknown extends DistinctStatus
 }
 
-class DynamoDistinctCheck(client: AmazonDynamoDBAsync, tableName: String) extends Logging {
-  def insertNotification(notification: NotificationPayload)(implicit ec: ExecutionContext): Future[DistinctStatus] = {
+class DynamoDistinctCheck[A <: Payload](client: AmazonDynamoDBAsync, tableName: String) extends Logging {
+  def insertNotification(notification: A)(implicit ec: ExecutionContext, writes: play.api.libs.json.Writes[A]): Future[DistinctStatus] = {
     import org.scanamo.syntax._
     import org.scanamo.generic.auto._
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
@@ -1,31 +1,107 @@
 package com.gu.mobile.notifications.football.lib
 
 import com.gu.mobile.notifications.client.models.NotificationPayload
+import com.gu.mobile.notifications.client.models.liveActitivites.LiveActivityPayload
 import com.gu.mobile.notifications.football.Logging
-import com.gu.mobile.notifications.football.models.{FootballMatchEvent, MatchDataWithArticle}
-import com.gu.mobile.notifications.football.notificationbuilders.MatchStatusNotificationBuilder
+import com.gu.mobile.notifications.football.models.{
+  FootballMatchEvent,
+  MatchDataWithArticle
+}
+import com.gu.mobile.notifications.football.notificationbuilders.{
+  MatchStatusLiveActivityPayloadBuilder,
+  MatchStatusNotificationBuilder
+}
 import pa.{MatchDay, MatchEvent}
 
 class EventConsumer(
-  matchStatusNotificationBuilder: MatchStatusNotificationBuilder
+    matchStatusNotificationBuilder: MatchStatusNotificationBuilder
 ) extends Logging {
 
-  def eventsToNotifications(matchData: MatchDataWithArticle): List[NotificationPayload] = {
+  def eventsToNotifications(
+      matchData: MatchDataWithArticle
+  ): List[NotificationPayload] = {
     matchData.allEvents.flatMap { event =>
-      receiveEvent(matchData.matchDay, matchData.allEvents, event, matchData.articleId)
+      receiveEvent(
+        matchData.matchDay,
+        matchData.allEvents,
+        event,
+        matchData.articleId
+      )
     }
   }
 
-  def receiveEvent(matchDay: MatchDay, events: List[MatchEvent], event: MatchEvent, articleId: Option[String]): List[NotificationPayload] = {
+  def receiveEvent(
+      matchDay: MatchDay,
+      events: List[MatchEvent],
+      event: MatchEvent,
+      articleId: Option[String]
+  ): List[NotificationPayload] = {
     logger.debug(s"Processing event $event for match ${matchDay.id}")
     val previousEvents = events.takeWhile(_ != event)
-    FootballMatchEvent.fromPaMatchEvent(matchDay.homeTeam, matchDay.awayTeam)(event) map { ev =>
-      List(matchStatusNotificationBuilder.build(
-        triggeringEvent = ev,
-        matchInfo = matchDay,
-        previousEvents = previousEvents.flatMap(FootballMatchEvent.fromPaMatchEvent(matchDay.homeTeam, matchDay.awayTeam)(_)),
-        articleId = articleId
-      ))
+    FootballMatchEvent.fromPaMatchEvent(matchDay.homeTeam, matchDay.awayTeam)(
+      event
+    ) map { ev =>
+      List(
+        matchStatusNotificationBuilder.build(
+          triggeringEvent = ev,
+          matchInfo = matchDay,
+          previousEvents = previousEvents.flatMap(
+            FootballMatchEvent
+              .fromPaMatchEvent(matchDay.homeTeam, matchDay.awayTeam)(_)
+          ),
+          articleId = articleId
+        )
+      )
     } getOrElse Nil
   }
+}
+
+class LiveActivityEventConsumer(
+    matchStatusLiveActivityPayloadBuilder: MatchStatusLiveActivityPayloadBuilder
+) extends Logging {
+
+  def eventsToLiveActivityPayload(
+      matchData: MatchDataWithArticle
+  ): List[LiveActivityPayload] = {
+    matchData.allEvents.flatMap { event =>
+      processForLiveActivities(
+        matchData.matchDay,
+        matchData.allEvents,
+        event,
+        matchData.articleId
+      )
+    }
+  }
+
+  def processForLiveActivities(
+      matchDay: MatchDay,
+      events: List[MatchEvent],
+      event: MatchEvent,
+      articleId: Option[String]
+  ): List[LiveActivityPayload] = {
+    logger.debug(
+      s"Processing live activity event $event for match ${matchDay.id}"
+    )
+
+    val previousEvents = events.takeWhile(_ != event)
+
+    FootballMatchEvent.fromPaMatchEvent(matchDay.homeTeam, matchDay.awayTeam)(
+      event
+    ) map { ev =>
+      // Build live activity payload
+      List(
+        matchStatusLiveActivityPayloadBuilder.build(
+          triggeringEvent = ev,
+          matchInfo = matchDay,
+          previousEvents = previousEvents.flatMap(
+            FootballMatchEvent
+              .fromPaMatchEvent(matchDay.homeTeam, matchDay.awayTeam)(_)
+          ),
+          articleId = articleId
+        )
+      )
+    } getOrElse Nil
+
+  }
+
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventFilter.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventFilter.scala
@@ -4,13 +4,13 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.UnaryOperator
 
-import com.gu.mobile.notifications.client.models.NotificationPayload
+import com.gu.mobile.notifications.client.models.Payload
 import com.gu.mobile.notifications.football.lib.DynamoDistinctCheck.{Distinct, Duplicate}
 import com.gu.mobile.notifications.football.Logging
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class EventFilter(distinctCheck: DynamoDistinctCheck) extends Logging {
+class EventFilter[A <: Payload](distinctCheck: DynamoDistinctCheck[A]) extends Logging {
   private val processedEvents = new AtomicReference[Set[UUID]](Set.empty)
 
   private def cache(eventId: UUID): Unit = {
@@ -19,7 +19,7 @@ class EventFilter(distinctCheck: DynamoDistinctCheck) extends Logging {
     })
   }
 
-  private def filterNotification(notification: NotificationPayload)(implicit ec: ExecutionContext): Future[Option[NotificationPayload]] = {
+  private def filterNotification(notification: A)(implicit ec: ExecutionContext, writes: play.api.libs.json.Writes[A]): Future[Option[A]] = {
     if (!processedEvents.get.contains(notification.id)) {
       distinctCheck.insertNotification(notification).map {
         case Distinct =>
@@ -36,7 +36,7 @@ class EventFilter(distinctCheck: DynamoDistinctCheck) extends Logging {
     }
   }
 
-  def filterNotifications(notifications: List[NotificationPayload])(implicit ec: ExecutionContext): Future[List[NotificationPayload]] = {
+  def filterNotifications(notifications: List[A])(implicit ec: ExecutionContext, writes: play.api.libs.json.Writes[A]): Future[List[A]] = {
     Future.traverse(notifications)(filterNotification).map(_.flatten)
   }
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
@@ -10,11 +10,14 @@ import software.amazon.awssdk.services.eventbridge.model.{
   PutEventsRequestEntry,
   PutEventsResponse
 }
-
 import scala.util.Try
 
 // Temporary json formatters to test pushing match data - will be replaced once we know what we want to send.
 import play.api.libs.json.Writes
+import scala.concurrent.Future
+import scala.util.Success
+import scala.util.Failure
+import scala.concurrent.ExecutionContext
 
 class LiveActivityPusher extends Logging {
 
@@ -25,63 +28,74 @@ class LiveActivityPusher extends Logging {
       .builder()
       .build()
 
-  def pushToEventbus(events: List[LiveActivityPayload]) = {
+  def pushEvents(events: List[LiveActivityPayload])(implicit ec: ExecutionContext): Future[Unit] = {
 
     logger.info(
       "Eventbus pusher: number of events to push: " + events.size
     )
-    events.map(payload => {
+    Future.traverse(events)(pushToEventbus).map(_ => ())
+  }
+
+  def pushToEventbus(payload: LiveActivityPayload)(implicit ec: ExecutionContext): Future[Unit] = {
+
+    logger.info(
+      s"Eventbus pusher: Processing event with id ${payload.id}"
+    )
+    val jsonDetail = Json.toJson(payload).toString()
+    if (jsonDetail.isEmpty || jsonDetail == "{}") {
       logger.info(
-        s"Eventbus pusher: Processing event with id ${payload.eventId}"
+        s"Eventbus pusher: Skipping empty event for ${payload.id}"
       )
+      Future.successful(())
+    } else {
 
-      val jsonDetail = Json.toJson(payload).toString()
-      if (jsonDetail.isEmpty || jsonDetail == "{}") {
-        logger.info(
-          s"Eventbus pusher: Skipping empty event for ${payload.eventId}"
-        )
-      } else {
-
-        // TODO for the eventbus to direct the event to the right place
-        val activityType = payload.eventType match {
-          case CreateChannel      => "channel-create"
-          case StartLiveActivity  => "broadcast-start"
-          case UpdateLiveActivity => "broadcast-update"
-          case EndLiveActivity    => "broadcast-end"
-          case DeleteChannel      => "channel-delete"
-          case _ => "unknown"
-        }
-
-        val result = Try {
-          val entry = PutEventsRequestEntry
-            .builder()
-            .source("football-lambda")
-            .detailType(activityType)
-            .detail(Json.toJson(payload).toString())
-            .eventBusName(eventBusName)
-            .build()
-
-          val request = PutEventsRequest
-            .builder()
-            .entries(entry)
-            .build()
-
-          val response: PutEventsResponse = eventBridgeClient.putEvents(request)
-          logger.info(
-            s"Eventbus pusher: Event published. Failed entry count: ${response.failedEntryCount()}"
-          )
-          logger.info(
-            s"Eventbus pusher: Event details: ${Json.toJson(payload).toString()}"
-          )
-        }
-
-        result.failed.foreach(e =>
-          logger.error(
-            s"Eventbus pusher: Failed to publish event: ${e.getMessage}"
-          )
-        )
-
+      // TODO for the eventbus to direct the event to the right place
+      val activityType = payload.eventType match {
+        case CreateChannel      => "channel-create"
+        case StartLiveActivity  => "broadcast-start"
+        case UpdateLiveActivity => "broadcast-update"
+        case EndLiveActivity    => "broadcast-end"
+        case DeleteChannel      => "channel-delete"
+        case _ => "unknown"
       }
-    })
+
+      val result = Try {
+        val entry = PutEventsRequestEntry
+          .builder()
+          .source("football-lambda")
+          .detailType(activityType)
+          .detail(Json.toJson(payload).toString())
+          .eventBusName(eventBusName)
+          .build()
+
+        val request = PutEventsRequest
+          .builder()
+          .entries(entry)
+          .build()
+
+        val response: PutEventsResponse = eventBridgeClient.putEvents(request)
+        logger.info(
+          s"Eventbus pusher: Event published. Failed entry count: ${response.failedEntryCount()}"
+        )
+        logger.info(
+          s"Eventbus pusher: Event details: ${Json.toJson(payload).toString()}"
+        )
+      }
+
+      result match {
+        case Success(_) => {
+          logger.info(
+            s"Eventbus pusher: Successfully processed event with id ${payload.id}"
+          )
+          Future.successful(())
+        }
+        case Failure(e) => {
+          logger.error(
+            s"Eventbus pusher: Failed to publish event with id ${payload.id}: ${e.getMessage}"
+          )
+          Future.failed(e)
+        }
+      }
+    }
   }
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
@@ -1,33 +1,20 @@
 package com.gu.mobile.notifications.football.lib
 
+import com.gu.mobile.notifications.client.models.liveActitivites._
 import com.gu.mobile.notifications.football.Logging
 import com.gu.mobile.notifications.football.models.MatchDataWithArticle
 import play.api.libs.json.Json
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient
 import software.amazon.awssdk.services.eventbridge.model.{
   PutEventsRequest,
-  PutEventsRequestEntry
+  PutEventsRequestEntry,
+  PutEventsResponse
 }
 
 import scala.util.Try
 
-import play.api.libs.json.{Json, Writes}
-import pa._
-import MatchDataWithArticleJson._
-object MatchDataWithArticleJson {
-  implicit val writesStage: Writes[Stage] = Json.writes[Stage]
-  implicit val writesRound: Writes[Round] = Json.writes[Round]
-  implicit val writesMatchDayTeam: Writes[MatchDayTeam] =
-    Json.writes[MatchDayTeam]
-  implicit val writesOfficial: Writes[Official] = Json.writes[Official]
-  implicit val writesVenue: Writes[Venue] = Json.writes[Venue]
-  implicit val writesPlayer: Writes[Player] = Json.writes[Player]
-  implicit val writesCompetition: Writes[Competition] = Json.writes[Competition]
-  implicit val writesMatchDay: Writes[MatchDay] = Json.writes[MatchDay]
-  implicit val writesMatchEvent: Writes[MatchEvent] = Json.writes[MatchEvent]
-  implicit val writesMatchDataWithArticle: Writes[MatchDataWithArticle] =
-    Json.writes[MatchDataWithArticle]
-}
+// Temporary json formatters to test pushing match data - will be replaced once we know what we want to send.
+import play.api.libs.json.Writes
 
 class LiveActivityPusher extends Logging {
 
@@ -38,27 +25,39 @@ class LiveActivityPusher extends Logging {
       .builder()
       .build()
 
-  def pushToEventbus(matchDataList: List[MatchDataWithArticle]) = {
+  def pushToEventbus(events: List[LiveActivityPayload]) = {
 
-    println(
-      "Eventbus pusher: Try to push events to eventbus, number of events: " + matchDataList.size
+    logger.info(
+      "Eventbus pusher: number of events to push: " + events.size
     )
-    matchDataList.map(matchData => {
-      println(s"Eventbus pusher: Processing event for match with article id ${matchData.articleId}")
+    events.map(payload => {
+      logger.info(
+        s"Eventbus pusher: Processing event with id ${payload.eventId}"
+      )
 
-      val jsonDetail = Json.toJson(matchData).toString()
+      val jsonDetail = Json.toJson(payload).toString()
       if (jsonDetail.isEmpty || jsonDetail == "{}") {
-        println(
-          s"Eventbus pusher: Skipping empty event for ${matchData.matchDay.id}"
+        logger.info(
+          s"Eventbus pusher: Skipping empty event for ${payload.eventId}"
         )
       } else {
+
+        // TODO for the eventbus to direct the event to the right place
+        val activityType = payload.eventType match {
+          case CreateChannel      => "channel-create"
+          case StartLiveActivity  => "broadcast-start"
+          case UpdateLiveActivity => "broadcast-update"
+          case EndLiveActivity    => "broadcast-end"
+          case DeleteChannel      => "channel-delete"
+          case _ => "unknown"
+        }
 
         val result = Try {
           val entry = PutEventsRequestEntry
             .builder()
             .source("football-lambda")
-            .detailType("football-match-events-with-articleId")
-            .detail(Json.toJson(matchData).toString())
+            .detailType(activityType)
+            .detail(Json.toJson(payload).toString())
             .eventBusName(eventBusName)
             .build()
 
@@ -67,14 +66,16 @@ class LiveActivityPusher extends Logging {
             .entries(entry)
             .build()
 
-          val response = eventBridgeClient.putEvents(request)
-          println(
+          val response: PutEventsResponse = eventBridgeClient.putEvents(request)
+          logger.info(
             s"Eventbus pusher: Event published. Failed entry count: ${response.failedEntryCount()}"
           )
         }
 
         result.failed.foreach(e =>
-          println(s"Eventbus pusher: Failed to publish event: ${e.getMessage}")
+          logger.error(
+            s"Eventbus pusher: Failed to publish event: ${e.getMessage}"
+          )
         )
 
       }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
@@ -70,6 +70,9 @@ class LiveActivityPusher extends Logging {
           logger.info(
             s"Eventbus pusher: Event published. Failed entry count: ${response.failedEntryCount()}"
           )
+          logger.info(
+            Json.toJson(payload).toString()
+          )
         }
 
         result.failed.foreach(e =>

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
@@ -71,7 +71,7 @@ class LiveActivityPusher extends Logging {
             s"Eventbus pusher: Event published. Failed entry count: ${response.failedEntryCount()}"
           )
           logger.info(
-            Json.toJson(payload).toString()
+            s"Eventbus pusher: Event details: ${Json.toJson(payload).toString()}"
           )
         }
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -1,14 +1,7 @@
 package com.gu.mobile.notifications.football.notificationbuilders
 
 import com.gu.mobile.notifications.client.models._
-import com.gu.mobile.notifications.client.models.liveActitivites.{
-  FootballLiveActivity,
-  FootballMatchContentState,
-  LiveActivityPayload,
-  Scheduled,
-  TeamState,
-  Competition
-}
+import com.gu.mobile.notifications.client.models.liveActitivites.{Competition, FootballLiveActivity, FootballMatchContentState, LiveActivityPayload, Scheduled, TeamState, UpdateLiveActivity}
 import com.gu.mobile.notifications.football.models._
 import pa.MatchDay
 
@@ -67,7 +60,7 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
       articleUrl = articleId.map(id => s"$mapiHost/items/$id")
     )
 
-    val liveActivityEventType = ???
+    val liveActivityEventType = UpdateLiveActivity // todo
 
     LiveActivityPayload(
       eventType = liveActivityEventType, // start stop etc

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -1,0 +1,91 @@
+package com.gu.mobile.notifications.football.notificationbuilders
+
+import com.gu.mobile.notifications.client.models._
+import com.gu.mobile.notifications.client.models.liveActitivites.{
+  FootballLiveActivity,
+  FootballMatchContentState,
+  LiveActivityPayload,
+  Scheduled,
+  TeamState,
+  Competition
+}
+import com.gu.mobile.notifications.football.models._
+import pa.MatchDay
+
+import java.util.{Date, UUID}
+
+class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
+
+  def build(
+      triggeringEvent: FootballMatchEvent,
+      matchInfo: MatchDay,
+      previousEvents: List[FootballMatchEvent],
+      articleId: Option[String]
+  ): LiveActivityPayload = {
+
+    val topics = List(
+      Topic(TopicTypes.FootballTeam, matchInfo.homeTeam.id),
+      Topic(TopicTypes.FootballTeam, matchInfo.awayTeam.id),
+      Topic(TopicTypes.FootballMatch, matchInfo.id)
+    )
+
+    val allEvents = triggeringEvent :: previousEvents
+    val goals = allEvents.collect { case g: Goal => g }
+    val score = Score.fromGoals(matchInfo.homeTeam, matchInfo.awayTeam, goals)
+//    val dismissals = ??? // todo needs to be calcualted from Dismissal events
+
+    val dynamoData = ""
+
+    // TODO this is hard coded mostly for now.
+    val contentState = FootballMatchContentState(
+      matchStatus = Scheduled,
+      kickOffTimestamp = matchInfo.date.toEpochSecond, // included date and time
+      homeTeam = TeamState(
+        name = transformTeamName(matchInfo.homeTeam.name),
+        score = score.home,
+        logoAssetName = None, // tbc
+        teamUrl = None, // tbc
+        penaltyScore = None, // tbc
+        redCards = None // tbc
+      ),
+      awayTeam = TeamState(
+        name = transformTeamName(matchInfo.awayTeam.name),
+        score = score.away,
+        logoAssetName = None, // tbc
+        teamUrl = None, // tbc
+        penaltyScore = None, // tbc
+        redCards = None // tbc
+      ),
+      competition = Competition(
+        id = matchInfo.competition.map(_.id).getOrElse(""),
+        name = matchInfo.competition.map(_.name).getOrElse("")
+      ),
+      commentary = matchInfo.comments,
+      lineupsAvailable = None, // Booliean   // not available on LiveMatch
+      currentMinute = None, // not available on LiveMatch
+      currentPeriodStartTime = None,
+      articleUrl = articleId.map(id => s"$mapiHost/items/$id")
+    )
+
+    val liveActivityEventType = ???
+
+    LiveActivityPayload(
+      eventType = liveActivityEventType, // start stop etc
+      eventId =
+        UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
+      liveActivityType = FootballLiveActivity,
+      liveActivityID =
+        matchInfo.id, // Match ID in the case of football, tbc for other sports/events
+      dynamoStoreData = Some(dynamoData), //  TBC
+      broadcastContentStateData = Some(contentState),
+      // todo
+      eventTimestamp =
+        new Date().getTime, // tbc - should this be the event time of the triggering event or the minute it happened??? ?
+      topics = topics
+    )
+
+  }
+
+  def transformTeamName(name: String): String = name.replace(" Ladies", "")
+
+}

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -63,9 +63,9 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
     val liveActivityEventType = UpdateLiveActivity // todo
 
     LiveActivityPayload(
+      id =
+        UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes),
       eventType = liveActivityEventType, // start stop etc
-      eventId =
-        UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
       liveActivityType = FootballLiveActivity,
       liveActivityID =
         matchInfo.id, // Match ID in the case of football, tbc for other sports/events

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastFixtures.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastFixtures.scala
@@ -1,6 +1,7 @@
 package com.gu.liveactivities
 
 import com.gu.liveactivities.models._
+import com.gu.mobile.notifications.client.models.liveActitivites.{Competition, FootballMatchContentState, FullTime, Scheduled, SecondHalf, TeamState}
 
 object BroadcastFixtures {
   def fifteenMinutesFromNowEpochSeconds: Long = (System.currentTimeMillis() / 1000L) + 15 * 60

--- a/liveactivities/src/main/scala/com/gu/liveactivities/models/BroadcastPayloads.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/models/BroadcastPayloads.scala
@@ -1,108 +1,8 @@
 package com.gu.liveactivities.models
 
+import com.gu.mobile.notifications.client.models.liveActitivites.ContentState
 import play.api.libs.json._
-
-// GENERIC CONTENT STATE //////////////////////////////////////////////////
-
-sealed trait ContentState
-object ContentState {
-  import FootballContentJsonFormats._
-
-  implicit val format: OFormat[ContentState] = new OFormat[ContentState] {
-    def writes(cs: ContentState): JsObject = cs match {
-      case f: FootballMatchContentState =>
-        footballMatchContentStateFormat
-          .writes(f)
-          .as[JsObject] + ("type" -> JsString("football"))
-      // Add cases for other ContentState subtypes here
-    }
-
-    def reads(json: JsValue): JsResult[ContentState] = {
-      (json \ "type").validate[String].flatMap {
-        case "football" => footballMatchContentStateFormat.reads(json)
-        // Add cases for other ContentState subtypes here
-        case other => JsError(s"Unknown ContentState type: $other")
-      }
-    }
-  }
-}
-
-// FOOTBALL CONTENT STATE //////////////////////////////////////////////////
-// @formatter:off
-sealed trait MatchStatus { val status: String }
-case object Scheduled extends MatchStatus { val status = "SCHEDULED" }
-case object PreMatch extends MatchStatus { val status = "PRE_MATCH" }
-case object FirstHalf extends MatchStatus { val status = "FIRST_HALF" }
-case object HalfTime extends MatchStatus { val status = "HALF_TIME" }
-case object SecondHalf extends MatchStatus { val status = "SECOND_HALF" }
-case object ExtraTimeFirstHalf extends MatchStatus { val status = "EXTRA_TIME_FIRST_HALF" }
-case object ExtraTimeHalfTime extends MatchStatus { val status = "EXTRA_TIME_HALF_TIME" }
-case object ExtraTimeSecondHalf extends MatchStatus { val status = "EXTRA_TIME_SECOND_HALF" }
-case object Penalties extends MatchStatus { val status = "PENALTIES" }
-case object FullTime extends MatchStatus { val status = "FULL_TIME" }
-case object Postponed extends MatchStatus { val status = "POSTPONED" }
-case object Abandoned extends MatchStatus { val status = "ABANDONED" }
-// @formatter:on
-
-case class Competition(
-    id: String,
-    name: String,
-    round: Option[String] = None
-)
-
-case class TeamState(
-    name: String,
-    score: Int,
-    logoAssetName: Option[String] = None,
-    teamUrl: Option[String] = None,
-    penaltyScore: Option[Int] = None,
-    redCards: Option[Int] = None
-)
-
-case class FootballMatchContentState(
-    matchStatus: MatchStatus,
-    kickOffTimestamp: Long,
-    homeTeam: TeamState,
-    awayTeam: TeamState,
-    competition: Competition,
-    commentary: Option[String] = None,
-    lineupsAvailable: Option[Boolean] = None,
-    currentMinute: Option[Int] = None,
-    currentPeriodStartTime: Option[Long] = None,
-    articleUrl: Option[String] = None
-) extends ContentState
-
-object FootballContentJsonFormats {
-  // MatchStatus format must be defined first since FootballMatchContentState depends on it
-  implicit val matchStatusFormat: Format[MatchStatus] = Format(
-    Reads {
-      case JsString(s) =>
-        s match {
-          case "SCHEDULED"              => JsSuccess(Scheduled)
-          case "PRE_MATCH"              => JsSuccess(PreMatch)
-          case "FIRST_HALF"             => JsSuccess(FirstHalf)
-          case "HALF_TIME"              => JsSuccess(HalfTime)
-          case "SECOND_HALF"            => JsSuccess(SecondHalf)
-          case "EXTRA_TIME_FIRST_HALF"  => JsSuccess(ExtraTimeFirstHalf)
-          case "EXTRA_TIME_HALF_TIME"   => JsSuccess(ExtraTimeHalfTime)
-          case "EXTRA_TIME_SECOND_HALF" => JsSuccess(ExtraTimeSecondHalf)
-          case "PENALTIES"              => JsSuccess(Penalties)
-          case "FULL_TIME"              => JsSuccess(FullTime)
-          case "POSTPONED"              => JsSuccess(Postponed)
-          case "ABANDONED"              => JsSuccess(Abandoned)
-          case other                    => JsError(s"Unknown match status: $other")
-        }
-      case _ => JsError("Expected a JSON string for MatchStatus")
-    },
-    Writes(ms => JsString(ms.status))
-  )
-
-  implicit val competitionFormat: OFormat[Competition] =
-    Json.format[Competition]
-  implicit val teamStateFormat: OFormat[TeamState] = Json.format[TeamState]
-  implicit val footballMatchContentStateFormat: OFormat[FootballMatchContentState] =
-    Json.format[FootballMatchContentState]
-}
+import pa._
 
 // BROADCAST PAYLOADS //////////////////////////////////////////////////
 
@@ -201,7 +101,7 @@ case class BroadcastEndBody(
 
 object BroadcastJsonFormats {
   import ActivityAttributesJsonFormats._
-  import FootballContentJsonFormats._
+  import com.gu.mobile.notifications.client.models.liveActitivites.FootballContentJsonFormats._
   import ContentState.format
 
   implicit val broadcastStartApsFormat: OFormat[BroadcastStartAps] =


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request makes the following changes to live activity prototype:
1. Refactor the Content State" data model
2. Define the payload model for messages the football lambda sends to eventbus
3. Refactor the football lambda to process a football match event for notification and for live activity independently
4. Add an initial version of live activity processing.  It builds a payload and sends to the event bus (WIP).