### PR TITLE
Calculate red cards for each football term per event

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
@@ -76,11 +76,11 @@ case class Competition(
 
 case class TeamState(
     name: String,
-    score: Int,
+    score: Int = 0,
     logoAssetName: Option[String] = None,
     teamUrl: Option[String] = None,
     penaltyScore: Option[Int] = None,
-    redCards: Option[Int] = None
+    redCards: Int = 0
 )
 
 case class FootballMatchContentState(

--- a/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
@@ -27,6 +27,16 @@ object Score {
 
 case class Score(home: Int, away: Int)
 
+object RedCards {
+  def fromDismissals(homeTeam: pa.MatchDayTeam, awayTeam: pa.MatchDayTeam, dismissals: List[Dismissal]): RedCards = {
+    val home = dismissals.count(_.team == homeTeam)
+    val away = dismissals.count(_.team == awayTeam)
+
+    RedCards(home, away)
+  }
+}
+case class RedCards(home: Int, away: Int)
+
 case class Dismissal(
   eventId: String,
   playerName: String,

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -10,11 +10,11 @@ import java.util.{Date, UUID}
 class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
 
   def build(
-             triggeringEvent: FootballMatchEvent,
-             matchInfo: MatchDay,
-             previousEvents: List[FootballMatchEvent],
-             articleId: Option[String]
-           ): LiveActivityPayload = {
+      triggeringEvent: FootballMatchEvent,
+      matchInfo: MatchDay,
+      previousEvents: List[FootballMatchEvent],
+      articleId: Option[String]
+  ): LiveActivityPayload = {
 
     val topics = List(
       Topic(TopicTypes.FootballTeam, matchInfo.homeTeam.id),
@@ -25,7 +25,8 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
     val allEvents = triggeringEvent :: previousEvents
     val goals = allEvents.collect { case g: Goal => g }
     val score = Score.fromGoals(matchInfo.homeTeam, matchInfo.awayTeam, goals)
-    //    val dismissals = ??? // todo needs to be calcualted from Dismissal events
+    val dismissals = allEvents.collect { case d: Dismissal => d }
+    val redCards = RedCards.fromDismissals(matchInfo.homeTeam, matchInfo.awayTeam, dismissals)
 
     val dynamoData = ""
 
@@ -39,7 +40,7 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
         logoAssetName = None, // tbc
         teamUrl = None, // tbc
         penaltyScore = None, // tbc
-        redCards = None // tbc
+        redCards = redCards.home
       ),
       awayTeam = TeamState(
         name = transformTeamName(matchInfo.awayTeam.name),
@@ -47,13 +48,14 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
         logoAssetName = None, // tbc
         teamUrl = None, // tbc
         penaltyScore = None, // tbc
-        redCards = None // tbc
+        redCards = redCards.away
       ),
       competition = Competition(
-        name = matchInfo.competition.map(_.name).getOrElse("")
+        name = matchInfo.competition.map(_.name).getOrElse(""),
+        round = matchInfo.round.name // World Cup Group
       ),
       commentary = matchInfo.comments,
-      lineupsAvailable = None, // Booliean   // not available on LiveMatch
+      lineupsAvailable = None, // Boolean   // not available on LiveMatch
       currentMinute = None, // not available on LiveMatch
       currentPeriodStartTime = None,
       articleUrl = articleId.map(id => s"$mapiHost/items/$id")

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastFixtures.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastFixtures.scala
@@ -22,7 +22,7 @@ object BroadcastFixtures {
           logoAssetName = None,
           teamUrl = None,
           penaltyScore = None,
-          redCards = None
+          redCards = 0
         ),
         awayTeam = TeamState(
           name = "Wolverhampton",
@@ -30,7 +30,7 @@ object BroadcastFixtures {
           logoAssetName = None,
           teamUrl = None,
           penaltyScore = None,
-          redCards = None
+          redCards = 0
         ),
         competition = Competition(
           name = "FIFA World Cup 2026",
@@ -63,7 +63,7 @@ object BroadcastFixtures {
           logoAssetName = None,
           teamUrl = None,
           penaltyScore = None,
-          redCards = Some(0)
+          redCards = 0
         ),
         awayTeam = TeamState(
           name = "Chelsea",
@@ -71,7 +71,7 @@ object BroadcastFixtures {
           logoAssetName = None,
           teamUrl = None,
           penaltyScore = None,
-          redCards = Some(0)
+          redCards = 1
         ),
         competition = Competition(
           name = "FIFA World Cup 2026",
@@ -100,7 +100,7 @@ object BroadcastFixtures {
           logoAssetName = None,
           teamUrl = None,
           penaltyScore = None,
-          redCards = Some(0)
+          redCards = 1
         ),
         awayTeam = TeamState(
           name = "Chelsea",
@@ -108,7 +108,7 @@ object BroadcastFixtures {
           logoAssetName = None,
           teamUrl = None,
           penaltyScore = None,
-          redCards = Some(1)
+          redCards = 2
         ),
         competition = Competition(
           name = "FIFA World Cup 2026",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Replace #1755  to clean up commit history since prototype branch was merged. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
