### PR TITLE
Add event bus rule to route payloads

### DIFF
--- a/cdk/lib/__snapshots__/liveactivities.test.ts.snap
+++ b/cdk/lib/__snapshots__/liveactivities.test.ts.snap
@@ -18,6 +18,139 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
     },
   },
   "Resources": {
+    "BroadcastRule3D75643B": {
+      "Properties": {
+        "EventBusName": {
+          "Ref": "EventsD32975C2",
+        },
+        "EventPattern": {
+          "detail-type": [
+            "broadcast-start",
+            "broadcast-update",
+            "broadcast-end",
+          ],
+          "source": [
+            "football-lambda",
+          ],
+        },
+        "State": "ENABLED",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "liveactivitiesbroadcastlambdaC288C367",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "BroadcastRuleAllowEventRuleLiveActivitiesCODEliveactivitiesbroadcastlambda1F8C7AF2670B7E1E": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "liveactivitiesbroadcastlambdaC288C367",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "BroadcastRule3D75643B",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "ChannelRule421C2920": {
+      "Properties": {
+        "EventBusName": {
+          "Ref": "EventsD32975C2",
+        },
+        "EventPattern": {
+          "detail-type": [
+            "channel-create",
+            "channel-delete",
+          ],
+          "source": [
+            "football-lambda",
+          ],
+        },
+        "State": "ENABLED",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "liveactivitieschannelmanagerlambda398DC149",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "ChannelRuleAllowEventRuleLiveActivitiesCODEliveactivitieschannelmanagerlambda76CE20D1B22DE0F2": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "liveactivitieschannelmanagerlambda398DC149",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "ChannelRule421C2920",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "EventsD32975C2": {
       "Properties": {
         "Description": "CODE event routing for live activities",

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -5,7 +5,7 @@ import type { App } from 'aws-cdk-lib';
 import { Duration, Tags } from 'aws-cdk-lib';
 import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { EventBus, Rule } from 'aws-cdk-lib/aws-events';
-import { SqsQueue } from 'aws-cdk-lib/aws-events-targets';
+import { LambdaFunction, SqsQueue } from 'aws-cdk-lib/aws-events-targets';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
@@ -117,6 +117,24 @@ export class LiveActivities extends GuStack {
 		const eventBus = new EventBus(this, 'Events', {
 			eventBusName: `${app}-eventbus-${stage}`,
 			description: `${stage} event routing for live activities`,
+		});
+
+		new Rule(this, 'ChannelRule', {
+			eventBus: eventBus,
+			eventPattern: {
+				source: ['football-lambda'],
+				detailType: ['channel-create', 'channel-delete'],
+			},
+			targets: [new LambdaFunction(channelLambda)],
+		});
+
+		new Rule(this, 'BroadcastRule', {
+			eventBus: eventBus,
+			eventPattern: {
+				source: ['football-lambda'],
+				detailType: ['broadcast-start', 'broadcast-update', 'broadcast-end'],
+			},
+			targets: [new LambdaFunction(broadcastLambda)],
 		});
 
 		// Development SQS to capture and inspect events from PA polling during development

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
@@ -56,7 +56,6 @@ class LiveActivityPusher extends Logging {
         case UpdateLiveActivity => "broadcast-update"
         case EndLiveActivity    => "broadcast-end"
         case DeleteChannel      => "channel-delete"
-        case _ => "unknown"
       }
 
       val result = Try {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR introduces EventBridge rules to route football live activity events to the appropriate Lambda consumers based on their event type.

Two rules are added:

- **ChannelRule**
Routes channel-related events (channel-create, channel-delete) to channelLambda.
- **BroadcastRule**
Routes broadcast-related events (broadcast-start, broadcast-update, broadcast-end) to broadcastLambda.

Both rules listen to events emitted from the football-lambda source and use detail-type to determine routing.

