### PR TITLE
Deduplicate liveactivities payload events

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
@@ -1,9 +1,8 @@
 package com.gu.mobile.notifications.client.models.liveActitivites
 
-import com.gu.mobile.notifications.client.models.Topic
+import com.gu.mobile.notifications.client.models.{Payload, Topic}
 import play.api.libs.json.{JsString, Json, Writes}
 import java.util.UUID
-import com.gu.mobile.notifications.client.models.Payload
 
 /**
  * These are the models for eventbus payloads shared between live activity services.

--- a/cdk/lib/__snapshots__/footballnotificationslambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/footballnotificationslambda.test.ts.snap
@@ -8,6 +8,8 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for CODE 1`]
       "GuScheduledLambda",
       "GuAlarm",
       "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -71,7 +73,7 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for CODE 1`]
     },
     "ErrorEventMetricFilter9872E3AE": {
       "Properties": {
-        "FilterPattern": "Error",
+        "FilterPattern": "Error sending match status",
         "LogGroupName": {
           "Fn::Join": [
             "",
@@ -87,6 +89,30 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for CODE 1`]
           {
             "MetricName": "error",
             "MetricNamespace": "CODE/football-notifications",
+            "MetricValue": "1",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+    "ErrorLiveActivitiesEventMetricFilterB40B00CE": {
+      "Properties": {
+        "FilterPattern": "Failed to publish live activities event",
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "footballLambdaAE03EC83",
+              },
+            ],
+          ],
+        },
+        "MetricTransformations": [
+          {
+            "MetricName": "error",
+            "MetricNamespace": "CODE/liveactivities-payload",
             "MetricValue": "1",
           },
         ],
@@ -116,6 +142,171 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for CODE 1`]
         ],
       },
       "Type": "AWS::Logs::MetricFilter",
+    },
+    "LiveActivitiesDynamoTable655B0994": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "id",
+            "AttributeType": "S",
+          },
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "id",
+            "KeyType": "HASH",
+          },
+        ],
+        "TableName": "mobile-notifications-liveactivities-payload-CODE",
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TimeToLiveSpecification": {
+          "AttributeName": "ttl",
+          "Enabled": true,
+        },
+      },
+      "Type": "AWS::DynamoDB::Table",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "MobileLiveActivitiesFootballConsumedReadThrottleEventsC09E6745": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":dynamodb",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if DynamoDB ReadThrottleEvents >= 10 in 5 minutes",
+        "AlarmName": "MobileLiveActivitiesFootballConsumedReadThrottleEvents-CODE",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "TableName",
+            "Value": "mobile-notifications-liveactivities-payload-CODE",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ReadThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+        "Unit": "Count",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MobileLiveActivitiesFootballConsumedWriteThrottleEvents28E4A6AF": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":dynamodb",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if DynamoDB WriteThrottleEvents >= 10 in 5 minutes",
+        "AlarmName": "MobileLiveActivitiesFootballConsumedWriteThrottleEvents-CODE",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "TableName",
+            "Value": "mobile-notifications-liveactivities-payload-CODE",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "WriteThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+        "Unit": "Count",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "MobileNotificationsFootballConsumedReadThrottleEvents9A50CD73": {
       "Properties": {
@@ -234,6 +425,30 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for CODE 1`]
         "Unit": "Count",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "SuccessLiveActivitiesEventMetricFilter6C8ACAEF": {
+      "Properties": {
+        "FilterPattern": "Successfully processed live activities event",
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "footballLambdaAE03EC83",
+              },
+            ],
+          ],
+        },
+        "MetricTransformations": [
+          {
+            "MetricName": "success",
+            "MetricNamespace": "CODE/liveactivities-payload",
+            "MetricValue": "1",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
     },
     "footballLambdaAE03EC83": {
       "DependsOn": [
@@ -485,6 +700,48 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for CODE 1`]
                 "dynamodb:Query",
               ],
               "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:dynamodb:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":table/mobile-notifications-football-notifications-CODE",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:dynamodb:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":table/mobile-notifications-liveactivities-payload-CODE",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:Query",
+              ],
+              "Effect": "Allow",
               "Resource": {
                 "Fn::Join": [
                   "",
@@ -585,6 +842,8 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for PROD 1`]
       "GuScheduledLambda",
       "GuAlarm",
       "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -648,7 +907,7 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for PROD 1`]
     },
     "ErrorEventMetricFilter9872E3AE": {
       "Properties": {
-        "FilterPattern": "Error",
+        "FilterPattern": "Error sending match status",
         "LogGroupName": {
           "Fn::Join": [
             "",
@@ -664,6 +923,30 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for PROD 1`]
           {
             "MetricName": "error",
             "MetricNamespace": "PROD/football-notifications",
+            "MetricValue": "1",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+    "ErrorLiveActivitiesEventMetricFilterB40B00CE": {
+      "Properties": {
+        "FilterPattern": "Failed to publish live activities event",
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "footballLambdaAE03EC83",
+              },
+            ],
+          ],
+        },
+        "MetricTransformations": [
+          {
+            "MetricName": "error",
+            "MetricNamespace": "PROD/liveactivities-payload",
             "MetricValue": "1",
           },
         ],
@@ -693,6 +976,171 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for PROD 1`]
         ],
       },
       "Type": "AWS::Logs::MetricFilter",
+    },
+    "LiveActivitiesDynamoTable655B0994": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "id",
+            "AttributeType": "S",
+          },
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "id",
+            "KeyType": "HASH",
+          },
+        ],
+        "TableName": "mobile-notifications-liveactivities-payload-PROD",
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "TimeToLiveSpecification": {
+          "AttributeName": "ttl",
+          "Enabled": true,
+        },
+      },
+      "Type": "AWS::DynamoDB::Table",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "MobileLiveActivitiesFootballConsumedReadThrottleEventsC09E6745": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":dynamodb",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if DynamoDB ReadThrottleEvents >= 10 in 5 minutes",
+        "AlarmName": "MobileLiveActivitiesFootballConsumedReadThrottleEvents-PROD",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "TableName",
+            "Value": "mobile-notifications-liveactivities-payload-PROD",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ReadThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+        "Unit": "Count",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MobileLiveActivitiesFootballConsumedWriteThrottleEvents28E4A6AF": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":dynamodb",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if DynamoDB WriteThrottleEvents >= 10 in 5 minutes",
+        "AlarmName": "MobileLiveActivitiesFootballConsumedWriteThrottleEvents-PROD",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "TableName",
+            "Value": "mobile-notifications-liveactivities-payload-PROD",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "WriteThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "Period": 300,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+        "Unit": "Count",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "MobileNotificationsFootballConsumedReadThrottleEvents9A50CD73": {
       "Properties": {
@@ -811,6 +1259,30 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for PROD 1`]
         "Unit": "Count",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "SuccessLiveActivitiesEventMetricFilter6C8ACAEF": {
+      "Properties": {
+        "FilterPattern": "Successfully processed live activities event",
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "footballLambdaAE03EC83",
+              },
+            ],
+          ],
+        },
+        "MetricTransformations": [
+          {
+            "MetricName": "success",
+            "MetricNamespace": "PROD/liveactivities-payload",
+            "MetricValue": "1",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
     },
     "footballLambdaAE03EC83": {
       "DependsOn": [
@@ -1054,6 +1526,48 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for PROD 1`]
                   ],
                 ],
               },
+            },
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:Query",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:dynamodb:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":table/mobile-notifications-football-notifications-PROD",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:dynamodb:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":table/mobile-notifications-liveactivities-payload-PROD",
+                    ],
+                  ],
+                },
+              ],
             },
             {
               "Action": [

--- a/cdk/lib/footballnotificationslambda.ts
+++ b/cdk/lib/footballnotificationslambda.ts
@@ -88,12 +88,29 @@ export class FootballNotificationsLambda extends GuStack {
 
 		Tags.of(dynamoTable).add('devx-backup-enabled', 'true');
 
+    // Live Activities DynamoDB Table
+    const liveActivitiesAppName = 'liveactivities';
+    const liveActivitiesDynamoTableName = `${stack}-${liveActivitiesAppName}-payload-${stage}`;
+
+    const liveActivitiesDynamoTable = new Table(
+      this,
+      'LiveActivitiesDynamoTable',
+      {
+        tableName: liveActivitiesDynamoTableName,
+        partitionKey: { name: 'id', type: AttributeType.STRING },
+        billingMode: BillingMode.PAY_PER_REQUEST,
+        timeToLiveAttribute: 'ttl',
+      },
+    );
+    Tags.of(liveActivitiesDynamoTable).add('devx-backup-enabled', 'true');
+
 		footballnotificationslambda.addToRolePolicy(
 			new PolicyStatement({
 				actions: ['dynamodb:PutItem', 'dynamodb:UpdateItem', 'dynamodb:Query'],
 				effect: Effect.ALLOW,
 				resources: [
 					`arn:aws:dynamodb:${region}:${account}:table/${dynamoTableName}`,
+          `arn:aws:dynamodb:${region}:${account}:table/${liveActivitiesDynamoTableName}`,
 				],
 			}),
 		);
@@ -155,6 +172,58 @@ export class FootballNotificationsLambda extends GuStack {
 			},
 		);
 
+    // Read Live Activities Throttle Events Alarm
+    new GuAlarm(
+      this,
+      'MobileLiveActivitiesFootballConsumedReadThrottleEvents',
+      {
+        app,
+        alarmName: `MobileLiveActivitiesFootballConsumedReadThrottleEvents-${stage}`,
+        alarmDescription:
+          'Triggers if DynamoDB ReadThrottleEvents >= 10 in 5 minutes',
+        snsTopicName: 'dynamodb',
+        metric: new Metric({
+          namespace: 'AWS/DynamoDB',
+          metricName: 'ReadThrottleEvents',
+          dimensionsMap: { TableName: liveActivitiesDynamoTableName },
+          period: Duration.minutes(5),
+          statistic: 'sum',
+          unit: Unit.COUNT,
+        }),
+        threshold: 10,
+        evaluationPeriods: 1,
+        comparisonOperator:
+        ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+      },
+    );
+
+    // Write Live Activities Throttle Events Alarm
+    new GuAlarm(
+      this,
+      'MobileLiveActivitiesFootballConsumedWriteThrottleEvents',
+      {
+        app,
+        alarmName: `MobileLiveActivitiesFootballConsumedWriteThrottleEvents-${stage}`,
+        alarmDescription:
+          'Triggers if DynamoDB WriteThrottleEvents >= 10 in 5 minutes',
+        snsTopicName: 'dynamodb',
+        metric: new Metric({
+          namespace: 'AWS/DynamoDB',
+          metricName: 'WriteThrottleEvents',
+          dimensionsMap: { TableName: liveActivitiesDynamoTableName },
+          period: Duration.minutes(5),
+          statistic: 'sum',
+          unit: Unit.COUNT,
+        }),
+        threshold: 10,
+        evaluationPeriods: 1,
+        comparisonOperator:
+        ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+      },
+    );
+
 		const footballNotificationLambdaLogGroupName = `/aws/lambda/${footballnotificationslambda.functionName}`;
 		const footballNotificationLambdaLogGroup = LogGroup.fromLogGroupName(
 			this,
@@ -174,10 +243,32 @@ export class FootballNotificationsLambda extends GuStack {
 		// ErrorEvent MetricFilter
 		new MetricFilter(this, 'ErrorEventMetricFilter', {
 			logGroup: footballNotificationLambdaLogGroup,
-			filterPattern: { logPatternString: 'Error' },
+      filterPattern: { logPatternString: 'Error sending match status' },
 			metricNamespace: `${stage}/football-notifications`,
 			metricName: 'error',
 			metricValue: '1',
 		});
+
+    // Live Activities Event MetricFilter
+    new MetricFilter(this, 'SuccessLiveActivitiesEventMetricFilter', {
+      logGroup: footballNotificationLambdaLogGroup,
+      filterPattern: {
+        logPatternString: 'Successfully processed live activities event',
+      },
+      metricNamespace: `${stage}/${liveActivitiesAppName}-payload`,
+      metricName: 'success',
+      metricValue: '1',
+    });
+
+    // Live Activities ErrorEvent MetricFilter
+    new MetricFilter(this, 'ErrorLiveActivitiesEventMetricFilter', {
+      logGroup: footballNotificationLambdaLogGroup,
+      filterPattern: {
+        logPatternString: 'Failed to publish live activities event',
+      },
+      metricNamespace: `${stage}/${liveActivitiesAppName}-payload`,
+      metricName: 'error',
+      metricValue: '1',
+    });
 	}
 }

--- a/cdk/lib/footballnotificationslambda.ts
+++ b/cdk/lib/footballnotificationslambda.ts
@@ -88,21 +88,21 @@ export class FootballNotificationsLambda extends GuStack {
 
 		Tags.of(dynamoTable).add('devx-backup-enabled', 'true');
 
-    // Live Activities DynamoDB Table
-    const liveActivitiesAppName = 'liveactivities';
-    const liveActivitiesDynamoTableName = `${stack}-${liveActivitiesAppName}-payload-${stage}`;
+		// Live Activities DynamoDB Table
+		const liveActivitiesAppName = 'liveactivities';
+		const liveActivitiesDynamoTableName = `${stack}-${liveActivitiesAppName}-payload-${stage}`;
 
-    const liveActivitiesDynamoTable = new Table(
-      this,
-      'LiveActivitiesDynamoTable',
-      {
-        tableName: liveActivitiesDynamoTableName,
-        partitionKey: { name: 'id', type: AttributeType.STRING },
-        billingMode: BillingMode.PAY_PER_REQUEST,
-        timeToLiveAttribute: 'ttl',
-      },
-    );
-    Tags.of(liveActivitiesDynamoTable).add('devx-backup-enabled', 'true');
+		const liveActivitiesDynamoTable = new Table(
+			this,
+			'LiveActivitiesDynamoTable',
+			{
+				tableName: liveActivitiesDynamoTableName,
+				partitionKey: { name: 'id', type: AttributeType.STRING },
+				billingMode: BillingMode.PAY_PER_REQUEST,
+				timeToLiveAttribute: 'ttl',
+			},
+		);
+		Tags.of(liveActivitiesDynamoTable).add('devx-backup-enabled', 'true');
 
 		footballnotificationslambda.addToRolePolicy(
 			new PolicyStatement({
@@ -110,7 +110,7 @@ export class FootballNotificationsLambda extends GuStack {
 				effect: Effect.ALLOW,
 				resources: [
 					`arn:aws:dynamodb:${region}:${account}:table/${dynamoTableName}`,
-          `arn:aws:dynamodb:${region}:${account}:table/${liveActivitiesDynamoTableName}`,
+					`arn:aws:dynamodb:${region}:${account}:table/${liveActivitiesDynamoTableName}`,
 				],
 			}),
 		);
@@ -172,57 +172,57 @@ export class FootballNotificationsLambda extends GuStack {
 			},
 		);
 
-    // Read Live Activities Throttle Events Alarm
-    new GuAlarm(
-      this,
-      'MobileLiveActivitiesFootballConsumedReadThrottleEvents',
-      {
-        app,
-        alarmName: `MobileLiveActivitiesFootballConsumedReadThrottleEvents-${stage}`,
-        alarmDescription:
-          'Triggers if DynamoDB ReadThrottleEvents >= 10 in 5 minutes',
-        snsTopicName: 'dynamodb',
-        metric: new Metric({
-          namespace: 'AWS/DynamoDB',
-          metricName: 'ReadThrottleEvents',
-          dimensionsMap: { TableName: liveActivitiesDynamoTableName },
-          period: Duration.minutes(5),
-          statistic: 'sum',
-          unit: Unit.COUNT,
-        }),
-        threshold: 10,
-        evaluationPeriods: 1,
-        comparisonOperator:
-        ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        treatMissingData: TreatMissingData.NOT_BREACHING,
-      },
-    );
+		// Read Live Activities Throttle Events Alarm
+		new GuAlarm(
+			this,
+			'MobileLiveActivitiesFootballConsumedReadThrottleEvents',
+			{
+				app,
+				alarmName: `MobileLiveActivitiesFootballConsumedReadThrottleEvents-${stage}`,
+				alarmDescription:
+					'Triggers if DynamoDB ReadThrottleEvents >= 10 in 5 minutes',
+				snsTopicName: 'dynamodb',
+				metric: new Metric({
+					namespace: 'AWS/DynamoDB',
+					metricName: 'ReadThrottleEvents',
+					dimensionsMap: { TableName: liveActivitiesDynamoTableName },
+					period: Duration.minutes(5),
+					statistic: 'sum',
+					unit: Unit.COUNT,
+				}),
+				threshold: 10,
+				evaluationPeriods: 1,
+				comparisonOperator:
+					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+				treatMissingData: TreatMissingData.NOT_BREACHING,
+			},
+		);
 
-    // Write Live Activities Throttle Events Alarm
-    new GuAlarm(
-      this,
-      'MobileLiveActivitiesFootballConsumedWriteThrottleEvents',
-      {
-        app,
-        alarmName: `MobileLiveActivitiesFootballConsumedWriteThrottleEvents-${stage}`,
-        alarmDescription:
-          'Triggers if DynamoDB WriteThrottleEvents >= 10 in 5 minutes',
-        snsTopicName: 'dynamodb',
-        metric: new Metric({
-          namespace: 'AWS/DynamoDB',
-          metricName: 'WriteThrottleEvents',
-          dimensionsMap: { TableName: liveActivitiesDynamoTableName },
-          period: Duration.minutes(5),
-          statistic: 'sum',
-          unit: Unit.COUNT,
-        }),
-        threshold: 10,
-        evaluationPeriods: 1,
-        comparisonOperator:
-        ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        treatMissingData: TreatMissingData.NOT_BREACHING,
-      },
-    );
+		// Write Live Activities Throttle Events Alarm
+		new GuAlarm(
+			this,
+			'MobileLiveActivitiesFootballConsumedWriteThrottleEvents',
+			{
+				app,
+				alarmName: `MobileLiveActivitiesFootballConsumedWriteThrottleEvents-${stage}`,
+				alarmDescription:
+					'Triggers if DynamoDB WriteThrottleEvents >= 10 in 5 minutes',
+				snsTopicName: 'dynamodb',
+				metric: new Metric({
+					namespace: 'AWS/DynamoDB',
+					metricName: 'WriteThrottleEvents',
+					dimensionsMap: { TableName: liveActivitiesDynamoTableName },
+					period: Duration.minutes(5),
+					statistic: 'sum',
+					unit: Unit.COUNT,
+				}),
+				threshold: 10,
+				evaluationPeriods: 1,
+				comparisonOperator:
+					ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+				treatMissingData: TreatMissingData.NOT_BREACHING,
+			},
+		);
 
 		const footballNotificationLambdaLogGroupName = `/aws/lambda/${footballnotificationslambda.functionName}`;
 		const footballNotificationLambdaLogGroup = LogGroup.fromLogGroupName(
@@ -243,32 +243,32 @@ export class FootballNotificationsLambda extends GuStack {
 		// ErrorEvent MetricFilter
 		new MetricFilter(this, 'ErrorEventMetricFilter', {
 			logGroup: footballNotificationLambdaLogGroup,
-      filterPattern: { logPatternString: 'Error sending match status' },
+			filterPattern: { logPatternString: 'Error sending match status' },
 			metricNamespace: `${stage}/football-notifications`,
 			metricName: 'error',
 			metricValue: '1',
 		});
 
-    // Live Activities Event MetricFilter
-    new MetricFilter(this, 'SuccessLiveActivitiesEventMetricFilter', {
-      logGroup: footballNotificationLambdaLogGroup,
-      filterPattern: {
-        logPatternString: 'Successfully processed live activities event',
-      },
-      metricNamespace: `${stage}/${liveActivitiesAppName}-payload`,
-      metricName: 'success',
-      metricValue: '1',
-    });
+		// Live Activities Event MetricFilter
+		new MetricFilter(this, 'SuccessLiveActivitiesEventMetricFilter', {
+			logGroup: footballNotificationLambdaLogGroup,
+			filterPattern: {
+				logPatternString: 'Successfully processed live activities event',
+			},
+			metricNamespace: `${stage}/${liveActivitiesAppName}-payload`,
+			metricName: 'success',
+			metricValue: '1',
+		});
 
-    // Live Activities ErrorEvent MetricFilter
-    new MetricFilter(this, 'ErrorLiveActivitiesEventMetricFilter', {
-      logGroup: footballNotificationLambdaLogGroup,
-      filterPattern: {
-        logPatternString: 'Failed to publish live activities event',
-      },
-      metricNamespace: `${stage}/${liveActivitiesAppName}-payload`,
-      metricName: 'error',
-      metricValue: '1',
-    });
+		// Live Activities ErrorEvent MetricFilter
+		new MetricFilter(this, 'ErrorLiveActivitiesEventMetricFilter', {
+			logGroup: footballNotificationLambdaLogGroup,
+			filterPattern: {
+				logPatternString: 'Failed to publish live activities event',
+			},
+			metricNamespace: `${stage}/${liveActivitiesAppName}-payload`,
+			metricName: 'error',
+			metricValue: '1',
+		});
 	}
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -63,11 +63,6 @@ object Lambda extends Logging {
 
   lazy val liveActivityHandler = new LiveActivityHandler(configuration, dynamoDBClient, liveActivitiesTableName)
 
-  // live activities //
-  lazy val liveActivityPusher = new LiveActivityPusher()
-  lazy val matchStatusLiveActivityPayloadBuilder = new MatchStatusLiveActivityPayloadBuilder(configuration.mapiHost)
-  lazy val liveActivityEventConsumer = new LiveActivityEventConsumer(matchStatusLiveActivityPayloadBuilder)
-
   def getZonedDateTime(): ZonedDateTime = {
     val zonedDateTime = if (configuration.stage == "CODE") {
       val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder}
 import com.gu.contentapi.client.GuardianContentClient
-import com.gu.mobile.notifications.football.lib.{ArticleSearcher, DynamoDistinctCheck, EventConsumer, LiveActivityEventConsumer, EventFilter, FootballData, LiveActivityPusher, NotificationHttpProvider, NotificationSender, NotificationsApiClient, PaFootballClient, SyntheticMatchEventGenerator}
+import com.gu.mobile.notifications.football.lib.{ArticleSearcher, DynamoDistinctCheck, DynamoMatchLiveActivity, DynamoMatchNotification, EventConsumer, EventFilter, FootballData, LiveActivityEventConsumer, LiveActivityPusher, NotificationHttpProvider, NotificationSender, NotificationsApiClient, PaFootballClient, SyntheticMatchEventGenerator}
 import com.gu.mobile.notifications.football.notificationbuilders.{MatchStatusLiveActivityPayloadBuilder, MatchStatusNotificationBuilder}
 import play.api.libs.json.Json
 
@@ -18,13 +18,16 @@ import scala.util.Failure
 import com.gu.mobile.notifications.client.models.NotificationPayload
 import com.gu.mobile.notifications.client.models.liveActitivites.LiveActivityPayload
 import com.gu.mobile.notifications.football.models.MatchDataWithArticle
+
 import scala.concurrent.Future
+import org.scanamo.generic.auto._
 
 object Lambda extends Logging {
 
   var cachedLambda: Boolean = false
 
   def tableName = s"mobile-notifications-football-notifications-${configuration.stage}"
+  def liveActivitiesTableName = s"mobile-notifications-liveactivities-payload-${configuration.stage}"
 
   lazy val configuration: Configuration = {
     logger.debug("Creating configuration")
@@ -58,7 +61,7 @@ object Lambda extends Logging {
 
   lazy val notificationHandler = new NotificationHandler(configuration, apiClient, dynamoDBClient, tableName)
 
-  lazy val liveActivityHandler = new LiveActivityHandler(configuration, dynamoDBClient, tableName)
+  lazy val liveActivityHandler = new LiveActivityHandler(configuration, dynamoDBClient, liveActivitiesTableName)
 
   // live activities //
   lazy val liveActivityPusher = new LiveActivityPusher()
@@ -130,14 +133,18 @@ class NotificationHandler(configuration: Configuration, apiClient: Notifications
 
   lazy val eventConsumer = new EventConsumer(matchStatusNotificationBuilder)
 
-  lazy val distinctCheck = new DynamoDistinctCheck[NotificationPayload](dynamoDBClient, tableName)
-
-  lazy val eventFilter = new EventFilter[NotificationPayload](distinctCheck)
+  lazy val distinctCheck = new DynamoDistinctCheck[NotificationPayload, DynamoMatchNotification](
+    client = dynamoDBClient,
+    tableName = tableName,
+    partitionKeyName = "notificationId",
+    toDynamoModel = payload => DynamoMatchNotification(payload)
+  )
+  lazy val eventFilter = new EventFilter[NotificationPayload, DynamoMatchNotification](distinctCheck)
 
   def process(rawEvents: List[MatchDataWithArticle]): Future[Unit] = {
     val notifications = rawEvents.flatMap(eventConsumer.eventsToNotifications)
     for {
-      filteredNotifications <- eventFilter.filterNotifications(notifications)
+      filteredNotifications <- eventFilter.filterDynamoEvents(notifications)
       result <- notificationSender.sendNotifications(filteredNotifications)
     } yield result
   }
@@ -151,17 +158,21 @@ class LiveActivityHandler(configuration: Configuration, dynamoDBClient: AmazonDy
 
   lazy val liveActivityEventConsumer = new LiveActivityEventConsumer(matchStatusLiveActivityPayloadBuilder)
 
-  lazy val distinctCheck = new DynamoDistinctCheck[LiveActivityPayload](dynamoDBClient, tableName)
-
-  lazy val eventFilter = new EventFilter[LiveActivityPayload](distinctCheck)
+  lazy val liveActivityDistinctCheck = new DynamoDistinctCheck[LiveActivityPayload, DynamoMatchLiveActivity](
+    client = dynamoDBClient,
+    tableName = tableName,
+    partitionKeyName = "id",
+    toDynamoModel = payload => DynamoMatchLiveActivity(payload)
+  )
+  lazy val liveActivityEventFilter = new EventFilter[LiveActivityPayload, DynamoMatchLiveActivity](liveActivityDistinctCheck)
 
   def process(rawEvents: List[MatchDataWithArticle]): Future[Unit] = {
     val liveActivities = rawEvents.flatMap(liveActivityEventConsumer.eventsToLiveActivityPayload)
 
     for {
-      // filteredLiveActivities <- eventFilter.filterNotifications(liveActivities)
+      filteredLiveActivities <- liveActivityEventFilter.filterDynamoEvents(liveActivities)
       result <- if (configuration.stage != "PROD") {
-        liveActivityPusher.pushEvents(liveActivities)
+        liveActivityPusher.pushEvents(filteredLiveActivities)
       } else {
         Future.successful(())
       }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoDistinctCheck.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoDistinctCheck.scala
@@ -67,9 +67,9 @@ class DynamoDistinctCheck[A <: Payload, D: DynamoFormat](
 
     lazy val scanamoAsync: ScanamoAsync = ScanamoAsync(client)
     lazy val notificationsTable = Table[D](tableName)
-    val dynamoModel = toDynamoModel(item)
+    val dynamoPayload = toDynamoModel(item)
 
-    val putResult = scanamoAsync.exec(notificationsTable.given(not(attributeExists(partitionKeyName))).put(dynamoModel))
+    val putResult = scanamoAsync.exec(notificationsTable.given(not(attributeExists(partitionKeyName))).put(dynamoPayload))
     putResult map {
       case Right(_) =>
         logger.info(s"Distinct event ${item.id} written to dynamodb $tableName")

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoDistinctCheck.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoDistinctCheck.scala
@@ -58,11 +58,11 @@ object DynamoDistinctCheck {
 
 class DynamoDistinctCheck[A <: Payload, D: DynamoFormat](
   client: AmazonDynamoDBAsync,
-  tableName: String,
+  val tableName: String,
   partitionKeyName: String,
   toDynamoModel: A => D
 ) extends Logging {
-  def insertNotification(item: A)(implicit ec: ExecutionContext): Future[DistinctStatus] = {
+  def insertEvent(item: A)(implicit ec: ExecutionContext): Future[DistinctStatus] = {
     import org.scanamo.syntax._
 
     lazy val scanamoAsync: ScanamoAsync = ScanamoAsync(client)

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoDistinctCheck.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoDistinctCheck.scala
@@ -3,8 +3,9 @@ package com.gu.mobile.notifications.football.lib
 import scala.concurrent.{ExecutionContext, Future}
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.gu.mobile.notifications.client.models.{FootballMatchStatusPayload, Payload}
-import org.scanamo.{ScanamoAsync, Table}
+import org.scanamo.{DynamoFormat, ScanamoAsync, Table}
 import DynamoDistinctCheck.{Distinct, DistinctStatus, Duplicate, Unknown}
+import com.gu.mobile.notifications.client.models.liveActitivites.LiveActivityPayload
 import com.gu.mobile.notifications.football.Logging
 import play.api.libs.json.Json
 
@@ -30,6 +31,24 @@ object DynamoMatchNotification {
   }
 }
 
+case class DynamoMatchLiveActivity(
+  id: String,
+  liveActivityID: String,
+  payload: String,
+  ttl: Long
+)
+
+object DynamoMatchLiveActivity {
+  def apply(payload: LiveActivityPayload): DynamoMatchLiveActivity = {
+    DynamoMatchLiveActivity(
+      id = payload.id.toString,
+      liveActivityID = payload.liveActivityID,
+      payload = Json.prettyPrint(Json.toJson(payload)),
+      ttl = (System.currentTimeMillis() / 1000) + (14 * 24 * 3600)
+    )
+  }
+}
+
 object DynamoDistinctCheck {
   sealed trait DistinctStatus
   case object Distinct extends DistinctStatus
@@ -37,25 +56,30 @@ object DynamoDistinctCheck {
   case object Unknown extends DistinctStatus
 }
 
-class DynamoDistinctCheck[A <: Payload](client: AmazonDynamoDBAsync, tableName: String) extends Logging {
-  def insertNotification(notification: A)(implicit ec: ExecutionContext, writes: play.api.libs.json.Writes[A]): Future[DistinctStatus] = {
+class DynamoDistinctCheck[A <: Payload, D: DynamoFormat](
+  client: AmazonDynamoDBAsync,
+  tableName: String,
+  partitionKeyName: String,
+  toDynamoModel: A => D
+) extends Logging {
+  def insertNotification(item: A)(implicit ec: ExecutionContext): Future[DistinctStatus] = {
     import org.scanamo.syntax._
-    import org.scanamo.generic.auto._
 
     lazy val scanamoAsync: ScanamoAsync = ScanamoAsync(client)
-    lazy val notificationsTable = Table[DynamoMatchNotification](tableName)
+    lazy val notificationsTable = Table[D](tableName)
+    val dynamoModel = toDynamoModel(item)
 
-    val putResult = scanamoAsync.exec(notificationsTable.given(not(attributeExists("notificationId"))).put(DynamoMatchNotification(notification)))
+    val putResult = scanamoAsync.exec(notificationsTable.given(not(attributeExists(partitionKeyName))).put(dynamoModel))
     putResult map {
       case Right(_) =>
-        logger.info(s"Distinct notification ${notification.id} written to dynamodb")
+        logger.info(s"Distinct event ${item.id} written to dynamodb $tableName")
         Distinct
       case Left(error) =>
-        logger.info(s"Received $error when attempting to write ${notification.id} to dynamo, assuming it's a duplicate")
+        logger.info(s"Received $error when attempting to write ${item.id} to dynamodb $tableName, assuming it's a duplicate")
         Duplicate
     } recover {
       case e =>
-        logger.error(s"Failure while writing to dynamodb: ${e.getMessage}.  Request will be retried on next poll")
+        logger.error(s"Failure while writing to dynamodb $tableName: ${e.getMessage}.  Request will be retried on next poll")
         Unknown
     }
   }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventFilter.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventFilter.scala
@@ -21,7 +21,7 @@ class EventFilter[A <: Payload, D](distinctCheck: DynamoDistinctCheck[A, D]) ext
 
   private def filterDynamoEvent(item: A)(implicit ec: ExecutionContext): Future[Option[A]] = {
     if (!processedEvents.get.contains(item.id)) {
-      distinctCheck.insertNotification(item).map {
+      distinctCheck.insertEvent(item).map {
         case Distinct =>
           cache(item.id)
           Some(item)
@@ -31,12 +31,12 @@ class EventFilter[A <: Payload, D](distinctCheck: DynamoDistinctCheck[A, D]) ext
         case _ => None
       }
     } else {
-      logger.debug(s"Event ${item.id} already exists in local cache or does not have an id - discarding")
+      logger.debug(s"Event ${item.id} already exists in local cache or does not have an id - discarding (dynamo table: ${distinctCheck.tableName})")
       Future.successful(None)
     }
   }
 
-  def filterDynamoEvents(notifications: List[A])(implicit ec: ExecutionContext): Future[List[A]] = {
-    Future.traverse(notifications)(filterDynamoEvent).map(_.flatten)
+  def filterDynamoEvents(dynamoEvents: List[A])(implicit ec: ExecutionContext): Future[List[A]] = {
+    Future.traverse(dynamoEvents)(filterDynamoEvent).map(_.flatten)
   }
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventFilter.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventFilter.scala
@@ -10,7 +10,7 @@ import com.gu.mobile.notifications.football.Logging
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class EventFilter[A <: Payload](distinctCheck: DynamoDistinctCheck[A]) extends Logging {
+class EventFilter[A <: Payload, D](distinctCheck: DynamoDistinctCheck[A, D]) extends Logging {
   private val processedEvents = new AtomicReference[Set[UUID]](Set.empty)
 
   private def cache(eventId: UUID): Unit = {
@@ -19,24 +19,24 @@ class EventFilter[A <: Payload](distinctCheck: DynamoDistinctCheck[A]) extends L
     })
   }
 
-  private def filterNotification(notification: A)(implicit ec: ExecutionContext, writes: play.api.libs.json.Writes[A]): Future[Option[A]] = {
-    if (!processedEvents.get.contains(notification.id)) {
-      distinctCheck.insertNotification(notification).map {
+  private def filterDynamoEvent(item: A)(implicit ec: ExecutionContext): Future[Option[A]] = {
+    if (!processedEvents.get.contains(item.id)) {
+      distinctCheck.insertNotification(item).map {
         case Distinct =>
-          cache(notification.id)
-          Some(notification)
+          cache(item.id)
+          Some(item)
         case Duplicate =>
-          cache(notification.id)
+          cache(item.id)
           None
         case _ => None
       }
     } else {
-      logger.debug(s"Event ${notification.id} already exists in local cache or does not have an id - discarding")
+      logger.debug(s"Event ${item.id} already exists in local cache or does not have an id - discarding")
       Future.successful(None)
     }
   }
 
-  def filterNotifications(notifications: List[A])(implicit ec: ExecutionContext, writes: play.api.libs.json.Writes[A]): Future[List[A]] = {
-    Future.traverse(notifications)(filterNotification).map(_.flatten)
+  def filterDynamoEvents(notifications: List[A])(implicit ec: ExecutionContext): Future[List[A]] = {
+    Future.traverse(notifications)(filterDynamoEvent).map(_.flatten)
   }
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
@@ -83,13 +83,13 @@ class LiveActivityPusher extends Logging {
       result match {
         case Success(_) => {
           logger.info(
-            s"Eventbus pusher: Successfully processed event with id ${payload.id}"
+            s"Eventbus pusher: Successfully processed live activities event with id ${payload.id}"
           )
           Future.successful(())
         }
         case Failure(e) => {
           logger.error(
-            s"Eventbus pusher: Failed to publish event with id ${payload.id}: ${e.getMessage}"
+            s"Eventbus pusher: Failed to publish live activities event with id ${payload.id}: ${e.getMessage}"
           )
           Future.failed(e)
         }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -66,8 +66,12 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
       case _ => UpdateLiveActivityEvent
     }
 
+    // Deterministic ID used for deduplicating match events (matchId + eventId)
+    val derivedId = s"football-match-status/${matchInfo.id}/${triggeringEvent.eventId}"
+
     LiveActivityPayload(
-      id = UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes),
+      id =
+        UUID.nameUUIDFromBytes(derivedId.getBytes),
       eventType = liveActivityEventType,
       liveActivityType = FootballLiveActivity,
       liveActivityID =


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds a DynamoDB table to store football live activity events, enabling reliable event deduplication.

This PR does the followings:

**Infrastructure**
- Introduces a new DynamoDB table for storing live activities payload events
- Configures the table with on-demand (PAY_PER_REQUEST) billing
This is chosen because the Lambda only interacts with the table during live matches, making provisioned capacity inefficient for sporadic usage
- Adds CloudWatch alarms for read/write throttling on the table
- Adds metrics to track successful and failed event processing

**Implementation**
- Refactors DynamoDistinctCheck to be generic, allowing reuse across both notifications and live activity events
- Introduces a deterministic ID for deduplicating match events (based on matchId + eventId)

**Notes / Considerations**
- The deduplication strategy ensures idempotent processing of live activity events
- The on-demand billing model aligns cost with actual usage patterns during live matches

