### PR TITLE
Improve broadcast lambda error handling

### DIFF
--- a/cdk/lib/__snapshots__/liveactivities.test.ts.snap
+++ b/cdk/lib/__snapshots__/liveactivities.test.ts.snap
@@ -18,6 +18,34 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
     },
   },
   "Resources": {
+    "BroadcastDlq8DE17B20": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 604800,
+        "QueueName": "liveactivities-broadcast-dlq-CODE",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VisibilityTimeout": 240,
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
     "BroadcastRule3D75643B": {
       "Properties": {
         "EventBusName": {
@@ -307,9 +335,29 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
             "Value": "CODE",
           },
         ],
-        "Timeout": 120,
+        "Timeout": 180,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "liveactivitiesbroadcastlambdaEventInvokeConfig841BCA48": {
+      "Properties": {
+        "DestinationConfig": {
+          "OnFailure": {
+            "Destination": {
+              "Fn::GetAtt": [
+                "BroadcastDlq8DE17B20",
+                "Arn",
+              ],
+            },
+          },
+        },
+        "FunctionName": {
+          "Ref": "liveactivitiesbroadcastlambdaC288C367",
+        },
+        "MaximumRetryAttempts": 2,
+        "Qualifier": "$LATEST",
+      },
+      "Type": "AWS::Lambda::EventInvokeConfig",
     },
     "liveactivitiesbroadcastlambdaServiceRoleB0F7837A": {
       "Properties": {
@@ -368,6 +416,20 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "BroadcastDlq8DE17B20",
+                  "Arn",
+                ],
+              },
+            },
             {
               "Action": [
                 "s3:GetObject*",

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -78,6 +78,12 @@ export class LiveActivities extends GuStack {
 			}),
 		);
 
+		const broadcastDlq = new Queue(this, 'BroadcastDlq', {
+			queueName: `${app}-broadcast-dlq-${stage}`,
+			visibilityTimeout: Duration.minutes(4),
+			retentionPeriod: Duration.days(7),
+		});
+
 		const broadcastLambda = new GuLambdaFunction(
 			this,
 			`${app}-broadcast-lambda`,
@@ -89,7 +95,9 @@ export class LiveActivities extends GuStack {
 				fileName: `${app}.jar`,
 				runtime: Runtime.JAVA_11,
 				memorySize: 1024,
-				timeout: Duration.seconds(120),
+				timeout: Duration.minutes(3),
+				onFailure: new SqsDestination(broadcastDlq),
+				retryAttempts: 2,
 				environment: {
 					Stack: stack,
 					Stage: stage,

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -21,6 +21,8 @@ import java.time.ZonedDateTime
 import com.gu.liveactivities.util.DateTimeHelper.{dateTimeFromLong, dateTimeToLong, dateTimeToString}
 import com.gu.mobile.notifications.client.models.liveActitivites.{EndLiveActivityEvent, EventBridgeEvent, FootballMatchContentState, LiveActivityPayload, UpdateLiveActivityEvent}
 
+import scala.concurrent.duration.DurationInt
+
 
 
 object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
@@ -106,8 +108,12 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
       _ = logger.info(s"Record updated successfully for match ID $matchId")
     } yield mapping.channelId
 
-    // TODO - the timeout value
-    Try(Await.result(broadcastFuture, scala.concurrent.duration.Duration.Inf)) match {
+    //Timeout set to 160 seconds to provide a safety buffer.
+    // While the sum of downstream timeouts is at most ~110s,
+    // we allow extra time for other things such as JSON parsing, cold starts,
+    // authentication token fetches, and potential network congestion
+    // to ensure the Lambda doesn't fail a healthy request that is just running slow.
+    Try(Await.result(broadcastFuture, 160.seconds)) match {
 
       case Success(_) => {
         // todo


### PR DESCRIPTION
This PR improves the error handling for broadcast lambda:

**SQS Destination (On Failure):**
Added an SQS Destination (On Failure) to capture failed events.

Unlike a standard DLQ, this provides the full responsePayload (stack trace and error message) directly in the SQS message for easier debugging.

**Refined Timeout:**
App-level Timeout (160s): Calculated based on the maximum cumulative latency of downstream calls ($10s \text{ (Read)} + 90s \text{ (Create Channel)} + 10s \text{ (Write)}$) plus a 50s buffer to account for cold starts, authentication token fetches, potential network congestion, JSON parsing, etc.