### PR TITLE
Revert the added logging that was for debugging

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -1,14 +1,11 @@
 package com.gu.mobile.notifications.football.lib
 
-import com.gu.mobile.notifications.football.Lambda.logger
-import com.gu.mobile.notifications.football.Logging
-
 import java.util.UUID
 import pa.{MatchDay, MatchEvent}
 
 import java.time.{Instant, ZoneId, ZonedDateTime}
 
-class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) extends Logging {
+class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
 
   def generate(events: List[MatchEvent], id: String, matchDay: MatchDay): List[MatchEvent] = {
     // Live activity synthetic events are appended at the end, but when they are first generated, no other timeline events exist and duplicate events are filtered so this should not matter.
@@ -50,11 +47,6 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) extends 
 
   private val createChannel: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
     if (koWithinTwoHours(matchDay.date.toEpochSecond)) {
-      logger.info(
-        s"Creating channel for match ${matchDay.id}, ko is ${matchDay.date}, now is ${
-          Instant.ofEpochSecond(now).atZone(ZoneId.of("Europe/London"))
-        }"
-      )
       Some(emptyMatchEvent.copy(
         id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/create-channel".getBytes).toString),
         eventType = "create-channel"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Delete the redundant logging. As part of https://github.com/guardian/mobile-n10n/pull/1782 logging was added within the createChannel event generator for debugging purposes. This event generator is working fine now and the logging is redundant. 