### PR TITLE
Ensure processing of channel events

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/Topic.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/Topic.scala
@@ -7,9 +7,38 @@ import play.api.libs.json._
 sealed trait TopicType
 
 object TopicType {
-  implicit val jf: Writes[TopicType] = new Writes[TopicType] {
+  implicit val writes: Writes[TopicType] = new Writes[TopicType] {
     override def writes(o: TopicType): JsValue = JsString(o.toString)
   }
+
+  private val all: List[TopicType] = List(
+    Breaking,
+    Content,
+    TagContributor,
+    TagKeyword,
+    TagSeries,
+    TagBlog,
+    FootballTeam,
+    FootballMatch,
+    User,
+    Newsstand
+  )
+
+  private val fromString: Map[String, TopicType] =
+    all.map(t => t.toString -> t).toMap
+
+  implicit val reads: Reads[TopicType] = Reads {
+    case JsString(value) =>
+      fromString.get(value) match {
+        case Some(t) => JsSuccess(t)
+        case None    => JsError(s"Invalid TopicType: $value")
+      }
+
+    case _ => JsError("TopicType must be a string")
+  }
+
+  implicit val format: Format[TopicType] =
+    Format(reads, writes)
 }
 
 object TopicTypes {
@@ -30,6 +59,7 @@ case class Topic(`type`: TopicType, name: String) {
 }
 object Topic {
   implicit val jf: OWrites[Topic] = Json.writes[Topic]
+  implicit val format: OFormat[Topic] = Json.format[Topic]
   val BreakingNewsUk = Topic(Breaking, UK.toString)
   val BreakingNewsUs = Topic(Breaking, US.toString)
   val BreakingNewsAu = Topic(Breaking, AU.toString)

--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
@@ -12,7 +12,9 @@ import play.api.libs.json._
 
 
 // GENERIC CONTENT STATE //////////////////////////////////////////////////
-sealed trait ContentState
+sealed trait ContentState {
+  def contentType: String
+}
 object ContentState {
   import FootballContentJsonFormats._
 
@@ -21,7 +23,7 @@ object ContentState {
       case f: FootballMatchContentState =>
         footballMatchContentStateFormat
           .writes(f)
-          .as[JsObject] + ("type" -> JsString("football"))
+          .as[JsObject] + ("type" -> JsString(cs.contentType))
       // Add cases for other ContentState subtypes here
     }
 
@@ -94,7 +96,9 @@ case class FootballMatchContentState(
     currentMinute: Option[Int] = None,
     currentPeriodStartTime: Option[Long] = None,
     articleUrl: Option[String] = None
-) extends ContentState
+) extends ContentState {
+  val contentType = "football"
+}
 
 
 object FootballContentJsonFormats {

--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
@@ -1,7 +1,8 @@
 package com.gu.mobile.notifications.client.models.liveActitivites
 
 import com.gu.mobile.notifications.client.models.{Payload, Topic}
-import play.api.libs.json.{JsString, Json, Writes}
+import play.api.libs.json.{Format, JsError, JsResult, JsString, JsSuccess, JsValue, Json, Reads, Writes}
+
 import java.util.UUID
 
 /**
@@ -10,6 +11,94 @@ import java.util.UUID
  * Channel Manager and Broadcast lambdas.
  **/
 
+sealed trait EventSource
+case object FootballLambda extends EventSource
+
+object EventSource {
+//  implicit val reads: Reads[EventSource] = Reads {
+//    case JsString("football-lambda") => JsSuccess(FootballLambda)
+//    case JsString(other)             => JsError(s"Invalid EventSource: $other")
+//    case _                           => JsError("EventSource must be a string")
+//  }
+
+  implicit val eventSourceFormat: Format[EventSource] = new Format[EventSource] {
+
+    override def reads(json: JsValue): JsResult[EventSource] = json match {
+      case JsString("football-lambda") => JsSuccess(FootballLambda)
+      case JsString(other)             => JsError(s"Invalid EventSource: $other")
+      case _                           => JsError("EventSource must be a string")
+    }
+
+    override def writes(source: EventSource): JsValue = source match {
+      case FootballLambda => JsString("football-lambda")
+    }
+  }
+}
+
+sealed trait DetailType { def asString: String }
+
+// TODO: look at event pusher
+case object ChannelCreate   extends DetailType { val asString = "channel-create" }
+case object ChannelDelete   extends DetailType { val asString = "channel-delete" }
+case object BroadcastUpdate extends DetailType { val asString = "broadcast-update" }
+case object BroadcastStart  extends DetailType { val asString = "broadcast-start" }
+case object BroadcastEnd    extends DetailType { val asString = "broadcast-end" }
+
+object DetailType {
+  private val all: List[DetailType] = List(
+    ChannelCreate,
+    ChannelDelete,
+    BroadcastUpdate,
+    BroadcastStart,
+    BroadcastEnd
+  )
+
+  private val fromString: Map[String, DetailType] =
+    all.map(dt => dt.asString -> dt).toMap
+
+  implicit val format: Format[DetailType] = new Format[DetailType] {
+
+    override def reads(json: JsValue): JsResult[DetailType] = json match {
+      case JsString(value) =>
+        all.find(_.asString == value)
+          .map(JsSuccess(_))
+          .getOrElse(JsError(s"Invalid detail-type: $value"))
+
+      case _ => JsError("detail-type must be a string")
+    }
+
+    override def writes(detailType: DetailType): JsValue =
+      JsString(detailType.asString)
+  }
+
+
+//  implicit val reads: Reads[DetailType] = Reads {
+//    case JsString(value) =>
+//      fromString.get(value) match {
+//        case Some(detailType) => JsSuccess(detailType)
+//        case None             => JsError(s"Invalid detail-type: $value")
+//      }
+//
+//    case _ =>
+//      JsError("detail-type must be a string")
+//  }
+}
+
+case class EventBridgeEvent(
+                             version: String,
+                             id: String,
+                             `detail-type`: DetailType,
+                             source: EventSource,
+                             account: String,
+                             time: String,
+                             region: String,
+                             resources: List[String],
+                             detail: LiveActivityPayload
+                           )
+
+object EventBridgeEvent {
+  implicit val eventBridgeEventFormat: Format[EventBridgeEvent] = Json.format[EventBridgeEvent]
+}
 
 // life cycle of a live activity:
 sealed trait LiveActivityEventType
@@ -59,8 +148,38 @@ object LiveActivityPayload {
     case FootballLiveActivity => JsString("FootballLiveActivity")
   }
 
+  // --- EventType ---
+  implicit val liveActivityEventTypeReads: Reads[LiveActivityEventType] =
+    Reads {
+      case JsString("CreateChannel")     => JsSuccess(CreateChannelEvent)
+      case JsString("StartLiveActivity") => JsSuccess(StartLiveActivityEvent)
+      case JsString("UpdateLiveActivity") => JsSuccess(UpdateLiveActivityEvent)
+      case JsString("EndLiveActivity")   => JsSuccess(EndLiveActivityEvent)
+      case JsString("DeleteChannel")     => JsSuccess(DeleteChannelEvent)
+      case JsString(other)               => JsError(s"Invalid LiveActivityEventType: $other")
+      case _                             => JsError("LiveActivityEventType must be a string")
+    }
+
+  // --- Type ---
+  implicit val liveActivityTypeReads: Reads[LiveActivityType] =
+    Reads {
+      case JsString("FootballLiveActivity") => JsSuccess(FootballLiveActivity)
+      case JsString(other)                  => JsError(s"Invalid LiveActivityType: $other")
+      case _                                => JsError("LiveActivityType must be a string")
+    }
+
+  implicit val liveActivityEventTypeFormat: Format[LiveActivityEventType] =
+    Format(liveActivityEventTypeReads, liveActivityEventTypeWrites)
+
+  implicit val liveActivityTypeFormat: Format[LiveActivityType] =
+    Format(liveActivityTypeReads, liveActivityTypeWrites)
+
   implicit val dynamoDataWrites: Writes[dynamoData] = Json.writes[dynamoData]
 
   implicit val liveActivityPayloadWrites: Writes[LiveActivityPayload] =
     Json.writes[LiveActivityPayload]
+
+  implicit val liveActivityPayloadFormat: Format[LiveActivityPayload] =
+    Json.format[LiveActivityPayload]
+
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -49,7 +49,7 @@ object Lambda extends Logging {
 
   lazy val capiClient = GuardianContentClient(configuration.capiApiKey)
 
-  lazy val syntheticMatchEventGenerator = new SyntheticMatchEventGenerator()
+  lazy val syntheticMatchEventGenerator = new SyntheticMatchEventGenerator(getZonedDateTime())
 
   lazy val notificationHttpProvider = new NotificationHttpProvider()
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -69,7 +69,7 @@ class FootballData(
 
   def matchIdsInProgress(dateTime: ZonedDateTime): Future[List[MatchDay]] = {
     def inProgress(m: MatchDay): Boolean =
-      m.date.minusMinutes(5).isBefore(dateTime) && m.date.plusHours(4).isAfter(dateTime)
+      m.date.minusHours(2).isBefore(dateTime) && m.date.plusHours(4).isAfter(dateTime)
 
 
     // unfortunately PA provide 00:00 as start date when they don't have the start date

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
@@ -39,7 +39,7 @@ class LiveActivityPusher extends Logging {
   def pushToEventbus(payload: LiveActivityPayload)(implicit ec: ExecutionContext): Future[Unit] = {
 
     logger.info(
-      s"Eventbus pusher: Processing event with id ${payload.id}"
+      s"Eventbus pusher: Processing event ${payload.eventType} with id ${payload.id}"
     )
     val jsonDetail = Json.toJson(payload).toString()
     if (jsonDetail.isEmpty || jsonDetail == "{}") {
@@ -83,13 +83,13 @@ class LiveActivityPusher extends Logging {
       result match {
         case Success(_) => {
           logger.info(
-            s"Eventbus pusher: Successfully processed live activities event with id ${payload.id}"
+            s"Eventbus pusher: Successfully processed live activities event ${payload.eventType} with id ${payload.id}"
           )
           Future.successful(())
         }
         case Failure(e) => {
           logger.error(
-            s"Eventbus pusher: Failed to publish live activities event with id ${payload.id}: ${e.getMessage}"
+            s"Eventbus pusher: Failed to publish live activities event ${payload.eventType} with id ${payload.id}: ${e.getMessage}"
           )
           Future.failed(e)
         }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -1,10 +1,11 @@
 package com.gu.mobile.notifications.football.lib
 
 import java.util.UUID
-
 import pa.{MatchDay, MatchEvent}
 
-class SyntheticMatchEventGenerator {
+import java.time.ZonedDateTime
+
+class SyntheticMatchEventGenerator(dateTime: ZonedDateTime) {
 
   def generate(events: List[MatchEvent], id: String, matchDay: MatchDay): List[MatchEvent] = {
     // Live activity synthetic events are appended at the end, but when they are first generated, no other timeline events exist and duplicate events are filtered so this should not matter.
@@ -40,7 +41,7 @@ class SyntheticMatchEventGenerator {
 
   // Live Activity supporting events //
 
-  val now: Long = java.time.Instant.now.getEpochSecond
+  val now: Long = dateTime.toInstant.getEpochSecond
   def koWithinTwoHours(ko: Long): Boolean = now >= ko - 7200 && now < ko - 1200
   def koWithin20Minutes(ko: Long): Boolean = now >= ko - 1200 && now < ko
 

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -280,13 +280,13 @@ class EventConsumerSpec(implicit ev: ExecutionEnv) extends Specification with Mo
 
     def rawEvents: List[MatchEvent] = Parser.parseMatchEvents(loadFile("match-event-feed.xml")).get.events
     def matchDay: MatchDay = Parser.parseMatchDay(loadFile("20170811.xml")).head
-    def events: List[MatchEvent] = new SyntheticMatchEventGenerator().generate(rawEvents, "4011135", matchDay)
+    def events: List[MatchEvent] = new SyntheticMatchEventGenerator(ZonedDateTime.now()).generate(rawEvents, "4011135", matchDay)
     def matchData = MatchDataWithArticle(matchDay, events, Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"))
 
     // live activity (we need a complete feed with penalties to test all live activity updates including ending the activity)
     def rawEventsLA: List[MatchEvent] = Parser.parseMatchEvents(loadFile("match-event-feed-penalties.xml")).get.events
     def matchDayLA: MatchDay = Parser.parseMatchDay(loadFile("4484328-penalites.xml")).head
-    def eventsLA: List[MatchEvent] = new SyntheticMatchEventGenerator().generate(rawEventsLA, "4484328", matchDayLA)
+    def eventsLA: List[MatchEvent] = new SyntheticMatchEventGenerator(ZonedDateTime.now()).generate(rawEventsLA, "4484328", matchDayLA)
     def matchDataLA = MatchDataWithArticle(matchDayLA, eventsLA, Some("football/live/2025/feb/11/exeter-city-v-nottingham-forest-juventus-v-psv-and-more-football-live"))
   }
 }

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
@@ -51,45 +51,46 @@ class SyntheticMatchEventGeneratorSpec extends Specification {
     )
 
     val kickoffId = UUID.nameUUIDFromBytes(s"football-match/match-id/timeline/00:00".getBytes).toString
+    val currentTime = ZonedDateTime.now()
   }
 
   "A SyntheticMatchEvent generator" should {
     "Add id to first timeline event" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo) mustEqual List(timelineEvent.copy(id = Some(kickoffId)))
     }
     "Add half-time event if status is HT" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "HT")).drop(1).head.eventType mustEqual "half-time"
     }
     "Add second-half event if status is SHS" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "SHS")).drop(1).head.eventType mustEqual "second-half"
     }
     "Add full-time event if match is result" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(result = true)).drop(1).head.eventType mustEqual "full-time"
     }
   }
 
   "A SyntheticMatchEvent generator supporting Live Activities" should {
     "Add a createChannel event if match kick off is within 2 hrs" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusHours(1))).head.eventType mustEqual "create-channel"
     }
 
     "Add a startLiveActivity event if match kick off is within 20min" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusMinutes(15))).head.eventType mustEqual "start-live-activity"
     }
 
     "Add id to first timeline event" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(date = ZonedDateTime.now())) mustEqual List(timelineEvent.copy(id = Some(kickoffId)))
     }
 
     "Add an endLiveActivity event if match info contains result" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(result = true)).reverse.head.eventType mustEqual "end-live-activity"
     }
   }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
@@ -1,9 +1,10 @@
 package com.gu.liveactivities
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
-import com.gu.liveactivities.models.{LiveActivityData, LiveActivityInvalidStateException}
+import com.gu.liveactivities.models.LiveActivityData
 import com.gu.liveactivities.service.ChannelApiClient
 import com.gu.liveactivities.util.Logging
+import com.gu.mobile.notifications.client.models.liveActitivites._
 import play.api.libs.json.{Format, JsError, JsSuccess, Json}
 
 import java.io.{InputStream, OutputStream}
@@ -21,7 +22,7 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
 
   val channelApiClient = new ChannelApiClient(authentication, config.bundleId, config.sendingToProdServer)
 
-  def processCreateChannelRequest(matchId: String, competitionId: Option[String], eventData: Option[LiveActivityData]): Future[String] = {
+  def processCreateChannelRequest(matchId: String, eventData: Option[LiveActivityData]): Future[String] = {
     logger.info(s"Received request to create channel for match ID $matchId")
 
     val maybeChannelId = repository.containMapping(matchId)
@@ -33,7 +34,7 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
       case None =>
         for {
           channelId <- channelApiClient.createChannel()
-          _ <- repository.createMapping(matchId, channelId, eventData, competitionId)
+          _ <- repository.createMapping(matchId, channelId, eventData)
           _ = logger.info(s"Channel created with channel ID $channelId for match ID $matchId")
         } yield channelId
     }
@@ -56,9 +57,15 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
   }
 
   def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
-    Json.parse(input).validate[ChannelRequest] match {
+    Json.parse(input).validate[EventBridgeEvent] match {
       case JsSuccess(request, _) => {
-        processRequest(request, context)
+        request.`detail-type` match {
+          case ChannelCreate | ChannelDelete =>
+            logger.info(s"Received ${request.`detail-type`.asString} event for event ID ${request.id}")
+          case other =>
+            logger.warn(s"Received unsupported event type: ${other.asString} for event ID ${request.id}")
+        }
+        processRequest(request.detail, context)
       }
       case JsError(errors) => {
         logger.error(s"Failed to parse request: $errors")
@@ -67,14 +74,16 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
     }
   }
 
-  // todo - consider error case: where a channel is created in APNS but the record update in Dynamo fails - consider cleanup mechanism for orphaned APNS channels.
-  // todo - consider error case: where channel created in APNS fails, how do we handle retries for upcoming live activities.
-  def processRequest(request: ChannelRequest, context: Context): Unit = {
-    val channelFuture = 
-      if (request.toCreate)
-        processCreateChannelRequest(request.matchId, request.competitionId, request.eventData)
-      else
-        processCloseChannelRequest(request.matchId)
+  def processRequest(request: LiveActivityPayload, context: Context): Unit = {
+    val channelFuture = request.eventType match {
+      case CreateChannelEvent =>
+        val eventData = request.broadcastContentStateData.map(LiveActivityData.toLiveActivityData)
+        processCreateChannelRequest(request.liveActivityID, eventData)
+      case DeleteChannelEvent =>
+        processCloseChannelRequest(request.liveActivityID)
+      case other =>
+        throw new Exception(s"Unsupported event type: ${other} for event ID ${request.id}")
+    }
 
     //Timeout set to 160 seconds to provide a safety buffer.
     // While the sum of downstream timeouts is at most ~110s,

--- a/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
@@ -39,5 +39,5 @@ trait Lambda {
       )
       .build()
 
-  val repository = new LiveActivityChannelRepository(dynamoDbClient, s"mobile-notifications-liveactivities-${config.stage}")
+  val repository = new LiveActivityChannelRepository(dynamoDbClient, s"mobile-notifications-liveactivities-CODE")
 }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/LambdaLocalRun.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/LambdaLocalRun.scala
@@ -8,9 +8,11 @@ import java.nio.charset.StandardCharsets
  */
 object ChannelManagerLambdaLocalRun extends App {
 
-  val channelId = "match123"
+  val channelId = "marjiMatch123"
 
   println("Start running ChannelManagerLambda locally")
+
+
 
   val createChannelJson = Json.toJson(ChannelRequest(channelId, Some("competiton-001"), None, toCreate = true)).toString()
 
@@ -20,37 +22,37 @@ object ChannelManagerLambdaLocalRun extends App {
 
   ChannelManagerLambda.handleRequest(createRequestStream, createResponseStream, null)
 
-  val closeRequest = ChannelRequest(channelId, None, None, toCreate = false)
+//  val closeRequest = ChannelRequest(channelId, None, None, toCreate = false)
+//
+//  val closeRequestStream = new java.io.ByteArrayInputStream(Json.toJson(closeRequest).toString().getBytes(StandardCharsets.UTF_8))
+//
+//  val closeResponseStream = new java.io.ByteArrayOutputStream()
+//
+//  ChannelManagerLambda.handleRequest(closeRequestStream, closeResponseStream, null)
 
-  val closeRequestStream = new java.io.ByteArrayInputStream(Json.toJson(closeRequest).toString().getBytes(StandardCharsets.UTF_8))
-
-  val closeResponseStream = new java.io.ByteArrayOutputStream()
-
-  ChannelManagerLambda.handleRequest(closeRequestStream, closeResponseStream, null)
-
-  println("Finished running ChannelManagerLambda locally with response: " + closeResponseStream.toString())
+//  println("Finished running ChannelManagerLambda locally with response: " + closeResponseStream.toString())
 }
-
-/**
- * Local run broadcasts a live activity update on the APNS Sandbox env for the iOS debug app.
- */
-object BroadcastLambdaLocalRun extends App {
-
-  println("Start running BroadcastLambda locally")
-
-  val broadcastRequest =
-    """{
-    "matchId": "match-test-6",
-    "payload": "test message",
-    "eventId": "event-007",
-    "eventTime": "2026-04-07T17:37:29.278+0000"
-  }"""
-
-  val broadcastRequestStream = new java.io.ByteArrayInputStream(broadcastRequest.getBytes(StandardCharsets.UTF_8))
-
-  val broadcastResponseStream = new java.io.ByteArrayOutputStream()
-
-  BroadcastLambda.handleRequest(broadcastRequestStream, broadcastResponseStream, null)
-
-  println("Finished running BroadcastLambda locally with response: " + broadcastResponseStream.toString())
-}
+//
+///**
+// * Local run broadcasts a live activity update on the APNS Sandbox env for the iOS debug app.
+// */
+//object BroadcastLambdaLocalRun extends App {
+//
+//  println("Start running BroadcastLambda locally")
+//
+//  val broadcastRequest =
+//    """{
+//    "matchId": "match-test-6",
+//    "payload": "test message",
+//    "eventId": "event-007",
+//    "eventTime": "2026-04-07T17:37:29.278+0000"
+//  }"""
+//
+//  val broadcastRequestStream = new java.io.ByteArrayInputStream(broadcastRequest.getBytes(StandardCharsets.UTF_8))
+//
+//  val broadcastResponseStream = new java.io.ByteArrayOutputStream()
+//
+//  BroadcastLambda.handleRequest(broadcastRequestStream, broadcastResponseStream, null)
+//
+//  println("Finished running BroadcastLambda locally with response: " + broadcastResponseStream.toString())
+//}

--- a/liveactivities/src/main/scala/com/gu/liveactivities/models/LiveActivities.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/models/LiveActivities.scala
@@ -4,18 +4,22 @@ import play.api.libs.json._
 import play.api.libs.json.Reads._
 import play.api.libs.json.Writes._
 import play.api.libs.functional.syntax._
+
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import com.gu.liveactivities.util.DateTimeHelper.{dateTimeFromString, dateTimeToString}
+import com.gu.mobile.notifications.client.models.liveActitivites.{ContentState, FootballMatchContentState}
 import org.scanamo.DynamoFormat
 import org.scanamo.generic.semiauto._
 
 sealed trait LiveActivityData
 
+// TODO: rename the file to be specific for dynamo metadata
 case class FootballLiveActivity(
     homeTeam: String,
     awayTeam: String,
-    articleUrl: String
+    competitionId: String,
+    kickOffTimestamp: Long
 ) extends LiveActivityData
 
 object FootballLiveActivity {
@@ -42,6 +46,16 @@ object LiveActivityData {
     }
 
   implicit val dynamoFormat: DynamoFormat[LiveActivityData] = deriveDynamoFormat[LiveActivityData]
+
+  def toLiveActivityData(contentState: ContentState): LiveActivityData = contentState match {
+    case footballMatchContentState: FootballMatchContentState =>
+      FootballLiveActivity(
+        homeTeam = footballMatchContentState.homeTeam.name,
+        awayTeam = footballMatchContentState.awayTeam.name,
+        competitionId = footballMatchContentState.competition.name,
+        kickOffTimestamp = footballMatchContentState.kickOffTimestamp
+      )
+  }
 }
 
 case class LiveActivityMapping(
@@ -50,7 +64,6 @@ case class LiveActivityMapping(
     isChannelActive: Boolean,
     isLive: Boolean,
     data: Option[LiveActivityData],
-    competitionId: Option[String],
     lastEventId: Option[String],
     lastEventAt: Option[ZonedDateTime],
 		createdAt: ZonedDateTime,

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
@@ -16,11 +16,10 @@ trait ChannelMappingsRepository {
 
   def containMapping(id: String): Future[Option[String]]
 
-  def createMapping(    
+  def createMapping(
     id: String,
     channelId: String,
-    eventData: Option[LiveActivityData],
-    competitionId: Option[String]): Future[Unit]
+    eventData: Option[LiveActivityData]): Future[Unit]
 
   def getMappingById(id: String): Future[LiveActivityMapping]
   
@@ -58,7 +57,6 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
     id: String,
     channelId: String,
     eventData: Option[LiveActivityData],
-    competitionId: Option[String],
   ): Future[Unit] = {
     val createdAt = ZonedDateTime.now()
     val newItem = new LiveActivityMapping(
@@ -66,8 +64,7 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
       channelId = channelId, 
       isChannelActive = true, 
       isLive = true, 
-      data = eventData, 
-      competitionId = competitionId,
+      data = eventData,
       lastEventId = None,
       lastEventAt = None,
       createdAt = createdAt,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
