### PR TITLE
Pass on PA lineups available status to live activity status. 

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
@@ -114,7 +114,7 @@ case class FootballMatchContentState(
     awayTeam: TeamState,
     competition: Competition,
     commentary: Option[String] = None,
-    lineupsAvailable: Option[Boolean] = None,
+    lineupsAvailable: Boolean = false,
     currentMinute: Option[Int] = None,
     currentPeriodStartTime: Option[Long] = None,
     articleUrl: Option[String] = None

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -57,7 +57,7 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
         round = matchInfo.round.name // World Cup Group
       ),
       commentary = matchInfo.comments,
-      lineupsAvailable = None, // Boolean   // not available on LiveMatch
+      lineupsAvailable = matchInfo.lineupsAvailable,
       currentMinute = currentMinute,
       currentPeriodStartTime = None,
       articleUrl = articleId.map(id => s"$mapiHost/items/$id")

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
@@ -31,6 +31,8 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
       contentState.matchStatus mustEqual FirstHalf
       contentState.currentMinute mustEqual Some(5)
       contentState.competition.name mustEqual "FA Cup"
+      contentState.lineupsAvailable mustEqual true
+      contentState.competition.round mustEqual Some("Final")
       contentState.articleUrl mustEqual Some("http://localhost/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
     }
   }
@@ -45,13 +47,13 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
       date = ZonedDateTime.parse("2000-01-01T00:00:00Z"),
       competition = Some(Competition(id = "1", name = "FA Cup")),
       stage = Stage("1"),
-      round = Round("1", None),
+      round = Round("1", Some("Final")),
       leg = "home",
       liveMatch = true,
       result = false,
       previewAvailable = false,
       reportAvailable = false,
-      lineupsAvailable = false,
+      lineupsAvailable = true,
       matchStatus = "KO",
       attendance = None,
       homeTeam = home,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We must pass on from PA Data whether match lineups are available

TODO
- [ ] Test in CODE

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
