### PR TITLE
Fix articleUrl and matchInfoUrl on liveactivity content state

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
@@ -114,7 +114,7 @@ case class FootballMatchContentState(
     awayTeam: TeamState,
     competition: Competition,
     commentary: Option[String] = None,
-    lineupsAvailable: Option[Boolean] = None,
+    lineupsAvailable: Boolean = false,
     currentMinute: Option[Int] = None,
     currentPeriodStartTime: Option[Long] = None,
     articleUrl: Option[String] = None

--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
@@ -117,9 +117,9 @@ case class FootballMatchContentState(
     lineupsAvailable: Boolean = false,
     currentMinute: Option[Int] = None,
     currentPeriodStartTime: Option[Long] = None,
-    articleUrl: Option[String] = None
+    articleUrl: Option[String] = None,
+    matchInfoUrl: String
 ) extends ContentState
-
 
 object FootballContentJsonFormats {
   // MatchStatus format must be defined first since FootballMatchContentState depends on it

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -153,7 +153,7 @@ class LiveActivityHandler(configuration: Configuration, dynamoDBClient: AmazonDy
 
   lazy val liveActivityPusher = new LiveActivityPusher(eventBusName, logger)
 
-  lazy val matchStatusLiveActivityPayloadBuilder = new MatchStatusLiveActivityPayloadBuilder(configuration.mapiHost)
+  lazy val matchStatusLiveActivityPayloadBuilder = new MatchStatusLiveActivityPayloadBuilder()
 
   lazy val liveActivityEventConsumer = new LiveActivityEventConsumer(matchStatusLiveActivityPayloadBuilder)
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -66,9 +66,10 @@ object Lambda extends Logging {
 
   def getZonedDateTime(): ZonedDateTime = {
     val zonedDateTime = if (configuration.stage == "CODE") {
-      val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
-      val json = Json.parse(Source.fromInputStream(is).mkString)
-      ZonedDateTime.parse((json \ "currentDate").as[String])
+      ZonedDateTime.now()
+//      val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
+//      val json = Json.parse(Source.fromInputStream(is).mkString)
+//      ZonedDateTime.parse((json \ "currentDate").as[String])
     } else {
       ZonedDateTime.now()
     }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -66,10 +66,9 @@ object Lambda extends Logging {
 
   def getZonedDateTime(): ZonedDateTime = {
     val zonedDateTime = if (configuration.stage == "CODE") {
-      ZonedDateTime.now()
-//      val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
-//      val json = Json.parse(Source.fromInputStream(is).mkString)
-//      ZonedDateTime.parse((json \ "currentDate").as[String])
+      val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
+      val json = Json.parse(Source.fromInputStream(is).mkString)
+      ZonedDateTime.parse((json \ "currentDate").as[String])
     } else {
       ZonedDateTime.now()
     }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -118,7 +118,6 @@ object Lambda extends Logging {
       Thread.sleep(10000)
     }
   }
-
 }
 
 class NotificationHandler(configuration: Configuration, apiClient: NotificationsApiClient, dynamoDBClient: AmazonDynamoDBAsync, tableName: String) extends Logging {

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -4,6 +4,7 @@ import com.gu.mobile.notifications.client.models.liveActitivites.{Competition, C
 import com.gu.mobile.notifications.football.models._
 import pa.MatchDay
 
+import java.net.URI
 import java.util.{Date, UUID}
 
 class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
@@ -60,7 +61,8 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
       lineupsAvailable = matchInfo.lineupsAvailable,
       currentMinute = currentMinute,
       currentPeriodStartTime = None,
-      articleUrl = articleId.map(id => s"$mapiHost/items/$id")
+      articleUrl = articleId.map(id => new URI(s"http://www.theguardian.com/$id").toString),
+      matchInfoUrl = new URI(s"http://www.theguardian.com/football/match/${matchInfo.id}").toString
     )
 
     // certain type of triggering match event types will trigger different live activity event type.

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -57,7 +57,7 @@ class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
         round = matchInfo.round.name // World Cup Group
       ),
       commentary = matchInfo.comments,
-      lineupsAvailable = None, // Boolean   // not available on LiveMatch
+      lineupsAvailable = matchInfo.lineupsAvailable,
       currentMinute = currentMinute,
       currentPeriodStartTime = None,
       articleUrl = articleId.map(id => s"$mapiHost/items/$id")

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -7,7 +7,7 @@ import pa.MatchDay
 import java.net.URI
 import java.util.{Date, UUID}
 
-class MatchStatusLiveActivityPayloadBuilder(mapiHost: String) {
+class MatchStatusLiveActivityPayloadBuilder {
 
   def build(
       triggeringEvent: FootballMatchEvent,

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -606,9 +606,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
     val eventConsumer = new EventConsumer(matchStatusNotificationBuilder)
 
     val matchStatusLiveActivityPayloadBuilder =
-      new MatchStatusLiveActivityPayloadBuilder(
-        "https://mobile.guardianapis.com"
-      )
+      new MatchStatusLiveActivityPayloadBuilder()
     val eventConsumerLiveActivities = new LiveActivityEventConsumer(
       matchStatusLiveActivityPayloadBuilder
     )

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
@@ -33,12 +33,13 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
       contentState.competition.name mustEqual "FA Cup"
       contentState.lineupsAvailable mustEqual true
       contentState.competition.round mustEqual Some("Final")
-      contentState.articleUrl mustEqual Some("http://localhost/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
+      contentState.articleUrl mustEqual Some("http://www.theguardian.com/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
+      contentState.matchInfoUrl mustEqual "http://www.theguardian.com/football/match/some-match-id"
     }
   }
 
   trait MatchEventsContext extends Scope {
-    val builder = new MatchStatusLiveActivityPayloadBuilder("http://localhost")
+    val builder = new MatchStatusLiveActivityPayloadBuilder("http://localhost.com")
     val home = MatchDayTeam("1", "Liverpool", None, None, None, None)
     val away = MatchDayTeam("2", "Plymouth", None, None, None, None)
     val baseGoal = Goal(DefaultGoalType, "Steve", home, away, 5, None, "")

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
@@ -39,7 +39,7 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
   }
 
   trait MatchEventsContext extends Scope {
-    val builder = new MatchStatusLiveActivityPayloadBuilder("http://localhost.com")
+    val builder = new MatchStatusLiveActivityPayloadBuilder()
     val home = MatchDayTeam("1", "Liverpool", None, None, None, None)
     val away = MatchDayTeam("2", "Plymouth", None, None, None, None)
     val baseGoal = Goal(DefaultGoalType, "Steve", home, away, 5, None, "")

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
@@ -31,6 +31,8 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
       contentState.matchStatus mustEqual FirstHalf
       contentState.currentMinute mustEqual Some(5)
       contentState.competition.name mustEqual "FA Cup"
+      contentState.lineupsAvailable mustEqual true
+      contentState.competition.round mustEqual Some("Final")
       contentState.articleUrl mustEqual Some("http://localhost/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
     }
   }
@@ -45,13 +47,13 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
       date = ZonedDateTime.parse("2000-01-01T00:00:00Z"),
       competition = Some(Competition(id = "1", name = "FA Cup")),
       stage = Stage("1"),
-      round = Round("1", None),
+      round = Round("1", Some("Final")),
       leg = "home",
       liveMatch = true,
       result = false,
       previewAvailable = false,
       reportAvailable = false,
-      lineupsAvailable = false,
+      lineupsAvailable = true,
       matchStatus = "KO",
       attendance = None,
       homeTeam = home,

--- a/liveactivities/src/main/resources/broadcast-update-payload.json
+++ b/liveactivities/src/main/resources/broadcast-update-payload.json
@@ -21,17 +21,17 @@
         "score": 1,
         "redCards": 1,
         "penaltyScore": {
-          "scored": 4,
+          "scored": 1,
           "missed": 1,
           "saved": 1
         }
       },
       "awayTeam": {
         "name": "Team B",
-        "score": 1,
-        "redCards": 1,
+        "score": 0,
+        "redCards": 0,
         "penaltyScore": {
-          "scored": 4,
+          "scored": 0,
           "missed": 1,
           "saved": 1
         }

--- a/liveactivities/src/main/resources/broadcast-update-payload.json
+++ b/liveactivities/src/main/resources/broadcast-update-payload.json
@@ -43,7 +43,9 @@
       },
       "commentary" : "Predicted to be an exciting match",
       "lineupsAvailable" : true,
-      "currentMinute" : 0
+      "currentMinute" : 0,
+      "articleUrl" : "http://www.theguardian.com/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live",
+      "matchInfoUrl" : "https://www.theguardian.com/football/match/4545750"
     },
     "eventTimestamp": 1777278992019
   }

--- a/liveactivities/src/test/scala/com/gu/liveactivities/models/BroadcastPayloadsSpec.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/models/BroadcastPayloadsSpec.scala
@@ -21,7 +21,9 @@ class BroadcastPayloadsSpec extends Specification {
       awayTeam = awayTeam,
       competition = competition,
       commentary = Some("Arsenal dominating."),
-      currentMinute = Some(30)
+      currentMinute = Some(30),
+      articleUrl = None,
+      matchInfoUrl = "http://www.theguardian.com/football/match/some-match-id"
     )
 
     val eventTime = now - 60L // 1min ago


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the required web urls hardcoded theguardian.com for deeplinking on the device. 

PR needs to be rebased onto main before merging.

TODO

- [x] test in CODE/dev 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
