### PR TITLE
Process channel events

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
@@ -60,6 +60,7 @@ object MatchStatus {
 }
 
 case class Competition(
+    id: String,
     name: String,
     round: Option[String] = None // World Cup Group name
 )

--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
@@ -11,11 +11,63 @@ import com.gu.mobile.notifications.client.models.Payload
  * Channel Manager and Broadcast lambdas.
  **/
 
+sealed trait EventSource
+case object FootballLambda extends EventSource
+
+object EventSource {
+  implicit val format: Format[EventSource] = new Format[EventSource] {
+    def writes(source: EventSource): JsValue = source match {
+      case FootballLambda => JsString("football-lambda")
+    }
+
+    def reads(json: JsValue): JsResult[EventSource] = json match {
+      case JsString("football-lambda") => JsSuccess(FootballLambda)
+      case JsString(other)             => JsError(s"Invalid EventSource: $other")
+      case _ => JsError("EventSource must be a string")
+    }
+  }
+}
+
+sealed trait LiveActivityEventType {
+  def asString: String
+}
+
+case object CreateChannelEvent extends LiveActivityEventType { val asString = "channel-create" }
+case object StartLiveActivityEvent extends LiveActivityEventType { val asString = "broadcast-start" }
+case object UpdateLiveActivityEvent extends LiveActivityEventType { val asString = "broadcast-update" }
+case object EndLiveActivityEvent extends LiveActivityEventType { val asString = "broadcast-end" }
+case object DeleteChannelEvent extends LiveActivityEventType { val asString = "channel-delete" }
+
+object LiveActivityEventType {
+  val values: Seq[LiveActivityEventType] = Seq(
+    CreateChannelEvent,
+    StartLiveActivityEvent,
+    UpdateLiveActivityEvent,
+    EndLiveActivityEvent,
+    DeleteChannelEvent
+  )
+
+  implicit val format: Format[LiveActivityEventType] = new Format[LiveActivityEventType] {
+    override def reads(json: JsValue): JsResult[LiveActivityEventType] = json match {
+      case JsString("channel-create")    => JsSuccess(CreateChannelEvent)
+      case JsString("broadcast-start")   => JsSuccess(StartLiveActivityEvent)
+      case JsString("broadcast-update")  => JsSuccess(UpdateLiveActivityEvent)
+      case JsString("broadcast-end")     => JsSuccess(EndLiveActivityEvent)
+      case JsString("channel-delete")    => JsSuccess(DeleteChannelEvent)
+      case JsString(other)               => JsError(s"Invalid LiveActivityEventType: $other")
+      case _                             => JsError("LiveActivityEventType must be a string")
+    }
+
+    override def writes(detailType: LiveActivityEventType): JsValue =
+      JsString(detailType.asString)
+  }
+}
+
 case class EventBridgeEvent(
   version: String,
   id: String,
-  `detail-type`: String,
-  source: String,
+  `detail-type`: LiveActivityEventType,
+  source: EventSource,
   account: String,
   time: String,
   region: String,
@@ -27,16 +79,6 @@ object EventBridgeEvent {
   implicit val eventBridgeEventFormat: Format[EventBridgeEvent] = Json.format[EventBridgeEvent]
 }
 
-// todo codify detail-type strings
-
-
-// Life cycle of a live activity:
-sealed trait LiveActivityEventType
-case object CreateChannelEvent extends LiveActivityEventType
-case object StartLiveActivityEvent extends LiveActivityEventType
-case object UpdateLiveActivityEvent extends LiveActivityEventType
-case object EndLiveActivityEvent extends LiveActivityEventType
-case object DeleteChannelEvent extends LiveActivityEventType
 
 sealed trait LiveActivityType
 case object FootballLiveActivity extends LiveActivityType
@@ -70,24 +112,6 @@ object LiveActivityPayload {
     },
     Writes {
       case FootballLiveActivity => JsString("FootballLiveActivity")
-    }
-  )
-
-  implicit val liveActivityEventTypeFormat: Format[LiveActivityEventType] = Format(
-    Reads {
-      case JsString("CreateChannel")      => JsSuccess(CreateChannelEvent)
-      case JsString("StartLiveActivity")  => JsSuccess(StartLiveActivityEvent)
-      case JsString("UpdateLiveActivity") => JsSuccess(UpdateLiveActivityEvent)
-      case JsString("EndLiveActivity")    => JsSuccess(EndLiveActivityEvent)
-      case JsString("DeleteChannel")      => JsSuccess(DeleteChannelEvent)
-      case _                              => JsError("Unknown LiveActivityEventType")
-    },
-    Writes {
-      case CreateChannelEvent      => JsString("CreateChannel")
-      case StartLiveActivityEvent  => JsString("StartLiveActivity")
-      case UpdateLiveActivityEvent => JsString("UpdateLiveActivity")
-      case EndLiveActivityEvent    => JsString("EndLiveActivity")
-      case DeleteChannelEvent      => JsString("DeleteChannel")
     }
   )
 

--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
@@ -84,15 +84,6 @@ sealed trait LiveActivityType
 case object FootballLiveActivity extends LiveActivityType
 // tbc cricket, elections
 
-case class dynamoData(
-  liveActivityId: String,
-  isLive: Boolean,
-  data: Option[String], // tbc
-  competitionId: Option[String], // should this move to data??†
-  lastEventId: Option[String],
-  lastEventAt: Option[Long]
-)
-
 case class LiveActivityPayload(
   id: UUID, // unique event id for each payload associate with a live activity, used for de-duplication
   eventType: LiveActivityEventType,
@@ -116,5 +107,4 @@ object LiveActivityPayload {
   )
 
   implicit val liveActivityPayloadFormat: Format[LiveActivityPayload] = Json.format[LiveActivityPayload]
-  implicit val dynamoDataFormat: Format[dynamoData] = Json.format[dynamoData]
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -49,7 +49,7 @@ object Lambda extends Logging {
 
   lazy val capiClient = GuardianContentClient(configuration.capiApiKey)
 
-  lazy val syntheticMatchEventGenerator = new SyntheticMatchEventGenerator()
+  lazy val syntheticMatchEventGenerator = new SyntheticMatchEventGenerator(getZonedDateTime())
 
   lazy val notificationHttpProvider = new NotificationHttpProvider()
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -69,7 +69,7 @@ class FootballData(
 
   def matchIdsInProgress(dateTime: ZonedDateTime): Future[List[MatchDay]] = {
     def inProgress(m: MatchDay): Boolean =
-      m.date.minusMinutes(5).isBefore(dateTime) && m.date.plusHours(4).isAfter(dateTime)
+      m.date.minusHours(2).isBefore(dateTime) && m.date.plusHours(4).isAfter(dateTime)
 
 
     // unfortunately PA provide 00:00 as start date when they don't have the start date

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
@@ -76,20 +76,20 @@ class LiveActivityPusher extends Logging {
 
         // todo - alert for failed entry counts?
         logger.info(
-          s"Eventbus pusher: Event published with event is ${payload.id}. Failed entry count: ${response.failedEntryCount()}"
+          s"Eventbus pusher: Event published with event ${payload.eventType} is ${payload.id}. Failed entry count: ${response.failedEntryCount()}"
         )
       }
 
       result match {
         case Success(_) => {
           logger.info(
-            s"Eventbus pusher: Successfully processed live activities event with id ${payload.id}"
+            s"Eventbus pusher: Successfully processed live activities event ${payload.eventType} with id ${payload.id}"
           )
           Future.successful(())
         }
         case Failure(e) => {
           logger.error(
-            s"Eventbus pusher: Failed to publish live activities event with id ${payload.id}: ${e.getMessage}"
+            s"Eventbus pusher: Failed to publish live activities event ${payload.eventType} with id ${payload.id}: ${e.getMessage}"
           )
           Future.failed(e)
         }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/LiveActivityPusher.scala
@@ -48,21 +48,11 @@ class LiveActivityPusher extends Logging {
       )
       Future.successful(())
     } else {
-
-      // TODO for the eventbus to direct the event to the right place
-      val activityType = payload.eventType match {
-        case CreateChannelEvent      => "channel-create"
-        case StartLiveActivityEvent  => "broadcast-start"
-        case UpdateLiveActivityEvent => "broadcast-update"
-        case EndLiveActivityEvent    => "broadcast-end"
-        case DeleteChannelEvent      => "channel-delete"
-      }
-
       val result = Try {
         val entry = PutEventsRequestEntry
           .builder()
           .source("football-lambda")
-          .detailType(activityType)
+          .detailType(payload.eventType.asString)
           .detail(Json.toJson(payload).toString())
           .eventBusName(eventBusName)
           .build()

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -1,10 +1,11 @@
 package com.gu.mobile.notifications.football.lib
 
 import java.util.UUID
-
 import pa.{MatchDay, MatchEvent}
 
-class SyntheticMatchEventGenerator {
+import java.time.ZonedDateTime
+
+class SyntheticMatchEventGenerator(dateTime: ZonedDateTime) {
 
   def generate(events: List[MatchEvent], id: String, matchDay: MatchDay): List[MatchEvent] = {
     // Live activity synthetic events are appended at the end, but when they are first generated, no other timeline events exist and duplicate events are filtered so this should not matter.
@@ -40,7 +41,7 @@ class SyntheticMatchEventGenerator {
 
   // Live Activity supporting events //
 
-  val now: Long = java.time.Instant.now.getEpochSecond
+  val now: Long = dateTime.toInstant.getEpochSecond
   def koWithinTwoHours(ko: Long): Boolean = now >= ko - 7200 && now < ko - 1200
   def koWithin20Minutes(ko: Long): Boolean = now >= ko - 1200 && now < ko
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -51,6 +51,7 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
         penaltyScore = PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, false)
       ),
       competition = Competition(
+        id = matchInfo.competition.map(_.id).getOrElse(""),
         name = matchInfo.competition.map(_.name).getOrElse(""),
         round = matchInfo.round.name // World Cup Group
       ),

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -304,7 +304,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
     def rawEvents: List[MatchEvent] =
       Parser.parseMatchEvents(loadFile("match-event-feed.xml")).get.events
     def matchDay: MatchDay = Parser.parseMatchDay(loadFile("20170811.xml")).head
-    def events: List[MatchEvent] = new SyntheticMatchEventGenerator().generate(
+    def events: List[MatchEvent] = new SyntheticMatchEventGenerator(ZonedDateTime.now()).generate(
       rawEvents,
       "4011135",
       matchDay
@@ -324,7 +324,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
       .events
     def matchDayLA: MatchDay =
       Parser.parseMatchDay(loadFile("4484328-penalties.xml")).head
-    def eventsLA: List[MatchEvent] = new SyntheticMatchEventGenerator()
+    def eventsLA: List[MatchEvent] = new SyntheticMatchEventGenerator(ZonedDateTime.now())
       .generate(rawEventsLA, "4484328", matchDayLA)
     def matchDataLA = MatchDataWithArticle(
       matchDayLA,

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
@@ -51,45 +51,46 @@ class SyntheticMatchEventGeneratorSpec extends Specification {
     )
 
     val kickoffId = UUID.nameUUIDFromBytes(s"football-match/match-id/timeline/00:00".getBytes).toString
+    val currentTime = ZonedDateTime.now()
   }
 
   "A SyntheticMatchEvent generator" should {
     "Add id to first timeline event" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo) mustEqual List(timelineEvent.copy(id = Some(kickoffId)))
     }
     "Add half-time event if status is HT" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "HT")).drop(1).head.eventType mustEqual "half-time"
     }
     "Add second-half event if status is SHS" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "SHS")).drop(1).head.eventType mustEqual "second-half"
     }
     "Add full-time event if match is result" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(result = true)).drop(1).head.eventType mustEqual "full-time"
     }
   }
 
   "A SyntheticMatchEvent generator supporting Live Activities" should {
     "Add a createChannel event if match kick off is within 2 hrs" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusHours(1))).head.eventType mustEqual "create-channel"
     }
 
     "Add a startLiveActivity event if match kick off is within 20min" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusMinutes(15))).head.eventType mustEqual "start-live-activity"
     }
 
     "Add id to first timeline event" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(date = ZonedDateTime.now())) mustEqual List(timelineEvent.copy(id = Some(kickoffId)))
     }
 
     "Add an endLiveActivity event if match info contains result" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(result = true)).reverse.head.eventType mustEqual "end-live-activity"
     }
   }

--- a/liveactivities/src/main/resources/broadcast-update-payload.json
+++ b/liveactivities/src/main/resources/broadcast-update-payload.json
@@ -27,6 +27,7 @@
         "redCards": 1
       },
       "competition": {
+        "id": "100",
         "name": "World Cup",
         "round": "Group C"
       },

--- a/liveactivities/src/main/resources/channel-create-payload.json
+++ b/liveactivities/src/main/resources/channel-create-payload.json
@@ -1,0 +1,41 @@
+{
+  "version": "0",
+  "id": "65587515-3040-b54e-t00d-4b7970bdd1eb",
+  "detail-type": "channel-create",
+  "source": "football-lambda",
+  "account": "00000000000000",
+  "time": "2026-04-27T08:36:52Z",
+  "region": "eu-west-1",
+  "resources": [],
+  "detail": {
+    "id": "165875bb-ade9-3245-b602-6343a1dd406d",
+    "eventType": "channel-create",
+    "liveActivityType": "FootballLiveActivity",
+    "liveActivityID": "123456-test",
+    "dynamoStoreData": "",
+    "broadcastContentStateData": {
+      "matchStatus": "SCHEDULED",
+      "kickOffTimestamp": 1766433600,
+      "homeTeam": {
+        "name": "Team A",
+        "score": 3,
+        "redCards": 1
+      },
+      "awayTeam": {
+        "name": "Team B",
+        "score": 5,
+        "redCards": 1
+      },
+      "competition": {
+        "name": "World Cup",
+        "round": "Group C"
+      },
+      "commentary" : "Predicted to be an exciting match",
+      "lineupsAvailable" : true,
+      "currentMinute" : 0
+    },
+    "eventTimestamp": 1777278992019
+  }
+}
+
+

--- a/liveactivities/src/main/resources/channel-create-payload.json
+++ b/liveactivities/src/main/resources/channel-create-payload.json
@@ -27,6 +27,7 @@
         "redCards": 1
       },
       "competition": {
+        "id": "100",
         "name": "World Cup",
         "round": "Group C"
       },

--- a/liveactivities/src/main/resources/channel-delete-payload.json
+++ b/liveactivities/src/main/resources/channel-delete-payload.json
@@ -1,0 +1,41 @@
+{
+  "version": "0",
+  "id": "65587515-3040-b54e-t00d-4b7970bdd1eb",
+  "detail-type": "channel-delete",
+  "source": "football-lambda",
+  "account": "00000000000000",
+  "time": "2026-04-27T08:36:52Z",
+  "region": "eu-west-1",
+  "resources": [],
+  "detail": {
+    "id": "165875bb-ade9-3245-b602-6343a1dd406d",
+    "eventType": "channel-delete",
+    "liveActivityType": "FootballLiveActivity",
+    "liveActivityID": "123456-test",
+    "dynamoStoreData": "",
+    "broadcastContentStateData": {
+      "matchStatus": "SCHEDULED",
+      "kickOffTimestamp": 1766433600,
+      "homeTeam": {
+        "name": "Team A",
+        "score": 3,
+        "redCards": 1
+      },
+      "awayTeam": {
+        "name": "Team B",
+        "score": 5,
+        "redCards": 1
+      },
+      "competition": {
+        "name": "World Cup",
+        "round": "Group C"
+      },
+      "commentary" : "Predicted to be an exciting match",
+      "lineupsAvailable" : true,
+      "currentMinute" : 0
+    },
+    "eventTimestamp": 1777278992019
+  }
+}
+
+

--- a/liveactivities/src/main/resources/channel-delete-payload.json
+++ b/liveactivities/src/main/resources/channel-delete-payload.json
@@ -27,6 +27,7 @@
         "redCards": 1
       },
       "competition": {
+        "id": "100",
         "name": "World Cup",
         "round": "Group C"
       },

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -32,12 +32,7 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
       case JsSuccess(request, _) => {
 
         // If we see these errors there is a misconfiguration in the eventbridge routing rules.
-        // todo codify detail-type strings in the model. They are in the LiveActivityEventPusher
-        if (request.source != "football-lambda") {
-          logger.error(s"Unexpected eventbridge event source: ${request.source}")
-          throw new Exception(s"Unexpected event source: ${request.source}")
-        }
-        if (request.`detail-type` != "broadcast-update" && request.`detail-type` != "broadcast-end") {
+        if (request.`detail-type` != UpdateLiveActivityEvent && request.`detail-type` != EndLiveActivityEvent) {
           logger.error(s"Unexpected eventbridge event type: ${request.`detail-type`}")
           throw new Exception(s"Unexpected event type: ${request.`detail-type`}")
         }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
@@ -1,9 +1,10 @@
 package com.gu.liveactivities
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
-import com.gu.liveactivities.models.{LiveActivityData, LiveActivityInvalidStateException}
+import com.gu.liveactivities.models.LiveActivityData
 import com.gu.liveactivities.service.ChannelApiClient
 import com.gu.liveactivities.util.Logging
+import com.gu.mobile.notifications.client.models.liveActitivites.{CreateChannelEvent, DeleteChannelEvent, EventBridgeEvent, LiveActivityPayload}
 import play.api.libs.json.{Format, JsError, JsSuccess, Json}
 
 import java.io.{InputStream, OutputStream}
@@ -19,9 +20,9 @@ object ChannelRequest {
 
 object ChannelManagerLambda extends RequestStreamHandler with Lambda with Logging {
 
-  val channelApiClient = new ChannelApiClient(authentication, config.bundleId, config.sendingToProdServer)
+  private val channelApiClient = new ChannelApiClient(authentication, config.bundleId, config.sendingToProdServer)
 
-  def processCreateChannelRequest(matchId: String, competitionId: Option[String], eventData: Option[LiveActivityData]): Future[String] = {
+  private def processCreateChannelRequest(matchId: String, eventData: Option[LiveActivityData]): Future[String] = {
     logger.info(s"Received request to create channel for match ID $matchId")
 
     val maybeChannelId = repository.containMapping(matchId)
@@ -33,13 +34,13 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
       case None =>
         for {
           channelId <- channelApiClient.createChannel()
-          _ <- repository.createMapping(matchId, channelId, eventData, competitionId)
+          _ <- repository.createMapping(matchId, channelId, eventData)
           _ = logger.info(s"Channel created with channel ID $channelId for match ID $matchId")
         } yield channelId
     }
   }
 
-  def processCloseChannelRequest(matchId: String): Future[String] = {
+  private def processCloseChannelRequest(matchId: String): Future[String] = {
     logger.info(s"Channel closed for match ID: $matchId")
     val maybeMapping = repository.getMappingById(matchId)
     maybeMapping.flatMap{
@@ -56,25 +57,31 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
   }
 
   def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
-    Json.parse(input).validate[ChannelRequest] match {
-      case JsSuccess(request, _) => {
-        processRequest(request, context)
-      }
-      case JsError(errors) => {
+    Json.parse(input).validate[EventBridgeEvent] match {
+      case JsSuccess(request, _) =>
+        request.`detail-type` match {
+          case CreateChannelEvent | DeleteChannelEvent =>
+            processRequest(request.detail, context)
+          case other =>
+            throw new Exception(s"Received unsupported event type: ${other.asString} for event ID ${request.id}")
+        }
+      case JsError(errors) =>
         logger.error(s"Failed to parse request: $errors")
         throw new Exception(s"Invalid request: $errors")
-      }
     }
   }
 
   // todo - consider error case: where a channel is created in APNS but the record update in Dynamo fails - consider cleanup mechanism for orphaned APNS channels.
-  // todo - consider error case: where channel created in APNS fails, how do we handle retries for upcoming live activities.
-  def processRequest(request: ChannelRequest, context: Context): Unit = {
-    val channelFuture = 
-      if (request.toCreate)
-        processCreateChannelRequest(request.matchId, request.competitionId, request.eventData)
-      else
-        processCloseChannelRequest(request.matchId)
+  private def processRequest(request: LiveActivityPayload, context: Context): Unit = {
+    val channelFuture = request.eventType match {
+      case CreateChannelEvent =>
+        val eventData = request.broadcastContentStateData.map(LiveActivityData.toLiveActivityData)
+        processCreateChannelRequest(request.liveActivityID, eventData)
+      case DeleteChannelEvent =>
+        processCloseChannelRequest(request.liveActivityID)
+      case other =>
+        throw new Exception(s"Unsupported event type: ${other} for event ID ${request.id}")
+    }
 
     //Timeout set to 160 seconds to provide a safety buffer.
     // While the sum of downstream timeouts is at most ~110s,

--- a/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
@@ -39,5 +39,5 @@ trait Lambda {
       )
       .build()
 
-  val repository = new LiveActivityChannelRepository(dynamoDbClient, s"mobile-notifications-liveactivities-${config.stage}")
+  val repository = new LiveActivityChannelRepository(dynamoDbClient, s"mobile-notifications-liveactivities-CODE")
 }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
@@ -39,5 +39,5 @@ trait Lambda {
       )
       .build()
 
-  val repository = new LiveActivityChannelRepository(dynamoDbClient, s"mobile-notifications-liveactivities-CODE")
+  val repository = new LiveActivityChannelRepository(dynamoDbClient, s"mobile-notifications-liveactivities-${config.stage}")
 }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/LambdaLocalRun.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/LambdaLocalRun.scala
@@ -7,30 +7,28 @@ import java.nio.charset.StandardCharsets
 /**
  *  Local run creates and closes a channel on the APNS Sandbox env for the iOS debug app.
  */
-//object ChannelManagerLambdaLocalRun extends App {
-//
-//  val channelId = "match123"
-//
-//  println("Start running ChannelManagerLambda locally")
-//
-//  val createChannelJson = Json.toJson(ChannelRequest(channelId, Some("competiton-001"), None, toCreate = true)).toString()
-//
-//  val createRequestStream = new java.io.ByteArrayInputStream(createChannelJson.getBytes(StandardCharsets.UTF_8))
-//
-//  val createResponseStream = new java.io.ByteArrayOutputStream()
-//
-//  ChannelManagerLambda.handleRequest(createRequestStream, createResponseStream, null)
-//
-//  val closeRequest = ChannelRequest(channelId, None, None, toCreate = false)
-//
-//  val closeRequestStream = new java.io.ByteArrayInputStream(Json.toJson(closeRequest).toString().getBytes(StandardCharsets.UTF_8))
-//
-//  val closeResponseStream = new java.io.ByteArrayOutputStream()
-//
-//  ChannelManagerLambda.handleRequest(closeRequestStream, closeResponseStream, null)
-//
-//  println("Finished running ChannelManagerLambda locally with response: " + closeResponseStream.toString())
-//}
+object ChannelManagerLambdaLocalRun extends App {
+
+  println("Start running ChannelManagerLambda locally")
+
+  val createChannelJson = Source.fromResource("channel-create-payload.json").mkString
+
+  val createRequestStream = new java.io.ByteArrayInputStream(createChannelJson.getBytes(StandardCharsets.UTF_8))
+
+  val createResponseStream = new java.io.ByteArrayOutputStream()
+
+  ChannelManagerLambda.handleRequest(createRequestStream, createResponseStream, null)
+
+  val closeChannelJson = Source.fromResource("channel-delete-payload.json").mkString
+
+  val closeRequestStream = new java.io.ByteArrayInputStream(closeChannelJson.getBytes(StandardCharsets.UTF_8))
+
+  val closeResponseStream = new java.io.ByteArrayOutputStream()
+
+  ChannelManagerLambda.handleRequest(closeRequestStream, closeResponseStream, null)
+
+  println("Finished running ChannelManagerLambda locally with response: " + closeResponseStream.toString())
+}
 
 /**
  * Local run broadcasts a live activity update on the APNS Sandbox env for the iOS debug app.

--- a/liveactivities/src/main/scala/com/gu/liveactivities/LambdaLocalRun.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/LambdaLocalRun.scala
@@ -7,30 +7,30 @@ import java.nio.charset.StandardCharsets
 /**
  *  Local run creates and closes a channel on the APNS Sandbox env for the iOS debug app.
  */
-object ChannelManagerLambdaLocalRun extends App {
-
-  val channelId = "match123"
-
-  println("Start running ChannelManagerLambda locally")
-
-  val createChannelJson = Json.toJson(ChannelRequest(channelId, Some("competiton-001"), None, toCreate = true)).toString()
-
-  val createRequestStream = new java.io.ByteArrayInputStream(createChannelJson.getBytes(StandardCharsets.UTF_8))
-
-  val createResponseStream = new java.io.ByteArrayOutputStream()
-
-  ChannelManagerLambda.handleRequest(createRequestStream, createResponseStream, null)
-
-  val closeRequest = ChannelRequest(channelId, None, None, toCreate = false)
-
-  val closeRequestStream = new java.io.ByteArrayInputStream(Json.toJson(closeRequest).toString().getBytes(StandardCharsets.UTF_8))
-
-  val closeResponseStream = new java.io.ByteArrayOutputStream()
-
-  ChannelManagerLambda.handleRequest(closeRequestStream, closeResponseStream, null)
-
-  println("Finished running ChannelManagerLambda locally with response: " + closeResponseStream.toString())
-}
+//object ChannelManagerLambdaLocalRun extends App {
+//
+//  val channelId = "match123"
+//
+//  println("Start running ChannelManagerLambda locally")
+//
+//  val createChannelJson = Json.toJson(ChannelRequest(channelId, Some("competiton-001"), None, toCreate = true)).toString()
+//
+//  val createRequestStream = new java.io.ByteArrayInputStream(createChannelJson.getBytes(StandardCharsets.UTF_8))
+//
+//  val createResponseStream = new java.io.ByteArrayOutputStream()
+//
+//  ChannelManagerLambda.handleRequest(createRequestStream, createResponseStream, null)
+//
+//  val closeRequest = ChannelRequest(channelId, None, None, toCreate = false)
+//
+//  val closeRequestStream = new java.io.ByteArrayInputStream(Json.toJson(closeRequest).toString().getBytes(StandardCharsets.UTF_8))
+//
+//  val closeResponseStream = new java.io.ByteArrayOutputStream()
+//
+//  ChannelManagerLambda.handleRequest(closeRequestStream, closeResponseStream, null)
+//
+//  println("Finished running ChannelManagerLambda locally with response: " + closeResponseStream.toString())
+//}
 
 /**
  * Local run broadcasts a live activity update on the APNS Sandbox env for the iOS debug app.

--- a/liveactivities/src/main/scala/com/gu/liveactivities/models/LiveActivities.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/models/LiveActivities.scala
@@ -1,21 +1,20 @@
 package com.gu.liveactivities.models
 
-import play.api.libs.json._
-import play.api.libs.json.Reads._
-import play.api.libs.json.Writes._
-import play.api.libs.functional.syntax._
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
-import com.gu.liveactivities.util.DateTimeHelper.{dateTimeFromString, dateTimeToString}
+import com.gu.mobile.notifications.client.models.liveActitivites.{ContentState, FootballMatchContentState}
 import org.scanamo.DynamoFormat
 import org.scanamo.generic.semiauto._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
+
+import java.time.ZonedDateTime
 
 sealed trait LiveActivityData
 
 case class FootballLiveActivity(
     homeTeam: String,
     awayTeam: String,
-    articleUrl: String
+    competitionId: String,
+    kickOffTimestamp: Long
 ) extends LiveActivityData
 
 object FootballLiveActivity {
@@ -42,6 +41,15 @@ object LiveActivityData {
     }
 
   implicit val dynamoFormat: DynamoFormat[LiveActivityData] = deriveDynamoFormat[LiveActivityData]
+  def toLiveActivityData(contentState: ContentState): LiveActivityData = contentState match {
+    case footballMatchContentState: FootballMatchContentState =>
+      FootballLiveActivity(
+        homeTeam = footballMatchContentState.homeTeam.name,
+        awayTeam = footballMatchContentState.awayTeam.name,
+        competitionId = footballMatchContentState.competition.name,
+        kickOffTimestamp = footballMatchContentState.kickOffTimestamp
+      )
+  }
 }
 
 case class LiveActivityMapping(
@@ -50,7 +58,6 @@ case class LiveActivityMapping(
     isChannelActive: Boolean,
     isLive: Boolean,
     data: Option[LiveActivityData],
-    competitionId: Option[String],
     lastEventId: Option[String],
     lastEventAt: Option[ZonedDateTime],
 		createdAt: ZonedDateTime,
@@ -58,7 +65,6 @@ case class LiveActivityMapping(
 )
 
 object LiveActivityMapping {
-
   import com.gu.liveactivities.util.DateTimeHelper.zonedDateTimeJsonFormat
 
   import com.gu.liveactivities.util.DateTimeHelper.zonedDateTimeDynamoFormat

--- a/liveactivities/src/main/scala/com/gu/liveactivities/models/LiveActivities.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/models/LiveActivities.scala
@@ -41,12 +41,13 @@ object LiveActivityData {
     }
 
   implicit val dynamoFormat: DynamoFormat[LiveActivityData] = deriveDynamoFormat[LiveActivityData]
+
   def toLiveActivityData(contentState: ContentState): LiveActivityData = contentState match {
     case footballMatchContentState: FootballMatchContentState =>
       FootballLiveActivity(
         homeTeam = footballMatchContentState.homeTeam.name,
         awayTeam = footballMatchContentState.awayTeam.name,
-        competitionId = footballMatchContentState.competition.name,
+        competitionId = footballMatchContentState.competition.id,
         kickOffTimestamp = footballMatchContentState.kickOffTimestamp
       )
   }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
@@ -19,8 +19,7 @@ trait ChannelMappingsRepository {
   def createMapping(    
     id: String,
     channelId: String,
-    eventData: Option[LiveActivityData],
-    competitionId: Option[String]): Future[Unit]
+    eventData: Option[LiveActivityData]): Future[Unit]
 
   def getMappingById(id: String): Future[LiveActivityMapping]
   
@@ -58,16 +57,14 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
     id: String,
     channelId: String,
     eventData: Option[LiveActivityData],
-    competitionId: Option[String],
   ): Future[Unit] = {
     val createdAt = ZonedDateTime.now()
     val newItem = new LiveActivityMapping(
       id = id, 
       channelId = channelId, 
       isChannelActive = true, 
-      isLive = true, 
-      data = eventData, 
-      competitionId = competitionId,
+      isLive = true,
+      data = eventData,
       lastEventId = None,
       lastEventAt = None,
       createdAt = createdAt,

--- a/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivityChannelRepositorySpec.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivityChannelRepositorySpec.scala
@@ -1,18 +1,13 @@
 package com.gu.liveactivities
 
+import com.gu.liveactivities.models.{FootballLiveActivity, LiveActivityMapping, RepositoryException}
+import com.gu.liveactivities.service.LiveActivityChannelRepository
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
-import software.amazon.awssdk.services.dynamodb.model._
-import scala.jdk.CollectionConverters._
-import com.gu.liveactivities.service.LiveActivityChannelRepository
-import com.gu.liveactivities.models.FootballLiveActivity
-import com.gu.liveactivities.models.LiveActivityMapping
-import com.gu.liveactivities.models.LiveActivityData
-import com.gu.liveactivities.service.ChannelMappingsRepository
-import java.time.ZonedDateTime
-import com.gu.liveactivities.models.RepositoryException
-import com.gu.liveactivities.models.LiveActivityInvalidStateException
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model._
+
+import java.time.ZonedDateTime
 
 class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
     extends DynamodbSpecification
@@ -37,8 +32,7 @@ class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
       repository.createMapping(
         footballMapping.id, 
         footballMapping.channelId, 
-        footballMapping.data, 
-        footballMapping.competitionId).flatMap { _ =>
+        footballMapping.data).flatMap { _ =>
         repository.getMappingById(footballMapping.id)
       } must beEqualToExcludingMetaData(footballMapping).await
     }
@@ -48,12 +42,10 @@ class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
       val footballMapping = createFootballMappingWithId("football-0004")
       repository.createMapping(footballMapping.id, 
         footballMapping.channelId, 
-        footballMapping.data, 
-        footballMapping.competitionId).flatMap { _ =>
+        footballMapping.data).flatMap { _ =>
         repository.createMapping(footballMapping.id, 
           footballMapping.channelId, 
-          footballMapping.data, 
-          footballMapping.competitionId)
+          footballMapping.data)
       } must throwA[RepositoryException].await
     }
 
@@ -63,8 +55,7 @@ class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
       repository.createMapping(
         footballMapping.id, 
         footballMapping.channelId, 
-        footballMapping.data, 
-        footballMapping.competitionId).flatMap { _ =>
+        footballMapping.data).flatMap { _ =>
         repository.deleteMappingById(footballMapping.id)
       } must beEqualTo(()).await
     }
@@ -75,8 +66,7 @@ class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
       repository.createMapping(
         footballMapping.id, 
         footballMapping.channelId, 
-        footballMapping.data, 
-        footballMapping.competitionId).flatMap { _ =>
+        footballMapping.data).flatMap { _ =>
         repository.getMappingById(footballMapping.id)
       } must beEqualToExcludingMetaData(footballMapping).await
     }
@@ -90,7 +80,8 @@ class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
     val footballData = FootballLiveActivity(
       homeTeam = "HomeTeamName",
       awayTeam = "AwayTeamName",
-      articleUrl = "https://www.theguardian.com/football/test-article-id"
+      competitionId = "test-competition-id",
+      kickOffTimestamp = 1766433600
     )
 
     val footballMappingTemplate = LiveActivityMapping(
@@ -99,7 +90,6 @@ class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
       isChannelActive = true,
       isLive = true,     
       data = Some(footballData),
-      competitionId = Some("test-competition-id"),
       lastEventId = None,
       lastEventAt = None,
       createdAt = ZonedDateTime.now(),

--- a/liveactivities/src/test/scala/com/gu/liveactivities/models/BroadcastPayloadsSpec.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/models/BroadcastPayloadsSpec.scala
@@ -12,7 +12,7 @@ class BroadcastPayloadsSpec extends Specification {
 
     val homeTeam = TeamState(name = "Arsenal", score = 1)
     val awayTeam = TeamState(name = "Chelsea", score = 0)
-    val competition = Competition(name = "Premier League", round = Some("League"))
+    val competition = Competition(id = "100", name = "Premier League", round = Some("League"))
 
     val contentState = FootballMatchContentState(
       matchStatus = FirstHalf,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR ensures that the channel manager successfully receives and processes the vent bridge events. The following changes were implemented:
- Created types for `source` & `detail-type` within the `EventBridgeEvent` to avoid using String for them

- Shared the existing LiveActivityEventType type between `LiveActivityPayload.eventType` & `EventBridgeEvent.detail-type`. This is done to avoid consusion and duplication of types that were very similar
- Parameterized the date in SyntheticMatchEventGenerator to keep it in sync with PA polling, ensuring reliable event generation when using historical data in the CODE environment.
https://github.com/guardian/mobile-n10n/blob/main/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala#L66
- Modified the Channel Manager to accept the structured EventBridgeEvent as the primary input.
- Included competitionId in the content state to improve downstream event context.


## Test
Fully tested this locally and also in CODE. Set the time machine to about 1 hour before the start of match, and noticed the channel manager create a new channel. Then when the match started, the broadcast events were successfully processed by the broadcast manager. 