### PR TITLE
TESTING - Marji test 2

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -64,7 +64,7 @@ object Lambda extends Logging {
   lazy val liveActivityHandler = new LiveActivityHandler(configuration, dynamoDBClient, liveActivitiesTableName)
 
   def getZonedDateTime(): ZonedDateTime = {
-    val zonedDateTime = if (configuration.stage == "CODE") {
+    val zonedDateTime = if (configuration.stage == "DEV") {
       val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
       val json = Json.parse(Source.fromInputStream(is).mkString)
       ZonedDateTime.parse((json \ "currentDate").as[String])

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -69,7 +69,7 @@ class FootballData(
 
   def matchIdsInProgress(dateTime: ZonedDateTime): Future[List[MatchDay]] = {
     def inProgress(m: MatchDay): Boolean =
-      m.date.minusHours(2).isBefore(dateTime) && m.date.plusHours(4).isAfter(dateTime)
+      m.date.minusHours(8).isBefore(dateTime) && m.date.plusHours(4).isAfter(dateTime)
 
 
     // unfortunately PA provide 00:00 as start date when they don't have the start date

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -49,6 +49,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) extends 
   def koWithin20Minutes(ko: Long): Boolean = now >= ko - 1200 && now < ko
 
   private val createChannel: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+    logger.info(s"Using date time in create channel: ${Instant.ofEpochSecond(now).atZone(ZoneId.of("Europe/London"))}")
     if (koWithinTwoHours(matchDay.date.toEpochSecond)) {
       logger.info(
         s"Creating channel for match ${matchDay.id}, ko is ${matchDay.date}, now is ${


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
