### PR TITLE
Add TTL in epoch seconds to live activities dynamo table

### DIFF
--- a/cdk/lib/__snapshots__/liveactivities.test.ts.snap
+++ b/cdk/lib/__snapshots__/liveactivities.test.ts.snap
@@ -885,6 +885,10 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
             "Value": "CODE",
           },
         ],
+        "TimeToLiveSpecification": {
+          "AttributeName": "ttlInEpochSeconds",
+          "Enabled": true,
+        },
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -24,7 +24,9 @@ export class LiveActivities extends GuStack {
 			tableName: dynamoTableName,
 			partitionKey: { name: 'id', type: AttributeType.STRING },
 			billingMode: BillingMode.PAY_PER_REQUEST,
+			timeToLiveAttribute: 'ttlInEpochSeconds',
 		});
+
 		Tags.of(dynamoTable).add('devx-backup-enabled', 'true');
 
 		const channelManagerDlq = new Queue(this, 'ChannelManagerDlq', {

--- a/liveactivities/src/main/scala/com/gu/liveactivities/models/LiveActivities.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/models/LiveActivities.scala
@@ -61,8 +61,9 @@ case class LiveActivityMapping(
     data: Option[LiveActivityData],
     lastEventId: Option[String],
     lastEventAt: Option[ZonedDateTime],
-		createdAt: ZonedDateTime,
-    lastModifiedAt: ZonedDateTime
+    createdAt: ZonedDateTime,
+    lastModifiedAt: ZonedDateTime,
+    ttlInEpochSeconds: Option[Long] = None
 )
 
 object LiveActivityMapping {

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
@@ -59,6 +59,7 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
     eventData: Option[LiveActivityData],
   ): Future[Unit] = {
     val createdAt = ZonedDateTime.now()
+    val ttlEpochSeconds = createdAt.toEpochSecond + 14 * 24 * 3600 // 15=4 days from now
     val newItem = new LiveActivityMapping(
       id = id, 
       channelId = channelId, 
@@ -68,7 +69,8 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
       lastEventId = None,
       lastEventAt = None,
       createdAt = createdAt,
-      lastModifiedAt = createdAt
+      lastModifiedAt = createdAt,
+      ttlInEpochSeconds = Some(ttlEpochSeconds)
     )
     scanamo.exec {
         table.when(attributeNotExists(idKeyName)).put(newItem)

--- a/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivityChannelRepositorySpec.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/LiveActivityChannelRepositorySpec.scala
@@ -93,7 +93,8 @@ class LiveActivityChannelRepositoryTest(implicit ev: ExecutionEnv)
       lastEventId = None,
       lastEventAt = None,
       createdAt = ZonedDateTime.now(),
-      lastModifiedAt = ZonedDateTime.now()
+      lastModifiedAt = ZonedDateTime.now(),
+      ttlInEpochSeconds = Some(ZonedDateTime.now().toEpochSecond + 14 * 24 * 3600)
     )
 
     def createFootballMappingWithId(id: String): LiveActivityMapping = {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a ttl of 14 days to the liveactivities dynamo table containing channel mappings.

A ttl along with a clean up lambda will allow us to keep this table small but have enough data to debug live activites. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
