### PR TITLE
Implement Match Status and CurrentMinute

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
@@ -43,20 +43,57 @@ case object Abandoned extends MatchStatus { val status = "ABANDONED" }
 // @formatter:on
 
 object MatchStatus {
-  def fromString(s: String): MatchStatus = s match {
-    case "Pre-match" | "prematch"                        => PreMatch
-    case "MatchInProgress" | "1st Half" | "first_half"   => FirstHalf
-    case "HalfTime" | "Half Time" | "half_time"          => HalfTime
-    case "2nd Half" | "second_half"                      => SecondHalf
-    case "Extra Time" | "ET 1st Half"                    => ExtraTimeFirstHalf
-    case "ET Half Time"                                  => ExtraTimeHalfTime
-    case "ET 2nd Half"                                   => ExtraTimeSecondHalf
-    case "Penalties"                                     => Penalties
-    case "MatchComplete" | "MC" | "Full Time" | "Result" => FullTime
+  def fromString(s: String): MatchStatus = statuses.getOrElse(s, s) match {
+    case "Prematch"                                      => PreMatch
+    case "1st"                                           => FirstHalf
+    case "HT"                                            => HalfTime
+    case "2nd"                                           => SecondHalf
+    case "ET" | "ETS"                                    => ExtraTimeFirstHalf
+    case "ETHT"                                          => ExtraTimeHalfTime
+    case "ETSHS"                                         => ExtraTimeSecondHalf
+    case "PT"                                            => Penalties
+    case "FT"                                            => FullTime
     case "Postponed"                                     => Postponed
     case "Abandoned"                                     => Abandoned
     case _                                               => Scheduled
   }
+
+  // How PA match status are handled differs from push notification
+  private val statuses = Map(
+    ("KO", "1st"), // The Match has started (Kicked Off).
+
+    ("HT", "HT"), // The Referee has blown the whistle for Half Time.
+
+    ("SHS", "2nd"), // The Second Half of the Match has Started.
+
+    ("FT", "FT"), // The Referee has blown the whistle for Full Time.
+    ("PTFT", "FT"), // Penalty ShooT Full Time.
+    ("Result", "FT"), // The Result is official.
+    ("ETFT", "FT"), // Extra Time, Full Time has been blown.
+    ("MC", "FT"), // Match has been Completed.
+
+    ("FTET", "ET"), // Full Time, Extra Time it to be played.
+    ("ETS", "ETS"), // Extra Time has Started.
+    ("ETHT", "ETHT"), // Extra Time Half Time has been called.
+    ("ETSHS", "ETSHS"), // Extra Time, Second Half has Started.
+
+    ("FTPT", "PT"), // Full Time, Penalties are To be played.
+    ("PT", "PT"), // Penalty ShooT Out has started.
+    ("ETFTPT", "PT"), // Extra Time, Full Time, Penalties are To be played.
+
+    // Prematch
+    ("Fixture", "Prematch"), // fixture maps to 1st just in case the matchInfo and event feed are out of sync
+    ("-", "Prematch"), // same as above
+    ("New", "Prematch"), // New Match has been added to our data.
+
+    // edge cases
+    // TODO these need to be addressed. A match can be suspended and resumed within x days?)
+    ("Suspended", "S"), // Match has been Suspended. // todo when does this happen?
+    ("Resumed", "R"), // Match has been Resumed. // todo what game time does this map to? first half second half? match minute?
+    ("Abandoned", "A"), // Match has been Abandoned.
+    ("Cancelled", "C") // A Match has been Cancelled.
+    // POSTPONED???
+  )
 }
 
 case class Competition(

--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
@@ -33,66 +33,56 @@ case object PreMatch extends MatchStatus { val status = "PRE_MATCH" }
 case object FirstHalf extends MatchStatus { val status = "FIRST_HALF" }
 case object HalfTime extends MatchStatus { val status = "HALF_TIME" }
 case object SecondHalf extends MatchStatus { val status = "SECOND_HALF" }
+case object ExtraTimeToBePlayed extends MatchStatus { val status = "EXTRA_TIME_TO_BE_PLAYED" }
 case object ExtraTimeFirstHalf extends MatchStatus { val status = "EXTRA_TIME_FIRST_HALF" }
 case object ExtraTimeHalfTime extends MatchStatus { val status = "EXTRA_TIME_HALF_TIME" }
 case object ExtraTimeSecondHalf extends MatchStatus { val status = "EXTRA_TIME_SECOND_HALF" }
+case object PenaltiesToBePlayed extends MatchStatus { val status = "PENALTIES_TO_BE_PLAYED" }
 case object Penalties extends MatchStatus { val status = "PENALTIES" }
 case object FullTime extends MatchStatus { val status = "FULL_TIME" }
 case object Postponed extends MatchStatus { val status = "POSTPONED" }
+case object Suspended extends MatchStatus { val status = "SUSPENDED" }
 case object Abandoned extends MatchStatus { val status = "ABANDONED" }
+case object Resumed extends MatchStatus { val status = "RESUMED" }
+case object Cancelled extends MatchStatus { val status = "CANCELLED" }
 // @formatter:on
 
 object MatchStatus {
-  def fromString(s: String): MatchStatus = statuses.getOrElse(s, s) match {
-    case "Prematch"                                      => PreMatch
-    case "1st"                                           => FirstHalf
-    case "HT"                                            => HalfTime
-    case "2nd"                                           => SecondHalf
-    case "ET" | "ETS"                                    => ExtraTimeFirstHalf
-    case "ETHT"                                          => ExtraTimeHalfTime
-    case "ETSHS"                                         => ExtraTimeSecondHalf
-    case "PT"                                            => Penalties
-    case "FT"                                            => FullTime
-    case "Postponed"                                     => Postponed
-    case "Abandoned"                                     => Abandoned
-    case _                                               => Scheduled
-  }
+  def fromString(s: String): MatchStatus = statuses.getOrElse(s, Scheduled)
 
-  // How PA match status are handled differs from push notification
-  private val statuses = Map(
-    ("KO", "1st"), // The Match has started (Kicked Off).
+  // How PA match status are handled here differs from push notification mappings
+  private val statuses: Map[String, MatchStatus] = Map(
+    ("Fixture", PreMatch), //
+    ("-", PreMatch), // seen in the wild
+    ("New", PreMatch), //
 
-    ("HT", "HT"), // The Referee has blown the whistle for Half Time.
+    ("KO", FirstHalf), // The Match has started (Kicked Off).
 
-    ("SHS", "2nd"), // The Second Half of the Match has Started.
+    ("HT", HalfTime), // The Referee has blown the whistle for Half Time.
 
-    ("FT", "FT"), // The Referee has blown the whistle for Full Time.
-    ("PTFT", "FT"), // Penalty ShooT Full Time.
-    ("Result", "FT"), // The Result is official.
-    ("ETFT", "FT"), // Extra Time, Full Time has been blown.
-    ("MC", "FT"), // Match has been Completed.
+    ("SHS", SecondHalf), // The Second Half of the Match has Started.
 
-    ("FTET", "ET"), // Full Time, Extra Time it to be played.
-    ("ETS", "ETS"), // Extra Time has Started.
-    ("ETHT", "ETHT"), // Extra Time Half Time has been called.
-    ("ETSHS", "ETSHS"), // Extra Time, Second Half has Started.
+    ("FT", FullTime), // The Referee has blown the whistle for Full Time.
+    ("Result", FullTime), // The Result is official.
+    ("MC", FullTime), // Match has been Completed.
 
-    ("FTPT", "PT"), // Full Time, Penalties are To be played.
-    ("PT", "PT"), // Penalty ShooT Out has started.
-    ("ETFTPT", "PT"), // Extra Time, Full Time, Penalties are To be played.
+    ("FTET", ExtraTimeToBePlayed), // Full Time, Extra Time it to be played.
+    ("ETS", ExtraTimeFirstHalf), // Extra Time has Started.
+    ("ETHT", ExtraTimeHalfTime), // Extra Time Half Time has been called.
+    ("ETSHS", ExtraTimeSecondHalf), // Extra Time, Second Half has Started.
+    ("ETFT", ExtraTimeSecondHalf), // Extra Time, Full Time has been blown.
 
-    // Prematch
-    ("Fixture", "Prematch"), // fixture maps to 1st just in case the matchInfo and event feed are out of sync
-    ("-", "Prematch"), // same as above
-    ("New", "Prematch"), // New Match has been added to our data.
+    ("FTPT", PenaltiesToBePlayed), // Full Time, Penalties are To be played.
+    ("ETFTPT", PenaltiesToBePlayed), // Extra Time, Full Time, Penalties are To be played.
+    ("PT", Penalties), // Penalty ShooT Out has started.
+    ("PTFT", Penalties), // Penalty ShooT Full Time.
 
     // edge cases
-    // TODO these need to be addressed. A match can be suspended and resumed within x days?)
-    ("Suspended", "S"), // Match has been Suspended. // todo when does this happen?
-    ("Resumed", "R"), // Match has been Resumed. // todo what game time does this map to? first half second half? match minute?
-    ("Abandoned", "A"), // Match has been Abandoned.
-    ("Cancelled", "C") // A Match has been Cancelled.
-    // POSTPONED???
+    ("Suspended", Suspended), // Match has been Suspended.
+    ("Resumed", Resumed), // Match has been Resumed. // todo can match phase be determined by match minute?
+    ("Abandoned", Abandoned), // Match has been Abandoned.
+    ("Postponed", Postponed), // A Match has been Postponed.
+    ("Cancelled", Cancelled) // A Match has been Cancelled.
   )
 }
 
@@ -142,13 +132,18 @@ object FootballContentJsonFormats {
           case "FIRST_HALF"             => JsSuccess(FirstHalf)
           case "HALF_TIME"              => JsSuccess(HalfTime)
           case "SECOND_HALF"            => JsSuccess(SecondHalf)
+          case "EXTRA_TIME_TO_BE_PLAYED" => JsSuccess(ExtraTimeToBePlayed)
           case "EXTRA_TIME_FIRST_HALF"  => JsSuccess(ExtraTimeFirstHalf)
           case "EXTRA_TIME_HALF_TIME"   => JsSuccess(ExtraTimeHalfTime)
           case "EXTRA_TIME_SECOND_HALF" => JsSuccess(ExtraTimeSecondHalf)
+          case "PENALTIES_TO_BE_PLAYED" => JsSuccess(PenaltiesToBePlayed)
           case "PENALTIES"              => JsSuccess(Penalties)
           case "FULL_TIME"              => JsSuccess(FullTime)
+          case "SUSPENDED"              => JsSuccess(Suspended)
+          case "RESUMED"                => JsSuccess(Resumed)
           case "POSTPONED"              => JsSuccess(Postponed)
           case "ABANDONED"              => JsSuccess(Abandoned)
+          case "CANCELLED"              => JsSuccess(Cancelled)
           case other                    => JsError(s"Unknown match status: $other")
         }
       case _ => JsError("Expected a JSON string for MatchStatus")

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -65,9 +65,10 @@ object Lambda extends Logging {
 
   def getZonedDateTime(): ZonedDateTime = {
     val zonedDateTime = if (configuration.stage == "CODE") {
-      val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
-      val json = Json.parse(Source.fromInputStream(is).mkString)
-      ZonedDateTime.parse((json \ "currentDate").as[String])
+      ZonedDateTime.now()
+//      val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
+//      val json = Json.parse(Source.fromInputStream(is).mkString)
+//      ZonedDateTime.parse((json \ "currentDate").as[String])
     } else {
       ZonedDateTime.now()
     }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -65,10 +65,9 @@ object Lambda extends Logging {
 
   def getZonedDateTime(): ZonedDateTime = {
     val zonedDateTime = if (configuration.stage == "CODE") {
-      ZonedDateTime.now()
-//      val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
-//      val json = Json.parse(Source.fromInputStream(is).mkString)
-//      ZonedDateTime.parse((json \ "currentDate").as[String])
+      val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
+      val json = Json.parse(Source.fromInputStream(is).mkString)
+      ZonedDateTime.parse((json \ "currentDate").as[String])
     } else {
       ZonedDateTime.now()
     }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
@@ -3,7 +3,10 @@ package com.gu.mobile.notifications.football.lib
 import com.gu.mobile.notifications.client.models.NotificationPayload
 import com.gu.mobile.notifications.client.models.liveActitivites.LiveActivityPayload
 import com.gu.mobile.notifications.football.Logging
-import com.gu.mobile.notifications.football.models.{FootballMatchEvent, MatchDataWithArticle}
+import com.gu.mobile.notifications.football.models.{
+  FootballMatchEvent,
+  MatchDataWithArticle
+}
 import com.gu.mobile.notifications.football.notificationbuilders.{
   MatchStatusLiveActivityPayloadBuilder,
   MatchStatusNotificationBuilder
@@ -22,8 +25,22 @@ class EventConsumer(
       * to generate push notifications for, so we filter those out here.
       */
     // todo can we capture these strings in union type?
-    // todo we will want to send penalty kick notifications to push notification service for android
-    val liveActivityEventTypes = List("create-channel", "start-live-activity", "end-live-activity", "shootoutGoal", "shootoutMiss", "shootoutSave")
+    // todo we will want to send penalty kick notifications and extra synthetic events to push notifications for android
+    val liveActivityEventTypes =
+      List(
+        "create-channel",
+        "start-live-activity",
+        "end-live-activity",
+        // penalty shootout events
+        "shootoutGoal",
+        "shootoutMiss",
+        "shootoutSave",
+        // additional synthetic match phase events for live activities
+        "extra-time-first-half",
+        "extra-time-half-time",
+        "extra-time-second-half",
+        "penalties"
+      )
 
     val filteredMatchData = matchData.copy(allEvents =
       matchData.allEvents.filterNot(e =>

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
@@ -28,18 +28,27 @@ class EventConsumer(
     // todo we will want to send penalty kick notifications and extra synthetic events to push notifications for android
     val liveActivityEventTypes =
       List(
-        "create-channel",
-        "start-live-activity",
-        "end-live-activity",
+
         // penalty shootout events
         "shootoutGoal",
         "shootoutMiss",
         "shootoutSave",
+        // additional synthetic live activity life cycle events
+        "create-channel",
+        "start-live-activity",
+        "end-live-activity",
         // additional synthetic match phase events for live activities
+        "extra-time-to-be-played",
         "extra-time-first-half",
         "extra-time-half-time",
         "extra-time-second-half",
-        "penalties"
+        "penalties-to-be-played",
+        "penalties",
+        "suspended",
+        "resumed",
+        "abandoned",
+        "cancelled",
+        "postponed"
       )
 
     val filteredMatchData = matchData.copy(allEvents =

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -41,7 +41,57 @@ class SyntheticMatchEventGenerator(dateTime: ZonedDateTime) {
     else None
   }
 
+
+  // LIVE ACTIVITIES
+  private val suspended: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+    if (matchDay.matchStatus == "Suspended") Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/suspended".getBytes).toString),
+      eventType = "suspended"
+    ))
+    else None
+  }
+
+  private val resumed: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+    if (matchDay.matchStatus == "Resumed") Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/resumed".getBytes).toString),
+      eventType = "resumed"
+    ))
+    else None
+  }
+
+  private val abandoned: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+    if (matchDay.matchStatus == "Abandoned") Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/abandoned".getBytes).toString),
+      eventType = "abandoned"
+    ))
+    else None
+  }
+
+  private val postponed: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+    if (matchDay.matchStatus == "Postponed") Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/postponed".getBytes).toString),
+      eventType = "postponed"
+    ))
+    else None
+  }
+
+  private val cancelled: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+    if (matchDay.matchStatus == "Cancelled") Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/cancelled".getBytes).toString),
+      eventType = "cancelled"
+    ))
+    else None
+  }
+
   // match statuses synthetic events needed for live activities
+  private val extraTimeToBePlayed: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+    if (matchDay.matchStatus == "FTET") Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/extra-time-to-be-played".getBytes).toString),
+      eventType = "extra-time-to-be-played"
+    ))
+    else None
+  }
+
   private val extraTimeFirstHalf: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
     if (matchDay.matchStatus == "ETS") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/extra-time-first-half".getBytes).toString),
@@ -66,6 +116,14 @@ class SyntheticMatchEventGenerator(dateTime: ZonedDateTime) {
     else None
   }
 
+  private val penaltiesToBePlayed: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+    if (matchDay.matchStatus == "FTPT" || matchDay.matchStatus == "ETFTPT") Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/penalties-to-be-played".getBytes).toString),
+      eventType = "penalties-to-be-played"
+    ))
+    else None
+  }
+
   private val penalties: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
     if (matchDay.matchStatus == "PT") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/penalties".getBytes).toString),
@@ -75,7 +133,6 @@ class SyntheticMatchEventGenerator(dateTime: ZonedDateTime) {
   }
 
   // Live Activity supporting events //
-
   val now: Long = dateTime.toInstant.getEpochSecond
   def koWithinTwoHours(ko: Long): Boolean = now >= ko - 7200 && now < ko - 1200
   def koWithin20Minutes(ko: Long): Boolean = now >= ko - 1200 && now < ko
@@ -106,7 +163,24 @@ class SyntheticMatchEventGenerator(dateTime: ZonedDateTime) {
     else None
   }
 
-  private val generators: List[MatchEventGenerator] = List(fullTime, halfTime, secondHalf, extraTimeFirstHalf, extraTimeHalfTime, extraTimeSecondHalf, penalties, createChannel, startLiveActivity, endLiveActivity)
+  private val generators: List[MatchEventGenerator] = List(
+    fullTime,
+    halfTime,
+    secondHalf,
+    extraTimeToBePlayed,
+    extraTimeFirstHalf,
+    extraTimeHalfTime,
+    extraTimeSecondHalf,
+    penaltiesToBePlayed,
+    penalties,
+    suspended,
+    resumed,
+    abandoned,
+    postponed,
+    cancelled,
+    createChannel,
+    startLiveActivity,
+    endLiveActivity)
 
   private def emptyMatchEvent = MatchEvent(
     id = None,

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -4,6 +4,9 @@ import java.util.UUID
 
 import pa.{MatchDay, MatchEvent}
 
+// Synthetic events create a timeline event for a match status change, that can be processed by the EventConsumer
+// and transformed into a NotificationPayload and/or LiveActivityPayload for broadcasting.
+
 class SyntheticMatchEventGenerator {
 
   def generate(events: List[MatchEvent], id: String, matchDay: MatchDay): List[MatchEvent] = {
@@ -34,6 +37,39 @@ class SyntheticMatchEventGenerator {
     if (matchDay.matchStatus == "SHS") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/second-half".getBytes).toString),
       eventType = "second-half"
+    ))
+    else None
+  }
+
+  // match statuses synthetic events needed for live activities
+  private val extraTimeFirstHalf: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+    if (matchDay.matchStatus == "ETS") Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/extra-time-first-half".getBytes).toString),
+      eventType = "extra-time-first-half"
+    ))
+    else None
+  }
+
+  private val extraTimeHalfTime: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+    if (matchDay.matchStatus == "ETHT") Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/extra-time-half-time".getBytes).toString),
+      eventType = "extra-time-half-time"
+    ))
+    else None
+  }
+
+  private val extraTimeSecondHalf: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+    if (matchDay.matchStatus == "ETSHS") Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/extra-time-second-half".getBytes).toString),
+      eventType = "extra-time-second-half"
+    ))
+    else None
+  }
+
+  private val penalties: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+    if (matchDay.matchStatus == "PT") Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/penalties".getBytes).toString),
+      eventType = "penalties"
     ))
     else None
   }
@@ -70,7 +106,7 @@ class SyntheticMatchEventGenerator {
     else None
   }
 
-  private val generators: List[MatchEventGenerator] = List(fullTime, halfTime, secondHalf, createChannel, startLiveActivity, endLiveActivity)
+  private val generators: List[MatchEventGenerator] = List(fullTime, halfTime, secondHalf, extraTimeFirstHalf, extraTimeHalfTime, extraTimeSecondHalf, penalties, createChannel, startLiveActivity, endLiveActivity)
 
   private def emptyMatchEvent = MatchEvent(
     id = None,

--- a/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
@@ -184,13 +184,21 @@ object MatchPhaseEvent {
       case "full-time"                                    => FullTime(eventId)
       case "half-time"                                    => HalfTime(eventId)
       case "second-half"                                  => SecondHalf(eventId)
+      case "extra-time-to-be-played"                      => ExtraTimeToBePlayed(eventId)
       case "extra-time-first-half"                        => ExtraTimeFirstHalf(eventId)
       case "extra-time-half-time"                         => ExtraTimeHalfTime(eventId)
       case "extra-time-second-half"                       => ExtraTimeSecondHalf(eventId)
+      case "penalties-to-be-played"                       => PenaltiesToBePlayed(eventId)
       case "penalties"                                    => Penalties(eventId)
+      case "suspended"                                    => Suspended(eventId)
+      case "resumed"                                      => Resumed(eventId)
+      case "abandoned"                                    => Abandoned(eventId)
+      case "postponed"                                    => Postponed(eventId)
+      case "cancelled"                                    => Cancelled(eventId)
       case "create-channel"                               => CreateChannel(eventId)
       case "start-live-activity"                          => StartLiveActivity(eventId)
       case "end-live-activity"                            => EndLiveActivity(eventId)
+
     }
   }
 }
@@ -199,12 +207,20 @@ case class KickOff(eventId: String) extends MatchPhaseEvent
 case class FullTime(eventId: String) extends MatchPhaseEvent
 case class HalfTime(eventId: String) extends MatchPhaseEvent
 case class SecondHalf(eventId: String) extends MatchPhaseEvent
+case class ExtraTimeToBePlayed(eventId: String) extends MatchPhaseEvent
 case class ExtraTimeFirstHalf(eventId: String) extends MatchPhaseEvent
 case class ExtraTimeHalfTime(eventId: String) extends MatchPhaseEvent
 case class ExtraTimeSecondHalf(eventId: String) extends MatchPhaseEvent
+case class PenaltiesToBePlayed(eventId: String) extends MatchPhaseEvent
 case class Penalties(eventId: String) extends MatchPhaseEvent
+// extraordinary events
+case class Suspended(eventId: String) extends MatchPhaseEvent
+case class Resumed(eventId: String) extends MatchPhaseEvent
+case class Abandoned(eventId: String) extends MatchPhaseEvent
+case class Postponed(eventId: String) extends MatchPhaseEvent
+case class Cancelled(eventId: String) extends MatchPhaseEvent
 
 // Live Activity phase events
 case class CreateChannel(eventId: String) extends MatchPhaseEvent
 case class StartLiveActivity(eventId: String) extends MatchPhaseEvent
-case class EndLiveActivity(eventId: String) extends MatchPhaseEvent
+case class EndLiveActivity(eventId: String) extends MatchPhaseEvent // occurs when there is a result

--- a/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
@@ -1,6 +1,5 @@
 package com.gu.mobile.notifications.football.models
 
-import ch.qos.logback.core.model.conditional.ElseModel
 import com.gu.mobile.notifications.client.models.liveActitivites.PenaltyShootoutState
 import com.gu.mobile.notifications.client.models.{DefaultGoalType, GoalType, MissedShootoutResult, OwnGoalType, PenaltyGoalType, SavedShootoutResult, ScoredShootoutResult, ShootoutResultType}
 
@@ -129,14 +128,14 @@ object PenaltyShootoutKick {
     kickingTeam = if (player.teamID == homeTeam.id) homeTeam else awayTeam
     otherTeam = if (player.teamID == homeTeam.id) awayTeam else homeTeam
     eventTime <- event.eventTime
-    eventMinute <- Try(eventTime.toInt).toOption
+    currentMinute <- Try(eventTime.toInt).toOption
     eventId <- event.id
   } yield PenaltyShootoutKick(
     result,
     player.name,
     kickingTeam,
     otherTeam,
-    eventMinute,
+    currentMinute,
     eventId
   )
 
@@ -172,16 +171,23 @@ object PenaltyShootoutScore {
 case class PenaltyShootoutScore(homeScored: Int = 0, homeMissed: Int = 0, homeSaved: Int = 0, awayScored: Int = 0, awayMissed: Int = 0, awaySaved: Int = 0)
 
 
-trait MatchPhaseEvent extends FootballMatchEvent
+trait MatchPhaseEvent extends FootballMatchEvent {
+  val currentMinute: Option[Int] = None
+}
 
 object MatchPhaseEvent {
+  // some of these are Synthetic Events we generate and add to the timeline.
   def fromEvent(event: pa.MatchEvent): Option[MatchPhaseEvent] = {
     val eventId = event.id.getOrElse("")
     condOpt(event.eventType) {
       case "timeline" if event.matchTime.contains("0:00") => KickOff(eventId)
-      case "full-time"                                    => FullTime(eventId) // todo use this to end activity?
+      case "full-time"                                    => FullTime(eventId)
       case "half-time"                                    => HalfTime(eventId)
       case "second-half"                                  => SecondHalf(eventId)
+      case "extra-time-first-half"                        => ExtraTimeFirstHalf(eventId)
+      case "extra-time-half-time"                         => ExtraTimeHalfTime(eventId)
+      case "extra-time-second-half"                       => ExtraTimeSecondHalf(eventId)
+      case "penalties"                                    => Penalties(eventId)
       case "create-channel"                               => CreateChannel(eventId)
       case "start-live-activity"                          => StartLiveActivity(eventId)
       case "end-live-activity"                            => EndLiveActivity(eventId)
@@ -193,6 +199,12 @@ case class KickOff(eventId: String) extends MatchPhaseEvent
 case class FullTime(eventId: String) extends MatchPhaseEvent
 case class HalfTime(eventId: String) extends MatchPhaseEvent
 case class SecondHalf(eventId: String) extends MatchPhaseEvent
+case class ExtraTimeFirstHalf(eventId: String) extends MatchPhaseEvent
+case class ExtraTimeHalfTime(eventId: String) extends MatchPhaseEvent
+case class ExtraTimeSecondHalf(eventId: String) extends MatchPhaseEvent
+case class Penalties(eventId: String) extends MatchPhaseEvent
+
+// Live Activity phase events
 case class CreateChannel(eventId: String) extends MatchPhaseEvent
 case class StartLiveActivity(eventId: String) extends MatchPhaseEvent
 case class EndLiveActivity(eventId: String) extends MatchPhaseEvent

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -1,7 +1,6 @@
 package com.gu.mobile.notifications.football.notificationbuilders
 
-import com.gu.mobile.notifications.client.models._
-import com.gu.mobile.notifications.client.models.liveActitivites.{Competition, FootballLiveActivity, FootballMatchContentState, LiveActivityPayload, Scheduled, TeamState, UpdateLiveActivityEvent, StartLiveActivityEvent, CreateChannelEvent, EndLiveActivityEvent}
+import com.gu.mobile.notifications.client.models.liveActitivites.{Competition, CreateChannelEvent, EndLiveActivityEvent, FootballLiveActivity, FootballMatchContentState, LiveActivityPayload, MatchStatus, Scheduled, StartLiveActivityEvent, TeamState, UpdateLiveActivityEvent}
 import com.gu.mobile.notifications.football.models._
 import pa.MatchDay
 
@@ -16,12 +15,6 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
       articleId: Option[String]
   ): LiveActivityPayload = {
 
-    val topics = List(
-      Topic(TopicTypes.FootballTeam, matchInfo.homeTeam.id),
-      Topic(TopicTypes.FootballTeam, matchInfo.awayTeam.id),
-      Topic(TopicTypes.FootballMatch, matchInfo.id)
-    )
-
     val allEvents = triggeringEvent :: previousEvents
     val goals = allEvents.collect { case g: Goal => g }
     val score = Score.fromGoals(matchInfo.homeTeam, matchInfo.awayTeam, goals)
@@ -30,9 +23,17 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
     val penaltyShootoutKicks = allEvents.collect { case psr: PenaltyShootoutKick => psr }
     val penaltyShootoutScore = PenaltyShootoutScore.fromPenaltyShootoutKicks(matchInfo.homeTeam, matchInfo.awayTeam, penaltyShootoutKicks)
 
+    val currentMinute: Option[Int] = triggeringEvent match {
+      case d:Dismissal => Some(d.minute)
+      case g:Goal => Some(g.minute)
+      case p: PenaltyShootoutKick => Some(p.minute)
+      case phase: MatchPhaseEvent => phase.currentMinute
+      case _ => None
+    }
+
     // TODO this is hard coded mostly for now.
     val contentState = FootballMatchContentState(
-      matchStatus = Scheduled,
+      matchStatus = MatchStatus.fromString(matchInfo.matchStatus),
       kickOffTimestamp = matchInfo.date.toEpochSecond, // included date and time
       homeTeam = TeamState(
         name = transformTeamName(matchInfo.homeTeam.name),
@@ -40,7 +41,7 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
         logoAssetName = None, // tbc
         teamUrl = None, // tbc
         redCards = redCards.home,
-        penaltyScore = PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, true)
+        penaltyScore = PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, isHomeTeam = true)
       ),
       awayTeam = TeamState(
         name = transformTeamName(matchInfo.awayTeam.name),
@@ -48,7 +49,7 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
         logoAssetName = None, // tbc
         teamUrl = None, // tbc
         redCards = redCards.away,
-        penaltyScore = PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, false)
+        penaltyScore = PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, isHomeTeam = false)
       ),
       competition = Competition(
         name = matchInfo.competition.map(_.name).getOrElse(""),
@@ -56,7 +57,7 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
       ),
       commentary = matchInfo.comments,
       lineupsAvailable = None, // Boolean   // not available on LiveMatch
-      currentMinute = None, // not available on LiveMatch
+      currentMinute = currentMinute,
       currentPeriodStartTime = None,
       articleUrl = articleId.map(id => s"$mapiHost/items/$id")
     )

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -68,7 +68,7 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
       case Abandoned(_) => EndLiveActivityEvent
       case Cancelled(_) => EndLiveActivityEvent
       case CreateChannel(_) => CreateChannelEvent
-      case StartLiveActivity(_) => StartLiveActivityEvent
+//      case StartLiveActivity(_) => StartLiveActivityEvent // we do not want to use start yet
       case EndLiveActivity(_) => EndLiveActivityEvent
       case _ => UpdateLiveActivityEvent
     }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -1,6 +1,6 @@
 package com.gu.mobile.notifications.football.notificationbuilders
 
-import com.gu.mobile.notifications.client.models.liveActitivites.{Competition, CreateChannelEvent, EndLiveActivityEvent, FootballLiveActivity, FootballMatchContentState, LiveActivityPayload, MatchStatus, Scheduled, StartLiveActivityEvent, TeamState, UpdateLiveActivityEvent}
+import com.gu.mobile.notifications.client.models.liveActitivites.{Competition, CreateChannelEvent, EndLiveActivityEvent, FootballLiveActivity, FootballMatchContentState, LiveActivityPayload, MatchStatus, StartLiveActivityEvent, TeamState, UpdateLiveActivityEvent}
 import com.gu.mobile.notifications.football.models._
 import pa.MatchDay
 
@@ -63,7 +63,10 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
       articleUrl = articleId.map(id => s"$mapiHost/items/$id")
     )
 
+    // certain type of triggering match event types will trigger different live activity event type.
     val liveActivityEventType = triggeringEvent match {
+      case Abandoned(_) => EndLiveActivityEvent
+      case Cancelled(_) => EndLiveActivityEvent
       case CreateChannel(_) => CreateChannelEvent
       case StartLiveActivity(_) => StartLiveActivityEvent
       case EndLiveActivity(_) => EndLiveActivityEvent

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -1,11 +1,11 @@
 package com.gu.mobile.notifications.football.lib
 
 import java.net.URI
-import com.gu.mobile.notifications.client.models._
+import com.gu.mobile.notifications.client.models.{liveActitivites, _}
 import com.gu.mobile.notifications.client.models.Importance.{Major, Minor}
 import com.gu.mobile.notifications.client.models.TopicTypes.{FootballMatch, FootballTeam}
-import com.gu.mobile.notifications.client.models.liveActitivites.{CreateChannelEvent, EndLiveActivityEvent, LiveActivityPayload, StartLiveActivityEvent}
-import com.gu.mobile.notifications.football.models.{MatchDataWithArticle, PenaltyShootoutKick}
+import com.gu.mobile.notifications.client.models.liveActitivites.{ContentState, CreateChannelEvent, EndLiveActivityEvent, ExtraTimeFirstHalf, FirstHalf, FootballMatchContentState, FullTime, HalfTime, LiveActivityPayload, Penalties, PreMatch, StartLiveActivityEvent}
+import com.gu.mobile.notifications.football.models.{MatchDataWithArticle, PenaltyShootoutKick, SecondHalf}
 import com.gu.mobile.notifications.football.notificationbuilders.{MatchStatusLiveActivityPayloadBuilder, MatchStatusNotificationBuilder}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
@@ -19,7 +19,7 @@ import scala.io.Source
 class EventConsumerSpec(implicit ev: ExecutionEnv)
     extends Specification
     with Mockito {
-  "An EventConsumer" should {
+  "An Notifications EventConsumer" should {
     "generate a kick-off notification" in new MatchEventsContext {
       override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "KO")
 
@@ -245,7 +245,9 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
   }
 
   "A Notification EventConsumer" should {
-    "not generate notification payload for penalties YET" in new MatchEventsContext {
+
+    // Penalty kicks are real events not synthetic events
+    "NOT generate notification payload for penalties" in new MatchEventsContext {
       override def matchDayLA: MatchDay =
         super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
 
@@ -253,34 +255,131 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
         eventConsumer.eventsToNotifications(matchDataLA)
 
       result must forall((payload: NotificationPayload) => payload.title.getOrElse("") != "Penalty Kick")
+    }
 
+    "NOT generate notification payload for extra time match phase events" in new MatchEventsContext {
+      override def matchDayLA: MatchDay =
+        super.matchDayLA.copy(date = ZonedDateTime.now(), matchStatus = "ETS")
+
+      val result: List[NotificationPayload] =
+        eventConsumer.eventsToNotifications(matchDataLA)
+
+      result must forall((payload: NotificationPayload) => payload.title.getOrElse("") != "The Guardian") // default string for unknown events
     }
 
   }
 
-  "A LiveActivity EventConsumer" should {
+  "A LiveActivity EventConsumer handles synthetic events and" should {
 
-    "generate a create channel payload" in new MatchEventsContext {
+    "generate a CREATE CHANNEL payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) => payload.eventType == CreateChannelEvent)
+    // note: this will trigger the downstream update from the channel manager with Scheduled Match Status.
+    }
+
+    "generate a START live activity payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusMinutes(10))
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.eventType == StartLiveActivityEvent)
+    }
+
+    "generate a END live activity payload when result is true" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "FT", result = true)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.eventType == EndLiveActivityEvent)
+    }
+
+    "generate a PreMatch live activity payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "-", result = false)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.PreMatch)
+    }
+
+    "generate a kick off first half start live activity payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "KO", result = false)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.FirstHalf)
+    }
+
+    "generate a half time live activity payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "HT", result = false)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.HalfTime)
+    }
+
+    "generate a second half live activity payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "SHS", result = false)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain { (payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.SecondHalf
+      }
+    }
+
+    "generate a extra time first half live activity payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "HT", result = false)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.HalfTime)
+    }
+
+    "generate a extra time first half live activity payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "ETS", result = false)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.ExtraTimeFirstHalf)
+    }
+
+    "generate a penalty time live activity payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "FTPT", result = false)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.Penalties)
+    }
+
+    "generate a fulltime time live activity payload without result" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "PTFT", result = false)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus must_== FullTime)
+    }
+
+  }
+
+  "A LiveActivity EventConsumer handles PA trigger events and" should {
+
+    "generate a goal payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
+
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+
+      result must contain((payload: LiveActivityPayload) => payload.eventType == CreateChannelEvent)
+      // note: this will trigger the downstream update from the channel manager with Scheduled Match Status.
+    }
+
+    "generate a red card payload" in new MatchEventsContext {
       override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
 
       val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) => payload.eventType == CreateChannelEvent)
+      // note: this will trigger the downstream update from the channel manager with Scheduled Match Status.
     }
 
-    "generate a start live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusMinutes(10))
+    "generate a penalty kick payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
 
       val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
-      result must contain((payload: LiveActivityPayload) => payload.eventType == StartLiveActivityEvent)
-    }
-
-    "generate a end live activity payload" in new MatchEventsContext {
-      override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "FT", result = true)
-
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
-      result must contain((payload: LiveActivityPayload) => payload.eventType == EndLiveActivityEvent)
+      result must contain((payload: LiveActivityPayload) => payload.eventType == CreateChannelEvent)
+      // note: this will trigger the downstream update from the channel manager with Scheduled Match Status.
     }
   }
+
+
 
   trait MatchEventsContext extends Scope {
     val matchStatusNotificationBuilder = new MatchStatusNotificationBuilder(

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -281,12 +281,12 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
     // note: this will trigger the downstream update from the channel manager with Scheduled Match Status.
     }
 
-    "generate a START live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusMinutes(10))
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
-      result must contain((payload: LiveActivityPayload) =>
-        payload.eventType == StartLiveActivityEvent)
-    }
+//    "generate a START live activity payload" in new MatchEventsContext {
+//      override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusMinutes(10))
+//      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+//      result must contain((payload: LiveActivityPayload) =>
+//        payload.eventType == StartLiveActivityEvent)
+//    }
 
     "generate a END live activity payload when result is true" in new MatchEventsContext {
       override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "FT", result = true)

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -4,7 +4,7 @@ import java.net.URI
 import com.gu.mobile.notifications.client.models.{liveActitivites, _}
 import com.gu.mobile.notifications.client.models.Importance.{Major, Minor}
 import com.gu.mobile.notifications.client.models.TopicTypes.{FootballMatch, FootballTeam}
-import com.gu.mobile.notifications.client.models.liveActitivites.{ContentState, CreateChannelEvent, EndLiveActivityEvent, ExtraTimeFirstHalf, FirstHalf, FootballMatchContentState, FullTime, HalfTime, LiveActivityPayload, Penalties, PreMatch, StartLiveActivityEvent}
+import com.gu.mobile.notifications.client.models.liveActitivites.{ContentState, CreateChannelEvent, EndLiveActivityEvent, ExtraTimeFirstHalf, FirstHalf, FootballMatchContentState, FullTime, HalfTime, LiveActivityPayload, Penalties, PreMatch, StartLiveActivityEvent, UpdateLiveActivityEvent}
 import com.gu.mobile.notifications.football.models.{MatchDataWithArticle, PenaltyShootoutKick, SecondHalf}
 import com.gu.mobile.notifications.football.notificationbuilders.{MatchStatusLiveActivityPayloadBuilder, MatchStatusNotificationBuilder}
 import org.specs2.concurrent.ExecutionEnv
@@ -291,6 +291,9 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
       result must contain((payload: LiveActivityPayload) =>
         payload.eventType == EndLiveActivityEvent)
     }
+  }
+
+  "A LiveActivity EventConsumer handles synthetic events for match phases and" should {
 
     "generate a PreMatch live activity payload" in new MatchEventsContext {
       override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "-", result = false)
@@ -321,12 +324,13 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
       }
     }
 
-    "generate a extra time first half live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "HT", result = false)
+    "generate a extra time to be played live activity payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "FTET", result = false)
       val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.HalfTime)
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.ExtraTimeToBePlayed)
     }
+
 
     "generate a extra time first half live activity payload" in new MatchEventsContext {
       override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "ETS", result = false)
@@ -335,20 +339,73 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
         payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.ExtraTimeFirstHalf)
     }
 
-    "generate a penalty time live activity payload" in new MatchEventsContext {
+    "generate a extra time half time live activity payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "ETHT", result = false)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.ExtraTimeHalfTime)
+    }
+
+    "generate a extra time second half live activity payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "ETSHS", result = false)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.ExtraTimeSecondHalf)
+    }
+
+    "generate a penalty time to be played live activity payload" in new MatchEventsContext {
       override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "FTPT", result = false)
       val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.PenaltiesToBePlayed)
+    }
+
+    "generate a penalty time live activity payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "PT", result = false)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+
+
+
       result must contain((payload: LiveActivityPayload) =>
         payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.Penalties)
     }
 
-    "generate a fulltime time live activity payload without result" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "PTFT", result = false)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
-      result must contain((payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus must_== FullTime)
+    "generate a fulltime time live activity UPDATE payload without a result" in new MatchEventsContext {
+          override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "FT", result = false)
+          val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+          println(result.head)
+
+          result must contain((payload: LiveActivityPayload) =>
+            payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.FullTime)
+          result must contain((payload: LiveActivityPayload) =>
+            payload.eventType == UpdateLiveActivityEvent)
+
     }
 
+    "generate a fulltime time live activity END payload with result" in new MatchEventsContext {
+          override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "FT", result = true)
+          val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+          result must contain((payload: LiveActivityPayload) =>
+            payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.FullTime
+          )
+          result must contain((payload: LiveActivityPayload) =>
+            payload.eventType == EndLiveActivityEvent
+          )
+
+    }
+
+    "generate a abandoned live activity END payload" in new MatchEventsContext {
+      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "Abandoned", result = false)
+      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.Abandoned
+      )
+      result must contain((payload: LiveActivityPayload) =>
+        payload.eventType == EndLiveActivityEvent
+      )
+
+    }
   }
 
   "A LiveActivity EventConsumer handles PA trigger events and" should {
@@ -374,6 +431,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
       override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
 
       val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+
       result must contain((payload: LiveActivityPayload) => payload.eventType == CreateChannelEvent)
       // note: this will trigger the downstream update from the channel manager with Scheduled Match Status.
     }

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -3,10 +3,21 @@ package com.gu.mobile.notifications.football.lib
 import java.net.URI
 import com.gu.mobile.notifications.client.models.{liveActitivites, _}
 import com.gu.mobile.notifications.client.models.Importance.{Major, Minor}
-import com.gu.mobile.notifications.client.models.TopicTypes.{FootballMatch, FootballTeam, FootballTeamLiveActivity, FootballMatchLiveActivity}
-import com.gu.mobile.notifications.football.models.{MatchDataWithArticle, PenaltyShootoutKick}
+import com.gu.mobile.notifications.client.models.TopicTypes.{
+  FootballMatch,
+  FootballTeam,
+  FootballTeamLiveActivity,
+  FootballMatchLiveActivity
+}
+import com.gu.mobile.notifications.football.models.{
+  MatchDataWithArticle,
+  PenaltyShootoutKick
+}
 import com.gu.mobile.notifications.client.models.liveActitivites._
-import com.gu.mobile.notifications.football.notificationbuilders.{MatchStatusLiveActivityPayloadBuilder, MatchStatusNotificationBuilder}
+import com.gu.mobile.notifications.football.notificationbuilders.{
+  MatchStatusLiveActivityPayloadBuilder,
+  MatchStatusNotificationBuilder
+}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
@@ -23,7 +34,8 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
     "generate a kick-off notification" in new MatchEventsContext {
       override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "KO")
 
-      val result: List[NotificationPayload] = eventConsumer.eventsToNotifications(matchData)
+      val result: List[NotificationPayload] =
+        eventConsumer.eventsToNotifications(matchData)
 
       val expectedNotification = FootballMatchStatusPayload(
         title = Some("Kick-off!"),
@@ -41,8 +53,14 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
         competitionName = Some("Premier League 17/18"),
         venue = Some("Emirates Stadium"),
         matchId = "4011135",
-        matchInfoUri = new URI("https://mobile.guardianapis.com/sport/football/matches/4011135"),
-        articleUri = Some(new URI("https://mobile.guardianapis.com/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")),
+        matchInfoUri = new URI(
+          "https://mobile.guardianapis.com/sport/football/matches/4011135"
+        ),
+        articleUri = Some(
+          new URI(
+            "https://mobile.guardianapis.com/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"
+          )
+        ),
         importance = Minor,
         topic = List(
           Topic(FootballTeam, "1006"),
@@ -50,7 +68,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
           Topic(FootballMatch, "4011135"),
           Topic(FootballTeamLiveActivity, "1006"),
           Topic(FootballTeamLiveActivity, "29"),
-          Topic(FootballMatchLiveActivity, "4011135"),
+          Topic(FootballMatchLiveActivity, "4011135")
         ),
         matchStatus = "1st",
         eventId = "7e730fbe-b013-3a0e-89cb-12b46260d7be",
@@ -64,7 +82,8 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
     "generate half-time notification" in new MatchEventsContext {
       override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "HT")
 
-      val result: List[NotificationPayload] = eventConsumer.eventsToNotifications(matchData)
+      val result: List[NotificationPayload] =
+        eventConsumer.eventsToNotifications(matchData)
 
       val expectedNotification = FootballMatchStatusPayload(
         title = Some("Half-time"),
@@ -77,13 +96,20 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
         awayTeamId = "29",
         homeTeamName = "Arsenal",
         homeTeamScore = 3,
-        homeTeamMessage = "Henrikh Mkhitaryan 10'\nSofiane Hanni 32'\nRed card: Carl Jenkinson 106'\nMarcus Rashford 107'\nRed card: Henrikh Mkhitaryan 114'",
+        homeTeamMessage =
+          "Henrikh Mkhitaryan 10'\nSofiane Hanni 32'\nRed card: Carl Jenkinson 106'\nMarcus Rashford 107'\nRed card: Henrikh Mkhitaryan 114'",
         homeTeamId = "1006",
         competitionName = Some("Premier League 17/18"),
         venue = Some("Emirates Stadium"),
         matchId = "4011135",
-        matchInfoUri = new URI("https://mobile.guardianapis.com/sport/football/matches/4011135"),
-        articleUri = Some(new URI("https://mobile.guardianapis.com/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")),
+        matchInfoUri = new URI(
+          "https://mobile.guardianapis.com/sport/football/matches/4011135"
+        ),
+        articleUri = Some(
+          new URI(
+            "https://mobile.guardianapis.com/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"
+          )
+        ),
         importance = Minor,
         topic = List(
           Topic(FootballTeam, "1006"),
@@ -101,10 +127,12 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
 
     "generate second half start notification" in new MatchEventsContext {
       // 23572566 is the first event of the second half
-      override def rawEvents: List[MatchEvent] = super.rawEvents.takeWhile(!_.id.contains("23572566"))
+      override def rawEvents: List[MatchEvent] =
+        super.rawEvents.takeWhile(!_.id.contains("23572566"))
       override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "SHS")
 
-      val result: List[NotificationPayload] = eventConsumer.eventsToNotifications(matchData)
+      val result: List[NotificationPayload] =
+        eventConsumer.eventsToNotifications(matchData)
 
       val expectedNotification = FootballMatchStatusPayload(
         title = Some("Second-half start"),
@@ -122,8 +150,14 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
         competitionName = Some("Premier League 17/18"),
         venue = Some("Emirates Stadium"),
         matchId = "4011135",
-        matchInfoUri = new URI("https://mobile.guardianapis.com/sport/football/matches/4011135"),
-        articleUri = Some(new URI("https://mobile.guardianapis.com/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")),
+        matchInfoUri = new URI(
+          "https://mobile.guardianapis.com/sport/football/matches/4011135"
+        ),
+        articleUri = Some(
+          new URI(
+            "https://mobile.guardianapis.com/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"
+          )
+        ),
         importance = Minor,
         topic = List(
           Topic(FootballTeam, "1006"),
@@ -140,9 +174,11 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
     }
 
     "generate full time notification" in new MatchEventsContext {
-      override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "FT", result = true)
+      override def matchDay: MatchDay =
+        super.matchDay.copy(matchStatus = "FT", result = true)
 
-      val result: List[NotificationPayload] = eventConsumer.eventsToNotifications(matchData)
+      val result: List[NotificationPayload] =
+        eventConsumer.eventsToNotifications(matchData)
 
       val expectedNotification = FootballMatchStatusPayload(
         title = Some("Full-Time"),
@@ -155,13 +191,20 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
         awayTeamId = "29",
         homeTeamName = "Arsenal",
         homeTeamScore = 3,
-        homeTeamMessage = "Henrikh Mkhitaryan 10'\nSofiane Hanni 32'\nRed card: Carl Jenkinson 106'\nMarcus Rashford 107'\nRed card: Henrikh Mkhitaryan 114'",
+        homeTeamMessage =
+          "Henrikh Mkhitaryan 10'\nSofiane Hanni 32'\nRed card: Carl Jenkinson 106'\nMarcus Rashford 107'\nRed card: Henrikh Mkhitaryan 114'",
         homeTeamId = "1006",
         competitionName = Some("Premier League 17/18"),
         venue = Some("Emirates Stadium"),
         matchId = "4011135",
-        matchInfoUri = new URI("https://mobile.guardianapis.com/sport/football/matches/4011135"),
-        articleUri = Some(new URI("https://mobile.guardianapis.com/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")),
+        matchInfoUri = new URI(
+          "https://mobile.guardianapis.com/sport/football/matches/4011135"
+        ),
+        articleUri = Some(
+          new URI(
+            "https://mobile.guardianapis.com/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"
+          )
+        ),
         importance = Minor,
         topic = List(
           Topic(FootballTeam, "1006"),
@@ -178,9 +221,11 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
     }
 
     "generate goal notifications from FootballMatchStatusPayload" in new MatchEventsContext {
-      override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "KO", result = true)
+      override def matchDay: MatchDay =
+        super.matchDay.copy(matchStatus = "KO", result = true)
 
-      val result: List[NotificationPayload] = eventConsumer.eventsToNotifications(matchData)
+      val result: List[NotificationPayload] =
+        eventConsumer.eventsToNotifications(matchData)
 
       val expectedNotification = FootballMatchStatusPayload(
         title = Some("Goal!"),
@@ -198,8 +243,14 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
         competitionName = Some("Premier League 17/18"),
         venue = Some("Emirates Stadium"),
         matchId = "4011135",
-        matchInfoUri = new URI("https://mobile.guardianapis.com/sport/football/matches/4011135"),
-        articleUri = Some(new URI("https://mobile.guardianapis.com/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")),
+        matchInfoUri = new URI(
+          "https://mobile.guardianapis.com/sport/football/matches/4011135"
+        ),
+        articleUri = Some(
+          new URI(
+            "https://mobile.guardianapis.com/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"
+          )
+        ),
         importance = Major,
         topic = List(
           Topic(FootballTeam, "1006"),
@@ -215,12 +266,16 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
       result should contain(expectedNotification)
     }
     "generate red card notifications from FootballMatchStatusPayload" in new MatchEventsContext {
-      override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "KO", result = true)
-      val result: List[NotificationPayload] = eventConsumer.eventsToNotifications(matchData)
+      override def matchDay: MatchDay =
+        super.matchDay.copy(matchStatus = "KO", result = true)
+      val result: List[NotificationPayload] =
+        eventConsumer.eventsToNotifications(matchData)
 
       val expectedNotification = FootballMatchStatusPayload(
         Some("Red card"),
-        Some("Arsenal 3-0 Leicester (1st)\nHenrikh Mkhitaryan (Arsenal) 114min"),
+        Some(
+          "Arsenal 3-0 Leicester (1st)\nHenrikh Mkhitaryan (Arsenal) 114min"
+        ),
         None,
         "mobile-notifications-football-lambda",
         "Leicester",
@@ -234,14 +289,25 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
         Some("Premier League 17/18"),
         Some("Emirates Stadium"),
         "4011135",
-        new URI("https://mobile.guardianapis.com/sport/football/matches/4011135"),
-        Some(new URI("https://mobile.guardianapis.com/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")),
+        new URI(
+          "https://mobile.guardianapis.com/sport/football/matches/4011135"
+        ),
+        Some(
+          new URI(
+            "https://mobile.guardianapis.com/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"
+          )
+        ),
         Minor,
-        List(Topic(FootballTeam,"1006"), Topic(FootballTeam,"29"), Topic(FootballMatch,"4011135")),
+        List(
+          Topic(FootballTeam, "1006"),
+          Topic(FootballTeam, "29"),
+          Topic(FootballMatch, "4011135")
+        ),
         "1st",
         "7c92d6ca-9f20-398f-9510-eb4c179fb5ae",
         false,
-        None)
+        None
+      )
 
       result should contain(expectedNotification)
     }
@@ -257,7 +323,9 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
       val result: List[NotificationPayload] =
         eventConsumer.eventsToNotifications(matchDataLA)
 
-      result must forall((payload: NotificationPayload) => payload.title.getOrElse("") != "Penalty Kick")
+      result must forall((payload: NotificationPayload) =>
+        payload.title.getOrElse("") != "Penalty Kick"
+      )
     }
 
     "NOT generate notification payload for extra time match phase events" in new MatchEventsContext {
@@ -267,7 +335,9 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
       val result: List[NotificationPayload] =
         eventConsumer.eventsToNotifications(matchDataLA)
 
-      result must forall((payload: NotificationPayload) => payload.title.getOrElse("") != "The Guardian") // default string for unknown events
+      result must forall((payload: NotificationPayload) =>
+        payload.title.getOrElse("") != "The Guardian"
+      ) // default string for unknown events
     }
 
   }
@@ -275,10 +345,14 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
   "A LiveActivity EventConsumer handles synthetic events and" should {
 
     "generate a CREATE CHANNEL payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
-      result must contain((payload: LiveActivityPayload) => payload.eventType == CreateChannelEvent)
-    // note: this will trigger the downstream update from the channel manager with Scheduled Match Status.
+      override def matchDayLA: MatchDay =
+        super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.eventType == CreateChannelEvent
+      )
+      // note: this will trigger the downstream update from the channel manager with Scheduled Match Status.
     }
 
 //    "generate a START live activity payload" in new MatchEventsContext {
@@ -289,120 +363,180 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
 //    }
 
     "generate a END live activity payload when result is true" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "FT", result = true)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "FT", result = true)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) =>
-        payload.eventType == EndLiveActivityEvent)
+        payload.eventType == EndLiveActivityEvent
+      )
     }
   }
 
   "A LiveActivity EventConsumer handles synthetic events for match phases and" should {
 
     "generate a PreMatch live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "-", result = false)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "-", result = false)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.PreMatch)
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.PreMatch
+      )
     }
 
     "generate a kick off first half start live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "KO", result = false)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "KO", result = false)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.FirstHalf)
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.FirstHalf
+      )
     }
 
     "generate a half time live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "HT", result = false)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "HT", result = false)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.HalfTime)
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.HalfTime
+      )
     }
 
     "generate a second half live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "SHS", result = false)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "SHS", result = false)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain { (payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.SecondHalf
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.SecondHalf
       }
     }
 
     "generate a extra time to be played live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "FTET", result = false)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "FTET", result = false)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.ExtraTimeToBePlayed)
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.ExtraTimeToBePlayed
+      )
     }
 
-
     "generate a extra time first half live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "ETS", result = false)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "ETS", result = false)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.ExtraTimeFirstHalf)
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.ExtraTimeFirstHalf
+      )
     }
 
     "generate a extra time half time live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "ETHT", result = false)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "ETHT", result = false)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.ExtraTimeHalfTime)
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.ExtraTimeHalfTime
+      )
     }
 
     "generate a extra time second half live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "ETSHS", result = false)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "ETSHS", result = false)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.ExtraTimeSecondHalf)
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.ExtraTimeSecondHalf
+      )
     }
 
     "generate a penalty time to be played live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "FTPT", result = false)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
-
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "FTPT", result = false)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.PenaltiesToBePlayed)
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.PenaltiesToBePlayed
+      )
     }
 
     "generate a penalty time live activity payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "PT", result = false)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
-
-
-
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "PT", result = false)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.Penalties)
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.Penalties
+      )
     }
 
     "generate a fulltime time live activity UPDATE payload without a result" in new MatchEventsContext {
-          override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "FT", result = false)
-          val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
-          println(result.head)
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "FT", result = false)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
 
-          result must contain((payload: LiveActivityPayload) =>
-            payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.FullTime)
-          result must contain((payload: LiveActivityPayload) =>
-            payload.eventType == UpdateLiveActivityEvent)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.FullTime
+      )
+      result must contain((payload: LiveActivityPayload) =>
+        payload.eventType == UpdateLiveActivityEvent
+      )
 
     }
 
     "generate a fulltime time live activity END payload with result" in new MatchEventsContext {
-          override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "FT", result = true)
-          val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
-          result must contain((payload: LiveActivityPayload) =>
-            payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.FullTime
-          )
-          result must contain((payload: LiveActivityPayload) =>
-            payload.eventType == EndLiveActivityEvent
-          )
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "FT", result = true)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.FullTime
+      )
+      result must contain((payload: LiveActivityPayload) =>
+        payload.eventType == EndLiveActivityEvent
+      )
 
     }
 
     "generate a abandoned live activity END payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDay.copy(matchStatus = "Abandoned", result = false)
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      override def matchDayLA: MatchDay =
+        super.matchDay.copy(matchStatus = "Abandoned", result = false)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
       result must contain((payload: LiveActivityPayload) =>
-        payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState].matchStatus == liveActitivites.Abandoned
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .matchStatus == liveActitivites.Abandoned
       )
       result must contain((payload: LiveActivityPayload) =>
         payload.eventType == EndLiveActivityEvent
@@ -414,33 +548,56 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
   "A LiveActivity EventConsumer handles PA trigger events and" should {
 
     "generate a goal payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
+      override def matchDayLA: MatchDay =
+        super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
 
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
 
-      result must contain((payload: LiveActivityPayload) => payload.eventType == CreateChannelEvent)
-      // note: this will trigger the downstream update from the channel manager with Scheduled Match Status.
+      result must contain((payload: LiveActivityPayload) =>
+        payload.eventType == UpdateLiveActivityEvent
+      )
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .awayTeam.score mustEqual(1)
+      )
     }
 
     "generate a red card payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
+      override def matchDayLA: MatchDay =
+        super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
 
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
-      result must contain((payload: LiveActivityPayload) => payload.eventType == CreateChannelEvent)
-      // note: this will trigger the downstream update from the channel manager with Scheduled Match Status.
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      result must contain((payload: LiveActivityPayload) =>
+        payload.eventType == UpdateLiveActivityEvent
+      )
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .homeTeam.redCards mustEqual(1)
+      )
     }
 
     "generate a penalty kick payload" in new MatchEventsContext {
-      override def matchDayLA: MatchDay = super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
+      override def matchDayLA: MatchDay =
+        super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
 
-      val result: List[LiveActivityPayload] = eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
+      val result: List[LiveActivityPayload] =
+        eventConsumerLiveActivities.eventsToLiveActivityPayload(matchDataLA)
 
-      result must contain((payload: LiveActivityPayload) => payload.eventType == CreateChannelEvent)
-      // note: this will trigger the downstream update from the channel manager with Scheduled Match Status.
+      result must contain((payload: LiveActivityPayload) =>
+        payload.eventType == UpdateLiveActivityEvent
+      )
+      result must contain((payload: LiveActivityPayload) =>
+        payload.broadcastContentStateData.get
+          .asInstanceOf[FootballMatchContentState]
+          .homeTeam.penaltyScore
+          .exists(_.asInstanceOf[PenaltyShootoutState].scored == 1)
+      )
     }
   }
-
-
 
   trait MatchEventsContext extends Scope {
     val matchStatusNotificationBuilder = new MatchStatusNotificationBuilder(
@@ -464,11 +621,12 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
     def rawEvents: List[MatchEvent] =
       Parser.parseMatchEvents(loadFile("match-event-feed.xml")).get.events
     def matchDay: MatchDay = Parser.parseMatchDay(loadFile("20170811.xml")).head
-    def events: List[MatchEvent] = new SyntheticMatchEventGenerator(() => ZonedDateTime.now()).generate(
-      rawEvents,
-      "4011135",
-      matchDay
-    )
+    def events: List[MatchEvent] =
+      new SyntheticMatchEventGenerator(() => ZonedDateTime.now()).generate(
+        rawEvents,
+        "4011135",
+        matchDay
+      )
     def matchData = MatchDataWithArticle(
       matchDay,
       events,
@@ -484,8 +642,9 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
       .events
     def matchDayLA: MatchDay =
       Parser.parseMatchDay(loadFile("4484328-penalties.xml")).head
-    def eventsLA: List[MatchEvent] = new SyntheticMatchEventGenerator(() => ZonedDateTime.now())
-      .generate(rawEventsLA, "4484328", matchDayLA)
+    def eventsLA: List[MatchEvent] =
+      new SyntheticMatchEventGenerator(() => ZonedDateTime.now())
+        .generate(rawEventsLA, "4484328", matchDayLA)
     def matchDataLA = MatchDataWithArticle(
       matchDayLA,
       eventsLA,

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
@@ -73,22 +73,22 @@ class SyntheticMatchEventGeneratorSpec extends Specification {
     }
 
     "Add extra time event if status is ETS" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETS")).drop(1).head.eventType mustEqual "extra-time-first-half"
     }
 
     "Add extra time half time event if status is ETHT" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETHT")).drop(1).head.eventType mustEqual "extra-time-half-time"
     }
 
     "Add extra time second half event if status is ETSHS" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETSHS")).drop(1).head.eventType mustEqual "extra-time-second-half"
     }
 
     "Add penalty shootout event if status is PT" in new TestScope {
-      val generator = new SyntheticMatchEventGenerator()
+      val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "PT")).drop(1).head.eventType mustEqual "penalties"
     }
 

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
@@ -70,6 +70,27 @@ class SyntheticMatchEventGeneratorSpec extends Specification {
       val generator = new SyntheticMatchEventGenerator()
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(result = true)).drop(1).head.eventType mustEqual "full-time"
     }
+
+    "Add extra time event if status is ETS" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator()
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETS")).drop(1).head.eventType mustEqual "extra-time-first-half"
+    }
+
+    "Add extra time half time event if status is ETHT" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator()
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETHT")).drop(1).head.eventType mustEqual "extra-time-half-time"
+    }
+
+    "Add extra time second half event if status is ETSHS" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator()
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETSHS")).drop(1).head.eventType mustEqual "extra-time-second-half"
+    }
+
+    "Add penalty shootout event if status is PT" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator()
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "PT")).drop(1).head.eventType mustEqual "penalties"
+    }
+
   }
 
   "A SyntheticMatchEvent generator supporting Live Activities" should {

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
@@ -92,6 +92,46 @@ class SyntheticMatchEventGeneratorSpec extends Specification {
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "PT")).drop(1).head.eventType mustEqual "penalties"
     }
 
+    "Add extra-time-to-be-played event if status is FTET" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator(currentTime)
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "FTET")).drop(1).head.eventType mustEqual "extra-time-to-be-played"
+    }
+
+    "Add penalties-to-be-played event if status is FTPT" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator(currentTime)
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "FTPT")).drop(1).head.eventType mustEqual "penalties-to-be-played"
+    }
+
+    "Add penalties-to-be-played event if status is ETFTPT" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator(currentTime)
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETFTPT")).drop(1).head.eventType mustEqual "penalties-to-be-played"
+    }
+
+    "Add suspended event if status is Suspended" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator(currentTime)
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Suspended")).drop(1).head.eventType mustEqual "suspended"
+    }
+
+    "Add resumed event if status is Resumed" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator(currentTime)
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Resumed")).drop(1).head.eventType mustEqual "resumed"
+    }
+
+    "Add abandoned event if status is Abandoned" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator(currentTime)
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Abandoned")).drop(1).head.eventType mustEqual "abandoned"
+    }
+
+    "Add postponed event if status is Postponed" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator(currentTime)
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Postponed")).drop(1).head.eventType mustEqual "postponed"
+    }
+
+    "Add cancelled event if status is Cancelled" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator(currentTime)
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Cancelled")).drop(1).head.eventType mustEqual "cancelled"
+    }
+
   }
 
   "A SyntheticMatchEvent generator supporting Live Activities" should {

--- a/football/src/test/scala/com/gu/mobile/notifications/football/models/MatchPhaseEventSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/models/MatchPhaseEventSpec.scala
@@ -10,6 +10,7 @@ class MatchPhaseEventSpec extends Specification with Mockito {
       event.id returns Some("123")
       event.eventType returns "timeline"
       event.matchTime returns Some("0:00")
+      event.eventTime returns Some("0")
       MatchPhaseEvent.fromEvent(event) should beSome(KickOff("123"))
     }
     "Return none event for timeline event 0:01" in {
@@ -17,25 +18,90 @@ class MatchPhaseEventSpec extends Specification with Mockito {
       event.id returns Some("123")
       event.eventType returns "timeline"
       event.matchTime returns Some("0:01")
+      event.eventTime returns Some("1")
       MatchPhaseEvent.fromEvent(event) should beNone
     }
     "Create a fulltime event from full-time" in {
       val event = mock[pa.MatchEvent]
       event.id returns Some("123")
       event.eventType returns "full-time"
+      event.eventTime returns Some("92")
       MatchPhaseEvent.fromEvent(event) should beSome(FullTime("123"))
     }
     "Create a halftime event from half-time" in {
       val event = mock[pa.MatchEvent]
       event.id returns Some("123")
       event.eventType returns "half-time"
+      event.eventTime returns Some("45")
       MatchPhaseEvent.fromEvent(event) should beSome(HalfTime("123"))
     }
     "Create a secondhalf event from second-half" in {
       val event = mock[pa.MatchEvent]
       event.id returns Some("123")
       event.eventType returns "second-half"
+      event.eventTime returns Some("47")
       MatchPhaseEvent.fromEvent(event) should beSome(SecondHalf("123"))
     }
+
+    "Create an extra time first half phase event from extra-time-first-half" in {
+      val event = mock[pa.MatchEvent]
+      event.id returns Some("123")
+      event.eventType returns "extra-time-first-half"
+      event.eventTime returns Some("99")
+      MatchPhaseEvent.fromEvent(event) should beSome(ExtraTimeFirstHalf("123"))
+    }
+
+    "Create an extra time half-time phase event from extra-time-half-time" in {
+      val event = mock[pa.MatchEvent]
+      event.id returns Some("123")
+      event.eventType returns "extra-time-half-time"
+      event.eventTime returns Some("105")
+      MatchPhaseEvent.fromEvent(event) should beSome(ExtraTimeHalfTime("123"))
+    }
+
+    "Create an extra time second half phase event from extra-time-second-half" in {
+      val event = mock[pa.MatchEvent]
+      event.id returns Some("123")
+      event.eventType returns "extra-time-second-half"
+      event.eventTime returns Some("115")
+      MatchPhaseEvent.fromEvent(event) should beSome(ExtraTimeSecondHalf("123"))
+    }
+
+    "Create a penalty phase event from penalties" in {
+      val event = mock[pa.MatchEvent]
+      event.id returns Some("123")
+      event.eventType returns "penalties"
+      event.eventTime returns Some("120")
+      MatchPhaseEvent.fromEvent(event) should beSome(Penalties("123"))
+    }
+
+
+    // Live Activity Phase events
+
+    "Create a create-channel event from create-channel" in {
+      val event = mock[pa.MatchEvent]
+      event.id returns Some("123")
+      event.eventType returns "create-channel"
+      MatchPhaseEvent.fromEvent(event) should beSome(CreateChannel("123"))
+    }
+    "Create a start-live-activity event from start-live-activity" in {
+      val event = mock[pa.MatchEvent]
+      event.id returns Some("123")
+      event.eventType returns "start-live-activity"
+      event.eventTime returns Some("0")
+      MatchPhaseEvent.fromEvent(event) should beSome(StartLiveActivity("123"))
+    }
+    "Create an end-live-activity event from end-live-activity" in {
+      val event = mock[pa.MatchEvent]
+      event.id returns Some("123")
+      event.eventType returns "end-live-activity"
+      event.eventTime returns Some("90")
+      MatchPhaseEvent.fromEvent(event) should beSome(EndLiveActivity("123"))
+    }
+
+
+
+
+
   }
 }

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
@@ -1,0 +1,65 @@
+package com.gu.mobile.notifications.football.notificationbuilders
+
+import com.gu.mobile.notifications.client.models.DefaultGoalType
+import com.gu.mobile.notifications.client.models.liveActitivites.{FirstHalf, FootballLiveActivity, FootballMatchContentState, LiveActivityPayload, TeamState, UpdateLiveActivityEvent, Competition => LACompetition}
+import com.gu.mobile.notifications.football.models.Goal
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import pa.{Competition, MatchDay, MatchDayTeam, Round, Stage, Venue}
+
+import java.time.ZonedDateTime
+import java.util.UUID
+
+// todo add more tests
+class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
+
+  "A MatchStatusLiveActivityPayloadBuilder" should {
+
+    "Build a LiveActivityPayload for a goal event" in new MatchEventsContext {
+      val result = builder.build(baseGoal, matchInfo, List.empty, Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"))
+
+      result.eventType mustEqual UpdateLiveActivityEvent
+      result.liveActivityType mustEqual FootballLiveActivity
+      result.liveActivityID mustEqual "some-match-id"
+      result.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/".getBytes)
+
+      val contentState = result.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState]
+      println(contentState)
+      contentState.homeTeam.name mustEqual "Liverpool"
+      contentState.homeTeam.score mustEqual 1
+      contentState.awayTeam.name mustEqual "Plymouth"
+      contentState.awayTeam.score mustEqual 0
+      contentState.matchStatus mustEqual FirstHalf
+      contentState.currentMinute mustEqual Some(5)
+      contentState.competition.name mustEqual "FA Cup"
+      contentState.articleUrl mustEqual Some("http://localhost/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
+    }
+  }
+
+  trait MatchEventsContext extends Scope {
+    val builder = new MatchStatusLiveActivityPayloadBuilder("http://localhost")
+    val home = MatchDayTeam("1", "Liverpool", None, None, None, None)
+    val away = MatchDayTeam("2", "Plymouth", None, None, None, None)
+    val baseGoal = Goal(DefaultGoalType, "Steve", home, away, 5, None, "")
+    val matchInfo = MatchDay(
+      id = "some-match-id",
+      date = ZonedDateTime.parse("2000-01-01T00:00:00Z"),
+      competition = Some(Competition(id = "1", name = "FA Cup")),
+      stage = Stage("1"),
+      round = Round("1", None),
+      leg = "home",
+      liveMatch = true,
+      result = false,
+      previewAvailable = false,
+      reportAvailable = false,
+      lineupsAvailable = false,
+      matchStatus = "KO",
+      attendance = None,
+      homeTeam = home,
+      awayTeam = away,
+      referee = None,
+      venue = Some(Venue(id = "1", name = "Wembley")),
+      comments = None
+    )
+  }
+}

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
@@ -24,7 +24,6 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
       result.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/".getBytes)
 
       val contentState = result.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState]
-      println(contentState)
       contentState.homeTeam.name mustEqual "Liverpool"
       contentState.homeTeam.score mustEqual 1
       contentState.awayTeam.name mustEqual "Plymouth"

--- a/liveactivities/src/main/resources/broadcast-update-payload.json
+++ b/liveactivities/src/main/resources/broadcast-update-payload.json
@@ -8,23 +8,33 @@
   "region": "eu-west-1",
   "resources": [],
   "detail": {
-    "id": "165875bb-ade9-3245-b602-6343a1dd406d",
-    "eventType": "UpdateLiveActivity",
+    "id": "165875bb-ade9-3245-b602-6343a1dd407d",
+    "eventType": "broadcast-update",
     "liveActivityType": "FootballLiveActivity",
     "liveActivityID": "123456-test",
     "dynamoStoreData": "",
     "broadcastContentStateData": {
-      "matchStatus": "SCHEDULED",
+      "matchStatus": "PENALTIES",
       "kickOffTimestamp": 1766433600,
       "homeTeam": {
         "name": "Team A",
-        "score": 3,
-        "redCards": 1
+        "score": 1,
+        "redCards": 1,
+        "penaltyScore": {
+          "scored": 4,
+          "missed": 1,
+          "saved": 1
+        }
       },
       "awayTeam": {
         "name": "Team B",
-        "score": 5,
-        "redCards": 1
+        "score": 1,
+        "redCards": 1,
+        "penaltyScore": {
+          "scored": 4,
+          "missed": 1,
+          "saved": 1
+        }
       },
       "competition": {
         "id": "100",

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -120,7 +120,7 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
         logger.info(s"Broadcast ${if(shouldEndBroadcast)"END"} successfully sent for liveActivityID $matchId")
       }
       case Failure(exception) => {
-        logger.error(s"Failed to send broadcast for liveActivityID $matchId: ${exception.getMessage}")
+        logger.error(s"Failed to send broadcast ${if(shouldEndBroadcast)"END"} for liveActivityID $matchId: ${exception.getMessage}")
         throw exception
       }
     }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -19,7 +19,7 @@ import com.gu.liveactivities.models.BroadcastBody
 
 import java.time.ZonedDateTime
 import com.gu.liveactivities.util.DateTimeHelper.{dateTimeFromLong, dateTimeToLong, dateTimeToString}
-import com.gu.mobile.notifications.client.models.liveActitivites.{EndLiveActivityEvent, EventBridgeEvent, FootballMatchContentState, LiveActivityPayload, UpdateLiveActivityEvent}
+import com.gu.mobile.notifications.client.models.liveActitivites.{EndLiveActivityEvent, EventBridgeEvent, FootballMatchContentState, LiveActivityPayload, StartLiveActivityEvent, UpdateLiveActivityEvent}
 
 import scala.concurrent.duration.DurationInt
 
@@ -68,6 +68,7 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
 
     val shouldEndBroadcast: Boolean = requestPayload.eventType match {
       case EndLiveActivityEvent => true
+      case StartLiveActivityEvent => false
       case UpdateLiveActivityEvent => false
       case _ =>
         logger.error(s"Unexpected event type ${requestPayload.eventType} for broadcast payload")

--- a/liveactivities/src/main/scala/com/gu/liveactivities/models/BroadcastPayloads.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/models/BroadcastPayloads.scala
@@ -129,9 +129,10 @@ object BroadcastBody extends Logging {
     val now = System.currentTimeMillis() / 1000
 
     // todo clean up once timings are verified e2e
-    logger.debug(
-      s"Creating BroadcastBody ${if (shouldEndBroadcast) "END"} with timestamp ${now}"
+    logger.info(
+      s"Creating BroadcastBody ${if (shouldEndBroadcast) "END"} with dismissal timestamp from: ${now}"
     )
+
     val apsEvent: BroadcastApsEvent =
       if (shouldEndBroadcast) {
         BroadcastEndAps(

--- a/liveactivities/src/main/scala/com/gu/liveactivities/models/BroadcastPayloads.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/models/BroadcastPayloads.scala
@@ -2,6 +2,8 @@ package com.gu.liveactivities.models
 
 import com.gu.mobile.notifications.client.models.liveActitivites.ContentState
 import play.api.libs.json._
+import com.gu.liveactivities.util.Logging
+
 
 // APN BROADCAST PAYLOADS ////////////////////////////////
 
@@ -115,7 +117,7 @@ case class BroadcastBody(
     aps: BroadcastApsEvent
 )
 
-object BroadcastBody {
+object BroadcastBody extends Logging {
   import BroadcastApsJsonFormats._
 
   implicit val broadcastBodyFormat: OFormat[BroadcastBody] =
@@ -127,7 +129,10 @@ object BroadcastBody {
   ): BroadcastBody = {
     val now = System.currentTimeMillis() / 1000
 
-    val apsEvent: BroadcastApsEvent = if (shouldEndBroadcast) {
+    // todo clean up once timings are verified e2e
+    logger.debug(s"Creating BroadcastBody ${if (shouldEndBroadcast) "END"} with timestamp ${now}"
+)
+    val apsEvent: BroadcastApsEvent =  {
       BroadcastEndAps(
         timestamp = now,
         `content-state` = contentState,

--- a/liveactivities/src/main/scala/com/gu/liveactivities/models/BroadcastPayloads.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/models/BroadcastPayloads.scala
@@ -4,7 +4,6 @@ import com.gu.mobile.notifications.client.models.liveActitivites.ContentState
 import play.api.libs.json._
 import com.gu.liveactivities.util.Logging
 
-
 // APN BROADCAST PAYLOADS ////////////////////////////////
 
 // Start Live Activity (via broadcast or push)
@@ -125,27 +124,29 @@ object BroadcastBody extends Logging {
 
   def apply(
       contentState: ContentState,
-      shouldEndBroadcast: Boolean = false,
+      shouldEndBroadcast: Boolean = false
   ): BroadcastBody = {
     val now = System.currentTimeMillis() / 1000
 
     // todo clean up once timings are verified e2e
-    logger.debug(s"Creating BroadcastBody ${if (shouldEndBroadcast) "END"} with timestamp ${now}"
-)
-    val apsEvent: BroadcastApsEvent =  {
-      BroadcastEndAps(
-        timestamp = now,
-        `content-state` = contentState,
-        `dismissal-date` =
-          now + (1 * 3600) // dismiss from lock screen after 1 hour
-      )
-    } else {
-      BroadcastUpdateAps(
-        timestamp = now,
-        `content-state` = contentState,
-        `stale-date` = now + (1 * 2760) // stale after 45 minutes
-      )
-    }
+    logger.debug(
+      s"Creating BroadcastBody ${if (shouldEndBroadcast) "END"} with timestamp ${now}"
+    )
+    val apsEvent: BroadcastApsEvent =
+      if (shouldEndBroadcast) {
+        BroadcastEndAps(
+          timestamp = now,
+          `content-state` = contentState,
+          `dismissal-date` =
+            now + (1 * 3600) // dismiss from lock screen after 1 hour
+        )
+      } else {
+        BroadcastUpdateAps(
+          timestamp = now,
+          `content-state` = contentState,
+          `stale-date` = now + (1 * 2760) // stale after 45 minutes
+        )
+      }
 
     BroadcastBody(aps = apsEvent)
   }

--- a/registration/test/registration/controllers/MainControllerSpec.scala
+++ b/registration/test/registration/controllers/MainControllerSpec.scala
@@ -54,7 +54,6 @@ class MainControllerSpec extends PlaySpecification with JsonMatchers with Mockit
 
     "new /device/register endpoint returns expected response" in new RegistrationsContext {
       val Some(result) = route(app, FakeRequest(POST, "/device/register").withJsonBody(Json.parse(newRegistrationJson)))
-      println(Json.prettyPrint(Json.parse(contentAsString(result))))
 
       status(result) must equalTo(OK)
       contentAsString(result) must /("provider" -> "Guardian")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR implements MatchStatus and CurrentMinute for the LiveActivityPayloadBuilder. 

1/ **CurrentMinute** - attached the current game minute Int (44') to send with timeline events - goals, red cards, penalty kicks. 

2/ Creates **synthetic MatchPhase timeline events** based on the match status returned by PA match info endpoint changes. This allows us to process an event for this 'MatchPhaseChange' in the event consumer and send an update for it. 

3/ Maps the PA match status strings to the match status required by the App for the UI design. 

_Note_: it is not possible to add a currentPhaseStartTime: Long as we do not get timestamp for each event or match status change from PA. The only way to do this would be to go by the time we poll and receive a relevant change from PA but it is unclear how in/out of sync this would be with reality.  



<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

MatchPhaseEvents observed in CODE for a live game, include a fulltime result phase change with final score comments .


<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
