### PR TITLE
Add `metals.sbt` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dynamodb-local-schedule-lambda/
 **.DS_Store
 
 .metals/
+metals.sbt
 .vscode/
 .bloop/
 project/.bloop/


### PR DESCRIPTION
It's a file generated by the VSCode Metals extension for Scala.
