### PR TITLE
Impeove channel lambda error handling

### DIFF
--- a/cdk/lib/__snapshots__/liveactivities.test.ts.snap
+++ b/cdk/lib/__snapshots__/liveactivities.test.ts.snap
@@ -85,6 +85,34 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
+    "ChannelManagerDlq58D33B75": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 604800,
+        "QueueName": "liveactivities-channel-manager-dlq-CODE",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VisibilityTimeout": 240,
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
     "ChannelRule421C2920": {
       "Properties": {
         "EventBusName": {
@@ -530,9 +558,29 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
             "Value": "CODE",
           },
         ],
-        "Timeout": 120,
+        "Timeout": 180,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "liveactivitieschannelmanagerlambdaEventInvokeConfigE15EB3FC": {
+      "Properties": {
+        "DestinationConfig": {
+          "OnFailure": {
+            "Destination": {
+              "Fn::GetAtt": [
+                "ChannelManagerDlq58D33B75",
+                "Arn",
+              ],
+            },
+          },
+        },
+        "FunctionName": {
+          "Ref": "liveactivitieschannelmanagerlambda398DC149",
+        },
+        "MaximumRetryAttempts": 2,
+        "Qualifier": "$LATEST",
+      },
+      "Type": "AWS::Lambda::EventInvokeConfig",
     },
     "liveactivitieschannelmanagerlambdaServiceRole18EEF4D7": {
       "Properties": {
@@ -591,6 +639,20 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ChannelManagerDlq58D33B75",
+                  "Arn",
+                ],
+              },
+            },
             {
               "Action": [
                 "s3:GetObject*",

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -8,6 +8,7 @@ import { EventBus, Rule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction, SqsQueue } from 'aws-cdk-lib/aws-events-targets';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { SqsDestination } from 'aws-cdk-lib/aws-lambda-destinations';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
 
 export class LiveActivities extends GuStack {
@@ -26,6 +27,12 @@ export class LiveActivities extends GuStack {
 		});
 		Tags.of(dynamoTable).add('devx-backup-enabled', 'true');
 
+		const channelManagerDlq = new Queue(this, 'ChannelManagerDlq', {
+			queueName: `${app}-channel-manager-dlq-${stage}`,
+			visibilityTimeout: Duration.minutes(4),
+			retentionPeriod: Duration.days(7),
+		});
+
 		const channelLambda = new GuLambdaFunction(
 			this,
 			`${app}-channel-manager-lambda`,
@@ -37,7 +44,9 @@ export class LiveActivities extends GuStack {
 				fileName: `${app}.jar`,
 				runtime: Runtime.JAVA_11,
 				memorySize: 1024,
-				timeout: Duration.seconds(120),
+				timeout: Duration.minutes(3),
+				onFailure: new SqsDestination(channelManagerDlq),
+				retryAttempts: 2,
 				environment: {
 					Stack: stack,
 					Stage: stage,

--- a/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
@@ -28,7 +28,7 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
     maybeChannelId.flatMap {
       case Some(id) =>
         logger.error(s"Channel mapping already exists for match ID $matchId")
-        // id channel id already exists for a match we don't want to fail the lambda to avoid the lambda retry on this event
+        // if channel id already exists for a match we don't want to fail the lambda to avoid the lambda retry on this event
         Future.successful(id)
       case None =>
         for {
@@ -41,16 +41,18 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
 
   def processCloseChannelRequest(matchId: String): Future[String] = {
     logger.info(s"Channel closed for match ID: $matchId")
-    for {
-      mapping <- repository.getMappingById(matchId)
-      _ <- if (!mapping.isChannelActive) {
-          logger.error(s"Channel not active for match ID ${matchId}")
-          Future.failed(new LiveActivityInvalidStateException(matchId, "Channel not active"))
-        } else Future.successful(())
-      _ <- channelApiClient.closeChannel(mapping.channelId)
-      _ <- repository.updateMappingActiveChannel(matchId, false)
-      _ = logger.info(s"Channel closed with channel ID ${mapping.channelId} for match ID ${matchId}")
-    } yield mapping.channelId
+    val maybeMapping = repository.getMappingById(matchId)
+    maybeMapping.flatMap{
+      case mapping if !mapping.isChannelActive =>
+        logger.error(s"Channel not active for match ID $matchId")
+        // if channel is inactive for a match we don't want to fail the lambda to avoid the lambda retry on this event
+        Future.successful(mapping.channelId)
+      case mapping =>  for {
+        _ <- channelApiClient.closeChannel(mapping.channelId)
+        _ <- repository.updateMappingActiveChannel(matchId, isActive = false)
+        _ = logger.info(s"Channel closed with channel ID ${mapping.channelId} for match ID $matchId")
+      } yield mapping.channelId
+    }
   }
 
   def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {

--- a/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
@@ -7,6 +7,7 @@ import com.gu.liveactivities.util.Logging
 import play.api.libs.json.{Format, JsError, JsSuccess, Json}
 
 import java.io.{InputStream, OutputStream}
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -73,13 +74,16 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
       else
         processCloseChannelRequest(request.matchId)
 
-    // TODO - the timeout value
-    Try(Await.result(channelFuture, scala.concurrent.duration.Duration.Inf)) match {
+    //Timeout set to 160 seconds to provide a safety buffer.
+    // While the sum of downstream timeouts is at most ~110s,
+    // we allow extra time for other things such as JSON parsing, cold starts,
+    // authentication token fetches, and potential network congestion
+    // to ensure the Lambda doesn't fail a healthy request that is just running slow.
+    Try(Await.result(channelFuture, 160.seconds)) match {
       case Success(_) => ()
-      case Failure(exception) => {
+      case Failure(exception) =>
         logger.error(s"Failed to process: ${exception.getMessage}")
         throw exception
-      }
     }
   }
 }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
@@ -1,26 +1,14 @@
 package com.gu.liveactivities
 
-import com.gu.liveactivities.service.{ChannelApiClient, BroadcastApiClient, Authentication}
-import com.gu.liveactivities.service.LiveActivityChannelRepository
-import com.gu.liveactivities.util.{Configuration, IosConfiguration}
-import com.gu.liveactivities.models.{LiveActivityMapping, LiveActivityData}
-import scala.concurrent.Await
-import scala.util.Success
-import scala.util.Failure
-import scala.util.Try
-import com.amazonaws.services.lambda.runtime.Context
-import com.amazonaws.services.lambda.runtime.RequestStreamHandler
-import java.io.{InputStream, OutputStream}
-import play.api.libs.json.Json
-import play.api.libs.json.Format
-import play.api.libs.json.JsSuccess
-import play.api.libs.json.JsError
-import java.nio.charset.StandardCharsets
-import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
-import software.amazon.awssdk.regions.Region.EU_WEST_1
+import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
+import com.gu.liveactivities.models.{LiveActivityData, LiveActivityInvalidStateException}
+import com.gu.liveactivities.service.ChannelApiClient
 import com.gu.liveactivities.util.Logging
-import scala.concurrent.Future
-import com.gu.liveactivities.models.LiveActivityInvalidStateException
+import play.api.libs.json.{Format, JsError, JsSuccess, Json}
+
+import java.io.{InputStream, OutputStream}
+import scala.concurrent.{Await, Future}
+import scala.util.{Failure, Success, Try}
 
 case class ChannelRequest(matchId: String, competitionId: Option[String], eventData: Option[LiveActivityData], toCreate: Boolean)
 
@@ -33,22 +21,26 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
   val channelApiClient = new ChannelApiClient(authentication, config.bundleId, config.sendingToProdServer)
 
   def processCreateChannelRequest(matchId: String, competitionId: Option[String], eventData: Option[LiveActivityData]): Future[String] = {
-    logger.info(s"Received request to create channel for match ID ${matchId}")
-    return for {
-      mappingExists <- repository.containMapping(matchId)
-      _ <- if (mappingExists) {
-          logger.error(s"Channel mapping already exists for match ID ${matchId}")
-          Future.failed(new LiveActivityInvalidStateException(matchId, "Channel mapping already exists"))
-        } else Future.successful(())
-      channelId <- channelApiClient.createChannel()
-      _ <- repository.createMapping(matchId, channelId, eventData, competitionId)
-      _ = logger.info(s"Channel created with channel ID ${channelId} for match ID ${matchId}")
-    } yield channelId
+    logger.info(s"Received request to create channel for match ID $matchId")
+
+    val maybeChannelId = repository.containMapping(matchId)
+    maybeChannelId.flatMap {
+      case Some(id) =>
+        logger.error(s"Channel mapping already exists for match ID $matchId")
+        // id channel id already exists for a match we don't want to fail the lambda to avoid the lambda retry on this event
+        Future.successful(id)
+      case None =>
+        for {
+          channelId <- channelApiClient.createChannel()
+          _ <- repository.createMapping(matchId, channelId, eventData, competitionId)
+          _ = logger.info(s"Channel created with channel ID $channelId for match ID $matchId")
+        } yield channelId
+    }
   }
 
   def processCloseChannelRequest(matchId: String): Future[String] = {
     logger.info(s"Channel closed for match ID: $matchId")
-    return for {
+    for {
       mapping <- repository.getMappingById(matchId)
       _ <- if (!mapping.isChannelActive) {
           logger.error(s"Channel not active for match ID ${matchId}")

--- a/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
@@ -1,17 +1,13 @@
 package com.gu.liveactivities
 
-import com.gu.liveactivities.service.Authentication
-import com.gu.liveactivities.service.ChannelApiClient
-import com.gu.liveactivities.service.LiveActivityChannelRepository
-import com.gu.liveactivities.util.Configuration
-import com.gu.liveactivities.util.IosConfiguration
-import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
-import software.amazon.awssdk.auth.credentials.{
-  AwsCredentialsProviderChain,
-  ProfileCredentialsProvider,
-  DefaultCredentialsProvider,
-}
+import com.gu.liveactivities.service.{Authentication, LiveActivityChannelRepository}
+import com.gu.liveactivities.util.{Configuration, IosConfiguration}
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, DefaultCredentialsProvider, ProfileCredentialsProvider}
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+
+import java.time.Duration
 
 trait Lambda {
 
@@ -31,6 +27,12 @@ trait Lambda {
       .builder()
       .credentialsProvider(credentialsv2)
       .region(Region.of(config.region))
+      .overrideConfiguration(
+        ClientOverrideConfiguration.builder()
+          .apiCallAttemptTimeout(Duration.ofSeconds(2)) // limit for one single try
+          .apiCallTimeout(Duration.ofSeconds(10)) // limit for the entire operation
+          .build()
+      )
       .build()
 
   val repository = new LiveActivityChannelRepository(dynamoDbClient, s"mobile-notifications-liveactivities-${config.stage}")

--- a/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
@@ -5,6 +5,7 @@ import com.gu.liveactivities.util.{Configuration, IosConfiguration}
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, DefaultCredentialsProvider, ProfileCredentialsProvider}
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.retries.DefaultRetryStrategy
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 
 import java.time.Duration
@@ -31,6 +32,9 @@ trait Lambda {
         ClientOverrideConfiguration.builder()
           .apiCallAttemptTimeout(Duration.ofSeconds(2)) // limit for one single try
           .apiCallTimeout(Duration.ofSeconds(10)) // limit for the entire operation
+          .retryStrategy(DefaultRetryStrategy.standardStrategyBuilder()
+            .maxAttempts(3)
+            .build())
           .build()
       )
       .build()

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
@@ -114,13 +114,13 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
           table.update(idKeyName === id, upsWithLastModified.reduce[UpdateExpression](_ and _))
         }
 
-        result.flatMap(_ match {
+        result.flatMap {
           case Right(_) => Future.successful(())
           case Left(ex) =>
             val errorMsg = s"Error updating live activity mapping for id $id - ${DynamoReadError.describe(ex)}"
             logger.error(errorMsg)
             Future.failed(new RepositoryException(errorMsg))
-        })
+        }.recover(handleErrors("updating mapping in DynamoDB", id))
     }
   }
 
@@ -139,18 +139,17 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
   override def getMappingById(
       id: String
   ): Future[LiveActivityMapping] = {
-    scanamo.exec { 
-      table.consistently.get(idKeyName === id)
-    }
-    .flatMap(_ match {
-      case Some(Right(result)) => Future.successful(result)
-      case None => Future.failed(new LiveActivityDataException(id, "Live Activity mapping not found"))
-      case Some(Left(ex)) => {
-        val errorMsg = s"Error getting live activity mapping for id $id - ${DynamoReadError.describe(ex)}"
-        logger.error(errorMsg)
-        Future.failed(new RepositoryException(errorMsg))
+    scanamo.exec {
+        table.consistently.get(idKeyName === id)
       }
-    })
+      .flatMap {
+        case Some(Right(result)) => Future.successful(result)
+        case None => Future.failed(new LiveActivityDataException(id, "Live Activity mapping not found"))
+        case Some(Left(ex)) =>
+          val errorMsg = s"Error getting live activity mapping for id $id - ${DynamoReadError.describe(ex)}"
+          logger.error(errorMsg)
+          Future.failed(new RepositoryException(errorMsg))
+      }.recover(handleErrors("reading mapping from DynamoDB", id))
   }
 
   override def deleteMappingById(

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
@@ -164,7 +164,7 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
     case ex: RepositoryException =>
       throw ex
     case ex: Exception =>
-      val msg = s"System error during $operation for id $id: ${ex.getMessage}"
+      val msg = s"Error during $operation for id $id: ${ex.getMessage}"
       logger.error(msg)
       throw new RepositoryException(msg)
   }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
@@ -1,31 +1,20 @@
 package com.gu.liveactivities.service
 
-import cats.syntax.all._
-import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
-import software.amazon.awssdk.services.dynamodb.model._
-import org.slf4j.{Logger, LoggerFactory}
-import play.api.libs.json._
-import tracking.Repository.RepositoryResult
-import tracking.RepositoryError
-
-import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters._
-import com.gu.liveactivities.models.{LiveActivityData, LiveActivityMapping, RepositoryException, LiveActivityDataException}
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
+import cats.data.NonEmptyList
+import com.gu.liveactivities.models.{LiveActivityData, LiveActivityDataException, LiveActivityMapping, RepositoryException}
+import com.gu.liveactivities.util.DateTimeHelper.dateTimeToString
 import com.gu.liveactivities.util.Logging
-import com.gu.liveactivities.util.FutureUtils._
-import scala.util.Failure
-import com.gu.liveactivities
-import com.gu.liveactivities.util.DateTimeHelper.{dateTimeFromString, dateTimeToString}
-import org.scanamo.{ScanamoAsync, Table, DynamoReadError, ScanamoError, ConditionNotMet}
 import org.scanamo.syntax._
 import org.scanamo.update.UpdateExpression
-import cats.data.NonEmptyList
+import org.scanamo.{ConditionNotMet, DynamoReadError, ScanamoAsync, Table}
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+
+import java.time.ZonedDateTime
+import scala.concurrent.{ExecutionContext, Future}
 
 trait ChannelMappingsRepository {
 
-  def containMapping(id: String): Future[Boolean]
+  def containMapping(id: String): Future[Option[String]]
 
   def createMapping(    
     id: String,
@@ -52,19 +41,18 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
   private val table = Table[LiveActivityMapping](tableName)
   private val idKeyName = "id"
 
-  override def containMapping(id: String): Future[Boolean] =
-    scanamo.exec { 
-      table.get(idKeyName === id)
-    }
-    .flatMap(_ match {
-      case Some(Right(_)) => Future.successful(true)
-      case None => Future.successful(false)
-      case Some(Left(ex)) => {
-        val errorMsg = s"Error checking if live activity mapping exists for id $id - ${DynamoReadError.describe(ex)}"
-        logger.error(errorMsg)
-        Future.failed(new RepositoryException(errorMsg))
+  override def containMapping(id: String): Future[Option[String]] =
+    scanamo.exec {
+        table.get(idKeyName === id)
       }
-    })
+      .map {
+        case Some(Right(mapping)) => Some(mapping.channelId)
+        case None => None
+        case Some(Left(ex)) =>
+          val errorMsg = s"Error checking if live activity mapping exists for id $id - ${DynamoReadError.describe(ex)}"
+          logger.error(errorMsg)
+          throw new RepositoryException(errorMsg)
+      }.recover(handleErrors("reading from DynamoDB", id))
 
   override def createMapping(
     id: String,
@@ -85,22 +73,20 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
       createdAt = createdAt,
       lastModifiedAt = createdAt
     )
-    scanamo.exec { 
-      table.when(attributeNotExists(idKeyName)).put(newItem)
-    }
-    .flatMap(_ match {
-      case Right(_) => Future.successful(())
-      case Left(ConditionNotMet(ex)) => {
-        val errorMsg = s"Live activity mapping for id $id already exists"
-        logger.error(errorMsg)
-        Future.failed(new RepositoryException(ex, errorMsg))
+    scanamo.exec {
+        table.when(attributeNotExists(idKeyName)).put(newItem)
       }
-      case Left(ex: DynamoReadError) => {
-        val errorMsg = s"Error saving live activity mapping for id $id - ${DynamoReadError.describe(ex)}"
-        logger.error(errorMsg)
-        Future.failed(new RepositoryException(errorMsg))
-      }
-    })
+      .map {
+        case Right(_) => ()
+        case Left(ConditionNotMet(ex)) =>
+          val errorMsg = s"Live activity mapping for id $id already exists"
+          logger.error(errorMsg)
+          throw new RepositoryException(ex, errorMsg)
+        case Left(ex: DynamoReadError) =>
+          val errorMsg = s"Error saving live activity mapping for id $id - ${DynamoReadError.describe(ex)}"
+          logger.error(errorMsg)
+          throw new RepositoryException(errorMsg)
+      }.recover(handleErrors("writing to DynamoDB", id))
   }
 
   private def updateMappingById(
@@ -175,4 +161,12 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
     }
   }
 
+  private def handleErrors[T](operation: String, id: String): PartialFunction[Throwable, T] = {
+    case ex: RepositoryException =>
+      throw ex
+    case ex: Exception =>
+      val msg = s"System error during $operation for id $id: ${ex.getMessage}"
+      logger.error(msg)
+      throw new RepositoryException(msg)
+  }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

**Refined Timeout:**
App-level Timeout (160s): Calculated based on the maximum cumulative latency of downstream calls ($10s \text{ (Read)} + 90s \text{ (Create Channel)} + 10s \text{ (Write)}$) plus a 50s buffer to account for cold starts, authentication token fetches, potential network congestion, JSON parsing, etc.

Lambda Global Timeout (180s): Set to 3 minutes to provide a 20s grace period over the application logic. This ensures the application stays in control and can successfully log specific error context to CloudWatch before a hard termination by the AWS runtime.

**DynamoDB Client Timeout:**
Configured request timeouts (apiCallAttemptTimeout and apiCallTimeout) to prevent the client from hanging indefinitely. This ensures the system fails fast and recovers quickly if DynamoDB is slow or the network is congested.

**Repository Error Handling:**
Implemented custom error recovery in the repository layer to wrap SDK exceptions with domain-specific context (e.g., including the record ID in logs).

**Graceful State Handling**
Updated the create and close flows to check for "Already Exists" or "Already Inactive" states.

Instead of throwing an error, the system now logs the state and exits successfully. This prevents unnecessary retries and prevents DLQ "pollution" when the system has already achieved the desired outcome.
Asynchronous Reliability:

**SQS Destination (On Failure):**
Added an SQS Destination (On Failure) to capture failed events.

Unlike a standard DLQ, this provides the full responsePayload (stack trace and error message) directly in the SQS message for easier debugging.

## Test
Fully tested this locally to check the timeouts and error handling by enforcing delay or error. 

Also tested this in CODE to check the message that goes to the dead letter queue. The message looks like this:
```
{
  "version": "1.0",
  "timestamp": "2026-04-28T14:16:14.107Z",
  "requestContext": {
    "requestId": "someId",
    "functionArn": "<arn>",
    "condition": "RetriesExhausted",
    "approximateInvokeCount": 3
  },
  "requestPayload": {
    "matchId": "testId",
    "competitionId": "competiton-001",
    "toCreate": false
  },
  "responseContext": {
    "statusCode":<status code>,
    "executedVersion": "<version>",
    "functionError": "Unhandled"
  },
  "responsePayload": {
    "errorMessage": "<error message>",
    "errorType": "<error type>",
    "stackTrace": [<stack trace> ]
  }
}
```

