### PR TITLE
Ensure current time is evaluated on every invocation

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -49,7 +49,7 @@ object Lambda extends Logging {
 
   lazy val capiClient = GuardianContentClient(configuration.capiApiKey)
 
-  lazy val syntheticMatchEventGenerator = new SyntheticMatchEventGenerator(getZonedDateTime())
+  lazy val syntheticMatchEventGenerator = new SyntheticMatchEventGenerator(getZonedDateTime)
 
   lazy val notificationHttpProvider = new NotificationHttpProvider()
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -1,13 +1,14 @@
 package com.gu.mobile.notifications.football.lib
 
 import com.gu.mobile.notifications.football.Lambda.logger
+import com.gu.mobile.notifications.football.Logging
 
 import java.util.UUID
 import pa.{MatchDay, MatchEvent}
 
 import java.time.{Instant, ZoneId, ZonedDateTime}
 
-class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
+class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) extends Logging {
 
   def generate(events: List[MatchEvent], id: String, matchDay: MatchDay): List[MatchEvent] = {
     // Live activity synthetic events are appended at the end, but when they are first generated, no other timeline events exist and duplicate events are filtered so this should not matter.

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -1,11 +1,13 @@
 package com.gu.mobile.notifications.football.lib
 
+import com.gu.mobile.notifications.football.Lambda.logger
+
 import java.util.UUID
 import pa.{MatchDay, MatchEvent}
 
-import java.time.ZonedDateTime
+import java.time.{Instant, ZoneId, ZonedDateTime}
 
-class SyntheticMatchEventGenerator(dateTime: ZonedDateTime) {
+class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
 
   def generate(events: List[MatchEvent], id: String, matchDay: MatchDay): List[MatchEvent] = {
     // Live activity synthetic events are appended at the end, but when they are first generated, no other timeline events exist and duplicate events are filtered so this should not matter.
@@ -41,16 +43,23 @@ class SyntheticMatchEventGenerator(dateTime: ZonedDateTime) {
 
   // Live Activity supporting events //
 
-  val now: Long = dateTime.toInstant.getEpochSecond
+  def now: Long = getCurrentTime().toInstant.getEpochSecond
   def koWithinTwoHours(ko: Long): Boolean = now >= ko - 7200 && now < ko - 1200
   def koWithin20Minutes(ko: Long): Boolean = now >= ko - 1200 && now < ko
 
   private val createChannel: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
-    if (koWithinTwoHours(matchDay.date.toEpochSecond)) Some(emptyMatchEvent.copy(
-      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/create-channel".getBytes).toString),
-      eventType = "create-channel"
-    ))
-    else None
+    if (koWithinTwoHours(matchDay.date.toEpochSecond)) {
+      logger.info(
+        s"Creating channel for match ${matchDay.id}, ko is ${matchDay.date}, now is ${
+          Instant.ofEpochSecond(now).atZone(ZoneId.of("Europe/London"))
+        }"
+      )
+      Some(emptyMatchEvent.copy(
+        id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/create-channel".getBytes).toString),
+        eventType = "create-channel"
+        )
+      )
+    } else None
   }
 
   private val startLiveActivity: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -304,7 +304,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
     def rawEvents: List[MatchEvent] =
       Parser.parseMatchEvents(loadFile("match-event-feed.xml")).get.events
     def matchDay: MatchDay = Parser.parseMatchDay(loadFile("20170811.xml")).head
-    def events: List[MatchEvent] = new SyntheticMatchEventGenerator(ZonedDateTime.now()).generate(
+    def events: List[MatchEvent] = new SyntheticMatchEventGenerator(() => ZonedDateTime.now()).generate(
       rawEvents,
       "4011135",
       matchDay
@@ -324,7 +324,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
       .events
     def matchDayLA: MatchDay =
       Parser.parseMatchDay(loadFile("4484328-penalties.xml")).head
-    def eventsLA: List[MatchEvent] = new SyntheticMatchEventGenerator(ZonedDateTime.now())
+    def eventsLA: List[MatchEvent] = new SyntheticMatchEventGenerator(() => ZonedDateTime.now())
       .generate(rawEventsLA, "4484328", matchDayLA)
     def matchDataLA = MatchDataWithArticle(
       matchDayLA,

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
@@ -51,7 +51,7 @@ class SyntheticMatchEventGeneratorSpec extends Specification {
     )
 
     val kickoffId = UUID.nameUUIDFromBytes(s"football-match/match-id/timeline/00:00".getBytes).toString
-    val currentTime = ZonedDateTime.now()
+    val currentTime = () => ZonedDateTime.now()
   }
 
   "A SyntheticMatchEvent generator" should {


### PR DESCRIPTION
This PR fixes an issue related to the current time used in the football lambda. 

The current time was passed as a parameter to the `SyntheticMatchEventGenerator` class, but because `SyntheticMatchEventGenerator` was instansiated as `lazy val`. Lazy val is evaluated only once per JVM/container lifecycle (typically at Lambda cold start), so the timestamp was effectively frozen and did not reflect the actual current time during subsequent Lambda invocations.

This caused time-based conditions on `create-channel` event to behave incorrectly during warm Lambda executions, as comparisons were made against a stale reference time.

The change ensures that the current time is evaluated dynamically at execution time rather than at object initialisation, preventing stale time state and ensuring correct behaviour across all Lambda invocations.