### PR TITLE
Complete live activity life cycle

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/LiveActivityPayloads.scala
@@ -13,15 +13,18 @@ import com.gu.mobile.notifications.client.models.Payload
 
 sealed trait EventSource
 case object FootballLambda extends EventSource
+case object ChannelManagerLambda extends EventSource
 
 object EventSource {
   implicit val format: Format[EventSource] = new Format[EventSource] {
     def writes(source: EventSource): JsValue = source match {
       case FootballLambda => JsString("football-lambda")
+      case ChannelManagerLambda => JsString("channel-manager-lambda")
     }
 
     def reads(json: JsValue): JsResult[EventSource] = json match {
       case JsString("football-lambda") => JsSuccess(FootballLambda)
+      case JsString("channel-manager-lambda") => JsSuccess(ChannelManagerLambda)
       case JsString(other)             => JsError(s"Invalid EventSource: $other")
       case _ => JsError("EventSource must be a string")
     }

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,6 @@ lazy val commontest = project
 
 lazy val common = project
   .dependsOn(commoneventconsumer)
-  .dependsOn(apiModels  % "test->test", apiModels  % "compile->compile")
   .settings(LocalDynamoDBCommon.settings)
   .settings(standardSettings: _*)
   .settings(
@@ -124,8 +123,7 @@ lazy val common = project
       "org.postgresql" % "postgresql" % "42.7.10",
       "ch.qos.logback" % "logback-core" % logbackVersion,
       "ch.qos.logback" % "logback-classic" % logbackVersion,
-      "net.logstash.logback" % "logstash-logback-encoder" % "8.1",
-      "software.amazon.awssdk" % "eventbridge" % "2.20.162",
+      "net.logstash.logback" % "logstash-logback-encoder" % "8.1"
     ),
     fork := true,
     startDynamoDBLocal := startDynamoDBLocal.dependsOn(Test / compile).value,
@@ -250,33 +248,33 @@ lazy val apiModels = {
 
 def lambda(projectName: String, directoryName: String, mainClassName: Option[String] = None): Project =
   Project(projectName, file(directoryName))
-  .enablePlugins(AssemblyPlugin)
-  .settings(
-    organization := "com.gu",
-    resolvers ++= Seq(
-      "Guardian GitHub Releases" at "https://guardian.github.com/maven/repo-releases",
-      "snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
-    ),
-    libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-lambda-java-core" % "1.4.0",
-      "org.slf4j" % "slf4j-api" % slf4jVersion,
-      "com.gu" %% "simple-configuration-core" % simpleConfigurationVersion,
-      "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
-      "ch.qos.logback" % "logback-classic" % logbackVersion,
-      "net.logstash.logback" % "logstash-logback-encoder" % "8.1",
-      specs2 % Test
-    ),
-    assemblyJarName := s"$projectName.jar",
-    assembly / assemblyMergeStrategy := {
-      case "META-INF/MANIFEST.MF" => MergeStrategy.discard
-      case _ => MergeStrategy.first
-    },
-    Test / run / fork := true,
-    scalacOptions := compilerOptions,
-    mainClass := mainClassName,
-    // Workaround Mockito causes deadlock on SBT classloaders: https://github.com/sbt/sbt/issues/3022
-    Test / parallelExecution := false
-  )
+    .enablePlugins(AssemblyPlugin)
+    .settings(
+      organization := "com.gu",
+      resolvers ++= Seq(
+        "Guardian GitHub Releases" at "https://guardian.github.com/maven/repo-releases",
+        "snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+      ),
+      libraryDependencies ++= Seq(
+        "com.amazonaws" % "aws-lambda-java-core" % "1.4.0",
+        "org.slf4j" % "slf4j-api" % slf4jVersion,
+        "com.gu" %% "simple-configuration-core" % simpleConfigurationVersion,
+        "com.gu" %% "simple-configuration-ssm" % simpleConfigurationVersion,
+        "ch.qos.logback" % "logback-classic" % logbackVersion,
+        "net.logstash.logback" % "logstash-logback-encoder" % "8.1",
+        specs2 % Test
+      ),
+      assemblyJarName := s"$projectName.jar",
+      assembly / assemblyMergeStrategy := {
+        case "META-INF/MANIFEST.MF" => MergeStrategy.discard
+        case _ => MergeStrategy.first
+      },
+      Test / run / fork := true,
+      scalacOptions := compilerOptions,
+      mainClass := mainClassName,
+      // Workaround Mockito causes deadlock on SBT classloaders: https://github.com/sbt/sbt/issues/3022
+      Test / parallelExecution := false
+    )
 
 lazy val schedulelambda = lambda("schedule", "schedulelambda")
   .dependsOn(commonscheduledynamodb)
@@ -303,8 +301,16 @@ lazy val schedulelambda = lambda("schedule", "schedulelambda")
     )
   }
 
+lazy val commonEventBusPusher = project
+  .dependsOn(apiModels  % "test->test", apiModels  % "compile->compile")
+  .settings(Seq(
+    libraryDependencies ++= Seq(
+      "software.amazon.awssdk" % "eventbridge" % "2.20.162"
+    ),
+  ))
+
 lazy val football = lambda("football", "football")
-  .dependsOn(common)
+  .dependsOn(commonEventBusPusher)
   .settings(
     resolvers += "Guardian GitHub Releases" at "https://guardian.github.com/maven/repo-releases",
     libraryDependencies ++= Seq(
@@ -433,10 +439,11 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
       // Hopefully this workaround can be removed once play-json-extensions either updates to Play 3.0 or is merged into play-json
       ExclusionRule(organization = "com.typesafe.play")
     ),
-)
+  )
 
 lazy val fakebreakingnewslambda = lambda("fakebreakingnewslambda", "fakebreakingnewslambda", Some("fakebreakingnews.LocalRun"))
   .dependsOn(common)
+  .dependsOn(apiModels  % "test->test", apiModels  % "compile->compile")
   .settings(
     libraryDependencies ++= Seq(
       "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
@@ -462,12 +469,14 @@ lazy val reportExtractor = lambda("reportextractor", "reportextractor", Some("co
 
 lazy val liveactivities = lambda("liveactivities", "liveactivities", Some("com.gu.liveactivities.LambdaLocalRun"))
   .dependsOn(common)
+  .dependsOn(commonEventBusPusher)
   .settings(LocalDynamoDBLiveActivities.settings)
   .settings(
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
       "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
       "software.amazon.awssdk" % "dynamodb" % awsSdk2Version,
+      "software.amazon.awssdk" % "eventbridge" % "2.20.162",
       "org.scanamo" %% "scanamo" % "6.0.0",
       "org.scanamo" %% "scanamo-testkit" % "6.0.0" % "test"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -99,6 +99,7 @@ lazy val commontest = project
 
 lazy val common = project
   .dependsOn(commoneventconsumer)
+  .dependsOn(apiModels  % "test->test", apiModels  % "compile->compile")
   .settings(LocalDynamoDBCommon.settings)
   .settings(standardSettings: _*)
   .settings(
@@ -123,7 +124,8 @@ lazy val common = project
       "org.postgresql" % "postgresql" % "42.7.10",
       "ch.qos.logback" % "logback-core" % logbackVersion,
       "ch.qos.logback" % "logback-classic" % logbackVersion,
-      "net.logstash.logback" % "logstash-logback-encoder" % "8.1"
+      "net.logstash.logback" % "logstash-logback-encoder" % "8.1",
+      "software.amazon.awssdk" % "eventbridge" % "2.20.162",
     ),
     fork := true,
     startDynamoDBLocal := startDynamoDBLocal.dependsOn(Test / compile).value,
@@ -302,7 +304,7 @@ lazy val schedulelambda = lambda("schedule", "schedulelambda")
   }
 
 lazy val football = lambda("football", "football")
-  .dependsOn(apiModels  % "test->test", apiModels  % "compile->compile")
+  .dependsOn(common)
   .settings(
     resolvers += "Guardian GitHub Releases" at "https://guardian.github.com/maven/repo-releases",
     libraryDependencies ++= Seq(
@@ -318,7 +320,6 @@ lazy val football = lambda("football", "football")
       "io.netty" % "netty-codec-http" % nettyVersion,
       "io.netty" % "netty-codec-http2" % nettyVersion,
       "io.netty" % "netty-common" % nettyVersion,
-      "software.amazon.awssdk" % "eventbridge" % "2.20.162"
     ),
     excludeDependencies ++= Seq(
       ExclusionRule("org.playframework", "play-ahc-ws_2.13"),
@@ -436,7 +437,6 @@ lazy val notificationworkerlambda = lambda("notificationworkerlambda", "notifica
 
 lazy val fakebreakingnewslambda = lambda("fakebreakingnewslambda", "fakebreakingnewslambda", Some("fakebreakingnews.LocalRun"))
   .dependsOn(common)
-  .dependsOn(apiModels  % "test->test", apiModels  % "compile->compile")
   .settings(
     libraryDependencies ++= Seq(
       "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
@@ -462,14 +462,12 @@ lazy val reportExtractor = lambda("reportextractor", "reportextractor", Some("co
 
 lazy val liveactivities = lambda("liveactivities", "liveactivities", Some("com.gu.liveactivities.LambdaLocalRun"))
   .dependsOn(common)
-  .dependsOn(apiModels  % "test->test", apiModels  % "compile->compile")
   .settings(LocalDynamoDBLiveActivities.settings)
   .settings(
     libraryDependencies ++= Seq(
       "com.turo" % "pushy" % "0.13.10",
       "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
       "software.amazon.awssdk" % "dynamodb" % awsSdk2Version,
-      "software.amazon.awssdk" % "eventbridge" % "2.20.162",
       "org.scanamo" %% "scanamo" % "6.0.0",
       "org.scanamo" %% "scanamo-testkit" % "6.0.0" % "test"
     ),

--- a/cdk/lib/__snapshots__/liveactivities.test.ts.snap
+++ b/cdk/lib/__snapshots__/liveactivities.test.ts.snap
@@ -834,6 +834,26 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
                 ],
               },
             },
+            {
+              "Action": "events:PutEvents",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:events:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":event-bus/liveactivities-eventbus-CODE",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -78,6 +78,15 @@ export class LiveActivities extends GuStack {
 			}),
 		);
 
+		channelLambda.addToRolePolicy(
+			new PolicyStatement({
+				actions: ['events:PutEvents'],
+				resources: [
+					`arn:aws:events:${region}:${account}:event-bus/${app}-eventbus-${stage}`,
+				],
+			}),
+		);
+
 		const broadcastDlq = new Queue(this, 'BroadcastDlq', {
 			queueName: `${app}-broadcast-dlq-${stage}`,
 			visibilityTimeout: Duration.minutes(4),

--- a/common/src/main/scala/aws/LiveActivityPusher.scala
+++ b/common/src/main/scala/aws/LiveActivityPusher.scala
@@ -1,28 +1,15 @@
-package com.gu.mobile.notifications.football.lib
+package aws
 
 import com.gu.mobile.notifications.client.models.liveActitivites._
-import com.gu.mobile.notifications.football.Logging
-import com.gu.mobile.notifications.football.models.MatchDataWithArticle
+import org.slf4j.Logger
 import play.api.libs.json.Json
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient
-import software.amazon.awssdk.services.eventbridge.model.{
-  PutEventsRequest,
-  PutEventsRequestEntry,
-  PutEventsResponse
-}
-import scala.util.Try
+import software.amazon.awssdk.services.eventbridge.model.{PutEventsRequest, PutEventsRequestEntry, PutEventsResponse}
 
-// Temporary json formatters to test pushing match data - will be replaced once we know what we want to send.
-import play.api.libs.json.Writes
-import scala.concurrent.Future
-import scala.util.Success
-import scala.util.Failure
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
-class LiveActivityPusher extends Logging {
-
-  private val eventBusName =
-    "liveactivities-eventbus-CODE"
+class LiveActivityPusher(eventBusName: String, logger: Logger) {
   private val eventBridgeClient =
     EventBridgeClient
       .builder()
@@ -41,13 +28,6 @@ class LiveActivityPusher extends Logging {
     logger.info(
       s"Eventbus pusher: Processing event with id ${payload.id}"
     )
-    val jsonDetail = Json.toJson(payload).toString()
-    if (jsonDetail.isEmpty || jsonDetail == "{}") {
-      logger.info(
-        s"Eventbus pusher: Skipping empty event for ${payload.id}"
-      )
-      Future.successful(())
-    } else {
       val result = Try {
         val entry = PutEventsRequestEntry
           .builder()
@@ -64,26 +44,27 @@ class LiveActivityPusher extends Logging {
 
         val response: PutEventsResponse = eventBridgeClient.putEvents(request)
 
-        // todo - alert for failed entry counts?
-        logger.info(
-          s"Eventbus pusher: Event published with event ${payload.eventType} is ${payload.id}. Failed entry count: ${response.failedEntryCount()}"
-        )
+        if (response.failedEntryCount() > 0) {
+          val error = response.entries().get(0).errorMessage()
+          throw new RuntimeException(s"EventBridge rejected entry: $error")
+        } else {
+          logger.info(
+            s"Eventbus pusher: Event published with event ${payload.eventType} is ${payload.id}"
+          )
+        }
       }
 
       result match {
-        case Success(_) => {
+        case Success(_) =>
           logger.info(
             s"Eventbus pusher: Successfully processed live activities event ${payload.eventType} with id ${payload.id}"
           )
           Future.successful(())
-        }
-        case Failure(e) => {
+        case Failure(e) =>
           logger.error(
             s"Eventbus pusher: Failed to publish live activities event ${payload.eventType} with id ${payload.id}: ${e.getMessage}"
           )
           Future.failed(e)
-        }
       }
-    }
   }
 }

--- a/commonEventBusPusher/src/main/scala/com/gu/mobile/liveactivities/event/bus/LiveActivityPusher.scala
+++ b/commonEventBusPusher/src/main/scala/com/gu/mobile/liveactivities/event/bus/LiveActivityPusher.scala
@@ -1,4 +1,4 @@
-package aws
+package com.gu.mobile.liveactivities.event.bus
 
 import com.gu.mobile.notifications.client.models.liveActitivites._
 import org.slf4j.Logger

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -1,13 +1,12 @@
 package com.gu.mobile.notifications.football
 
-import aws.LiveActivityPusher
-
-import java.net.{URI, URL}
+import java.net.URI
 import java.time.ZonedDateTime
 import java.util.concurrent.TimeUnit
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder}
 import com.gu.contentapi.client.GuardianContentClient
+import com.gu.mobile.liveactivities.event.bus.LiveActivityPusher
 import com.gu.mobile.notifications.football.lib.{ArticleSearcher, DynamoDistinctCheck, DynamoMatchLiveActivity, DynamoMatchNotification, EventConsumer, EventFilter, FootballData, LiveActivityEventConsumer, NotificationHttpProvider, NotificationSender, NotificationsApiClient, PaFootballClient, SyntheticMatchEventGenerator}
 import com.gu.mobile.notifications.football.notificationbuilders.{MatchStatusLiveActivityPayloadBuilder, MatchStatusNotificationBuilder}
 import play.api.libs.json.Json

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -1,12 +1,14 @@
 package com.gu.mobile.notifications.football
 
+import aws.LiveActivityPusher
+
 import java.net.{URI, URL}
 import java.time.ZonedDateTime
 import java.util.concurrent.TimeUnit
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder}
 import com.gu.contentapi.client.GuardianContentClient
-import com.gu.mobile.notifications.football.lib.{ArticleSearcher, DynamoDistinctCheck, DynamoMatchLiveActivity, DynamoMatchNotification, EventConsumer, EventFilter, FootballData, LiveActivityEventConsumer, LiveActivityPusher, NotificationHttpProvider, NotificationSender, NotificationsApiClient, PaFootballClient, SyntheticMatchEventGenerator}
+import com.gu.mobile.notifications.football.lib.{ArticleSearcher, DynamoDistinctCheck, DynamoMatchLiveActivity, DynamoMatchNotification, EventConsumer, EventFilter, FootballData, LiveActivityEventConsumer, NotificationHttpProvider, NotificationSender, NotificationsApiClient, PaFootballClient, SyntheticMatchEventGenerator}
 import com.gu.mobile.notifications.football.notificationbuilders.{MatchStatusLiveActivityPayloadBuilder, MatchStatusNotificationBuilder}
 import play.api.libs.json.Json
 
@@ -147,7 +149,10 @@ class NotificationHandler(configuration: Configuration, apiClient: Notifications
 
 class LiveActivityHandler(configuration: Configuration, dynamoDBClient: AmazonDynamoDBAsync, tableName: String) extends Logging {
 
-  lazy val liveActivityPusher = new LiveActivityPusher()
+  private val eventBusName =
+    "liveactivities-eventbus-CODE"
+
+  lazy val liveActivityPusher = new LiveActivityPusher(eventBusName, logger)
 
   lazy val matchStatusLiveActivityPayloadBuilder = new MatchStatusLiveActivityPayloadBuilder(configuration.mapiHost)
 

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -83,11 +83,6 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
           Future.failed(new LiveActivityInvalidStateException(matchId, "Channel not active"))
         } else Future.successful(())
 
-      _ <- if (!mapping.isLive) {
-          logger.error(s"Event not live for match ID $matchId")
-          Future.failed(new LiveActivityInvalidStateException(matchId, "Event not live"))
-        } else Future.successful(())
-
       _ <- if (mapping.lastEventId.contains(eventId)) {
           logger.warn(s"Duplicate event ID $eventId for match ID $matchId")
           Future.failed(new LiveActivityInvalidStateException(matchId, "Duplicate event ID"))
@@ -105,7 +100,7 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
       _ <- broadcastApiClient.sendToChannel(mapping.channelId, None, None, broadcastPayload)
       _ = logger.info(s"Broadcast ${if(shouldEndBroadcast)"END"} sent successfully for match ID $matchId to channel ID ${mapping.channelId}")
 
-      _ <- repository.updateMappingLastEvent(matchId, Some(eventId), Some(eventTime))
+      _ <- repository.updateMappingLiveAndLastEvent(matchId, isLive = true, Some(eventId), Some(eventTime))
       _ = logger.info(s"Record updated successfully for match ID $matchId")
     } yield mapping.channelId
 

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -101,7 +101,7 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
       _ <- broadcastApiClient.sendToChannel(mapping.channelId, None, None, broadcastPayload)
       _ = logger.info(s"Broadcast ${requestPayload.eventType.asString} sent successfully for match ID $matchId to channel ID ${mapping.channelId}")
 
-      _ <- repository.updateMappingLiveAndLastEvent(matchId, isLive = true, Some(eventId), Some(eventTime))
+      _ <- repository.updateMappingLiveAndLastEvent(matchId, isLive = !shouldEndBroadcast, Some(eventId), Some(eventTime))
       _ = logger.info(s"Record updated successfully for match ID $matchId")
     } yield mapping.channelId
 

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -34,7 +34,10 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
       case JsSuccess(request, _) => {
 
         // If we see these errors there is a misconfiguration in the eventbridge routing rules.
-        if (request.`detail-type` != UpdateLiveActivityEvent && request.`detail-type` != EndLiveActivityEvent) {
+        if (request.`detail-type` != UpdateLiveActivityEvent &&
+          request.`detail-type` != EndLiveActivityEvent &&
+          request.`detail-type` != StartLiveActivityEvent
+        ) {
           logger.error(s"Unexpected eventbridge event type: ${request.`detail-type`}")
           throw new Exception(s"Unexpected event type: ${request.`detail-type`}")
         }
@@ -70,7 +73,6 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
       case EndLiveActivityEvent => true
       case StartLiveActivityEvent => false
       case UpdateLiveActivityEvent => false
-      case StartLiveActivityEvent => false
       case _ =>
         logger.error(s"Unexpected event type ${requestPayload.eventType} for broadcast payload")
         throw new Exception(s"Unexpected event type ${requestPayload.eventType} for broadcast payload")

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -70,6 +70,7 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
       case EndLiveActivityEvent => true
       case StartLiveActivityEvent => false
       case UpdateLiveActivityEvent => false
+      case StartLiveActivityEvent => false
       case _ =>
         logger.error(s"Unexpected event type ${requestPayload.eventType} for broadcast payload")
         throw new Exception(s"Unexpected event type ${requestPayload.eventType} for broadcast payload")
@@ -98,7 +99,7 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
       _ = logger.info(s"Sending broadcast for match ID $matchId to channel ID ${mapping.channelId}")
       broadcastPayload = BroadcastBody(contentState, shouldEndBroadcast)
       _ <- broadcastApiClient.sendToChannel(mapping.channelId, None, None, broadcastPayload)
-      _ = logger.info(s"Broadcast ${if(shouldEndBroadcast)"END"} sent successfully for match ID $matchId to channel ID ${mapping.channelId}")
+      _ = logger.info(s"Broadcast ${requestPayload.eventType.asString} sent successfully for match ID $matchId to channel ID ${mapping.channelId}")
 
       _ <- repository.updateMappingLiveAndLastEvent(matchId, isLive = true, Some(eventId), Some(eventTime))
       _ = logger.info(s"Record updated successfully for match ID $matchId")

--- a/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
@@ -94,11 +94,10 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
   }
 
   private def pushUpdateLiveActivityEvent(matchId: String, broadcastContentStateData: Option[ContentState]): Future[Unit] = {
-    val triggeringEventId = Some(UUID.nameUUIDFromBytes(s"football-match/$matchId/live-activity-initial-data".getBytes).toString)
-    val derivedId = s"football-match-status/$matchId/$triggeringEventId"
+    val triggeringEventId = s"football-match-status/$matchId/live-activity-initial-data"
     liveActivityPusher.pushToEventbus(
       LiveActivityPayload(
-        id = UUID.nameUUIDFromBytes(derivedId.getBytes),
+        id = UUID.nameUUIDFromBytes(triggeringEventId.getBytes),
         eventType = UpdateLiveActivityEvent,
         liveActivityType = FootballLiveActivity,
         liveActivityID = matchId,

--- a/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
@@ -4,25 +4,20 @@ import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
 import com.gu.liveactivities.models.LiveActivityData
 import com.gu.liveactivities.service.ChannelApiClient
 import com.gu.liveactivities.util.Logging
-import com.gu.mobile.notifications.client.models.liveActitivites.{CreateChannelEvent, DeleteChannelEvent, EventBridgeEvent, LiveActivityPayload}
-import play.api.libs.json.{Format, JsError, JsSuccess, Json}
+import com.gu.mobile.notifications.client.models.liveActitivites._
+import play.api.libs.json.{JsError, JsSuccess, Json}
 
 import java.io.{InputStream, OutputStream}
+import java.util.{Date, UUID}
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success, Try}
-
-case class ChannelRequest(matchId: String, competitionId: Option[String], eventData: Option[LiveActivityData], toCreate: Boolean)
-
-object ChannelRequest {
-  implicit val jf: Format[ChannelRequest] = Json.format[ChannelRequest]
-}
 
 object ChannelManagerLambda extends RequestStreamHandler with Lambda with Logging {
 
   private val channelApiClient = new ChannelApiClient(authentication, config.bundleId, config.sendingToProdServer)
 
-  private def processCreateChannelRequest(matchId: String, eventData: Option[LiveActivityData]): Future[String] = {
+  private def processCreateChannelRequest(matchId: String, eventData: Option[LiveActivityData], broadcastContentStateData: Option[ContentState]): Future[String] = {
     logger.info(s"Received request to create channel for match ID $matchId")
 
     val maybeChannelId = repository.containMapping(matchId)
@@ -36,6 +31,8 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
           channelId <- channelApiClient.createChannel()
           _ <- repository.createMapping(matchId, channelId, eventData)
           _ = logger.info(s"Channel created with channel ID $channelId for match ID $matchId")
+          _ <- pushUpdateLiveActivityEvent(matchId, broadcastContentStateData)
+          _ = logger.info(s"Initial broadcast update pushed to event bus for channel ID $channelId and match ID $matchId")
         } yield channelId
     }
   }
@@ -76,7 +73,7 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
     val channelFuture = request.eventType match {
       case CreateChannelEvent =>
         val eventData = request.broadcastContentStateData.map(LiveActivityData.toLiveActivityData)
-        processCreateChannelRequest(request.liveActivityID, eventData)
+        processCreateChannelRequest(request.liveActivityID, eventData, request.broadcastContentStateData)
       case DeleteChannelEvent =>
         processCloseChannelRequest(request.liveActivityID)
       case other =>
@@ -94,5 +91,21 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
         logger.error(s"Failed to process: ${exception.getMessage}")
         throw exception
     }
+  }
+
+  private def pushUpdateLiveActivityEvent(matchId: String, broadcastContentStateData: Option[ContentState]): Future[Unit] = {
+    val triggeringEventId = Some(UUID.nameUUIDFromBytes(s"football-match/$matchId/live-activity-initial-data".getBytes).toString)
+    val derivedId = s"football-match-status/$matchId/$triggeringEventId"
+    liveActivityPusher.pushToEventbus(
+      LiveActivityPayload(
+        id = UUID.nameUUIDFromBytes(derivedId.getBytes),
+        eventType = UpdateLiveActivityEvent,
+        liveActivityType = FootballLiveActivity,
+        liveActivityID = matchId,
+        dynamoStoreData = None,
+        broadcastContentStateData = broadcastContentStateData,
+        eventTimestamp =  new Date().getTime,
+      )
+    )
   }
 }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
@@ -1,8 +1,8 @@
 package com.gu.liveactivities
 
-import aws.LiveActivityPusher
 import com.gu.liveactivities.service.{Authentication, LiveActivityChannelRepository}
 import com.gu.liveactivities.util.{Configuration, IosConfiguration, Logging}
+import com.gu.mobile.liveactivities.event.bus.LiveActivityPusher
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, DefaultCredentialsProvider, ProfileCredentialsProvider}
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.regions.Region

--- a/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
@@ -1,7 +1,8 @@
 package com.gu.liveactivities
 
+import aws.LiveActivityPusher
 import com.gu.liveactivities.service.{Authentication, LiveActivityChannelRepository}
-import com.gu.liveactivities.util.{Configuration, IosConfiguration}
+import com.gu.liveactivities.util.{Configuration, IosConfiguration, Logging}
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, DefaultCredentialsProvider, ProfileCredentialsProvider}
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.regions.Region
@@ -10,7 +11,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 
 import java.time.Duration
 
-trait Lambda {
+trait Lambda extends Logging{
 
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
 
@@ -40,4 +41,7 @@ trait Lambda {
       .build()
 
   val repository = new LiveActivityChannelRepository(dynamoDbClient, s"mobile-notifications-liveactivities-${config.stage}")
+
+  private val eventBusName = s"liveactivities-eventbus-${config.stage}"
+  lazy val liveActivityPusher = new LiveActivityPusher(eventBusName, logger)
 }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
@@ -28,6 +28,7 @@ trait ChannelMappingsRepository {
   def updateMappingLive(id: String, isLive: Boolean): Future[Unit]
 
   def updateMappingLastEvent(id: String, lastEventId: Option[String], lastEventUpdate: Option[ZonedDateTime]): Future[Unit]
+  def updateMappingLiveAndLastEvent(id: String, isLive: Boolean, lastEventId: Option[String], lastEventUpdate: Option[ZonedDateTime]): Future[Unit]
   
   def deleteMappingById(id: String): Future[Unit]
 }
@@ -131,6 +132,10 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
 
   override def updateMappingLastEvent(id: String, lastEventId: Option[String], lastEventAt: Option[ZonedDateTime]): Future[Unit] = {
     updateMappingById(id, lastEventId = lastEventId, lastEventAt = lastEventAt)
+  }
+
+  override def updateMappingLiveAndLastEvent(id: String, isLive: Boolean, lastEventId: Option[String], lastEventUpdate: Option[ZonedDateTime]): Future[Unit] = {
+    updateMappingById(id, isLive = Some(isLive), lastEventId = lastEventId, lastEventAt = lastEventUpdate)
   }
 
   override def getMappingById(

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
@@ -63,7 +63,7 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
       id = id, 
       channelId = channelId, 
       isChannelActive = true, 
-      isLive = true,
+      isLive = false,
       data = eventData,
       lastEventId = None,
       lastEventAt = None,

--- a/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivityChannelRepositorySpec.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivityChannelRepositorySpec.scala
@@ -88,7 +88,7 @@ class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
       id = "football-1234567",
       channelId = "test-channel-id",
       isChannelActive = true,
-      isLive = true,     
+      isLive = false,
       data = Some(footballData),
       lastEventId = None,
       lastEventAt = None,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR is correcting the LiveActivity lifecycle management: 
- Create commonEventBusPusher sbt module in order to share the implementation between football lambda and Channel manager lambda
- Throw error when there's any failedEntryCount on event bus pusher response
- Set `isLive` to false initially when channel is created in Channel manager
- Push a `UpdateLiveActivityEvent` event to event bus straight after channel is created in channel manager
- Set `isLive` to true when a UpdateLiveActivityEvent is received 
- Set `isLive` to false when EndLiveActivityEvent is received 
- Update channel manager policy to allow it to push messages to the event bus
- Support start live activity event in broadcast lambda (this is just a safety measurement since the create channel event also send a broadcast update message. We can remove this support in the future if we find it un-necessary)