### PR TITLE
fix liveactivities life cycle after end event

### DIFF
--- a/liveactivities/src/main/resources/broadcast-update-payload.json
+++ b/liveactivities/src/main/resources/broadcast-update-payload.json
@@ -1,6 +1,6 @@
 {
   "version": "0",
-  "id": "65587515-3040-b54e-t00d-4b7970bdd1eb",
+  "id": "65587515-3040-b54e-t00d-4b7970bdd1hj",
   "detail-type": "broadcast-update",
   "source": "football-lambda",
   "account": "00000000000000",
@@ -8,7 +8,7 @@
   "region": "eu-west-1",
   "resources": [],
   "detail": {
-    "id": "165875bb-ade9-3245-b602-6343a1dd407d",
+    "id": "165875bb-ade9-3245-b602-6343a1dd406f",
     "eventType": "broadcast-update",
     "liveActivityType": "FootballLiveActivity",
     "liveActivityID": "123456-test",
@@ -44,10 +44,10 @@
       "commentary" : "Predicted to be an exciting match",
       "lineupsAvailable" : true,
       "currentMinute" : 0,
-      "articleUrl" : "http://www.theguardian.com/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live",
-      "matchInfoUrl" : "https://www.theguardian.com/football/match/4545750"
+      "articleUrl": "http://www.theguardian.com/123456-test-article",
+      "matchInfoUrl": "http://www.theguardian.com/football/match/123456-test"
     },
-    "eventTimestamp": 1777278992020
+    "eventTimestamp": 1777998999999
   }
 }
 

--- a/liveactivities/src/main/resources/channel-create-payload.json
+++ b/liveactivities/src/main/resources/channel-create-payload.json
@@ -33,7 +33,9 @@
       },
       "commentary" : "Predicted to be an exciting match",
       "lineupsAvailable" : true,
-      "currentMinute" : 0
+      "currentMinute" : 0,
+      "articleUrl": "http://www.theguardian.com/123456-test-article",
+      "matchInfoUrl": "http://www.theguardian.com/football/match/123456-test"
     },
     "eventTimestamp": 1777278992019
   }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -79,33 +79,45 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
 
     }
 
-    val broadcastFuture = for {
-      mapping <- repository.getMappingById(matchId)
-      _ <- if (!mapping.isChannelActive) {
-          logger.error(s"Channel not active for match ID $matchId")
-          Future.failed(new LiveActivityInvalidStateException(matchId, "Channel not active"))
-        } else Future.successful(())
+    val broadcastFuture = repository.getMappingById(matchId).flatMap { mapping =>
+      // If the mapping is not live, but it HAS a lastEventId, it means it was Live once and has now Ended.
+      // We want to skip any further updates in this terminal state.
+      // But we don't want to fail the lambda because it's expected that the source may continue
+      // to send update events after a session has ended. Therefore, we treat these as expected no-ops.
+      val broadcastNotAllowed = !shouldEndBroadcast && !mapping.isLive && mapping.lastEventId.isDefined
 
-      _ <- if (mapping.lastEventId.contains(eventId)) {
-          logger.warn(s"Duplicate event ID $eventId for match ID $matchId")
-          Future.failed(new LiveActivityInvalidStateException(matchId, "Duplicate event ID"))
-        } else Future.successful(())
+      if (broadcastNotAllowed) {
+        logger.warn(s"${requestPayload.eventType.asString} event ID $eventId not allowed after ${EndLiveActivityEvent.asString} for match ID $matchId")
+        Future.successful(mapping.channelId)
+      } else {
+        for {
+          _ <- if (!mapping.isChannelActive) {
+            logger.error(s"Channel not active for match ID $matchId")
+            Future.failed(new LiveActivityInvalidStateException(matchId, "Channel not active"))
+          } else Future.successful(())
 
-      _ <- if (mapping.lastEventAt.exists(lastEventAt => eventTime.isBefore(lastEventAt))) {
-          logger.warn(s"Out of order event time ${dateTimeToString(eventTime)} for match ID $matchId")
-          Future.failed(new LiveActivityInvalidStateException(matchId, "Out of order event time"))
-        } else Future.successful(())
+          _ <- if (mapping.lastEventId.contains(eventId)) {
+            logger.warn(s"Duplicate event ID $eventId for match ID $matchId")
+            Future.failed(new LiveActivityInvalidStateException(matchId, "Duplicate event ID"))
+          } else Future.successful(())
 
-      // TODO - determine expiry time and priority
+          _ <- if (mapping.lastEventAt.exists(lastEventAt => eventTime.isBefore(lastEventAt))) {
+            logger.warn(s"Out of order event time ${dateTimeToString(eventTime)} for match ID $matchId")
+            Future.failed(new LiveActivityInvalidStateException(matchId, "Out of order event time"))
+          } else Future.successful(())
 
-      _ = logger.info(s"Sending broadcast for match ID $matchId to channel ID ${mapping.channelId}")
-      broadcastPayload = BroadcastBody(contentState, shouldEndBroadcast)
-      _ <- broadcastApiClient.sendToChannel(mapping.channelId, None, None, broadcastPayload)
-      _ = logger.info(s"Broadcast ${requestPayload.eventType.asString} sent successfully for match ID $matchId to channel ID ${mapping.channelId}")
+          // TODO - determine expiry time and priority
 
-      _ <- repository.updateMappingLiveAndLastEvent(matchId, isLive = !shouldEndBroadcast, Some(eventId), Some(eventTime))
-      _ = logger.info(s"Record updated successfully for match ID $matchId")
-    } yield mapping.channelId
+          _ = logger.info(s"Sending broadcast for match ID $matchId to channel ID ${mapping.channelId}")
+          broadcastPayload = BroadcastBody(contentState, shouldEndBroadcast)
+          _ <- broadcastApiClient.sendToChannel(mapping.channelId, None, None, broadcastPayload)
+          _ = logger.info(s"Broadcast ${requestPayload.eventType.asString} sent successfully for match ID $matchId to channel ID ${mapping.channelId}")
+
+          _ <- repository.updateMappingLiveAndLastEvent(matchId, isLive = !shouldEndBroadcast, Some(eventId), Some(eventTime))
+          _ = logger.info(s"Record updated successfully for match ID $matchId")
+        } yield mapping.channelId
+      }
+    }
 
     //Timeout set to 160 seconds to provide a safety buffer.
     // While the sum of downstream timeouts is at most ~110s,
@@ -113,10 +125,9 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
     // authentication token fetches, and potential network congestion
     // to ensure the Lambda doesn't fail a healthy request that is just running slow.
     Try(Await.result(broadcastFuture, 160.seconds)) match {
-
       case Success(_) => {
         // todo
-        logger.info(s"Broadcast ${if(shouldEndBroadcast)"END"} successfully sent for liveActivityID $matchId")
+        logger.info(s"Broadcast ${requestPayload.eventType.asString} successfully processed for liveActivityID $matchId")
       }
       case Failure(exception) => {
         logger.error(s"Failed to send broadcast ${if(shouldEndBroadcast)"END"} for liveActivityID $matchId: ${exception.getMessage}")

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -1,33 +1,22 @@
 package com.gu.liveactivities
 
+import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
 import com.gu.liveactivities.service.BroadcastApiClient
-
-import scala.concurrent.Await
-import scala.util.Try
-import scala.util.Success
-import scala.util.Failure
-import com.amazonaws.services.lambda.runtime.Context
-import com.amazonaws.services.lambda.runtime.RequestStreamHandler
+import com.gu.liveactivities.util.Logging
+import com.gu.mobile.notifications.client.models.liveActitivites._
+import play.api.libs.json._
 
 import java.io.{InputStream, OutputStream}
-import play.api.libs.json._
-import com.gu.liveactivities.util.Logging
-
-import scala.concurrent.Future
-import com.gu.liveactivities.models.LiveActivityInvalidStateException
-import com.gu.liveactivities.models.BroadcastBody
-
-import java.time.ZonedDateTime
-import com.gu.liveactivities.util.DateTimeHelper.{dateTimeFromLong, dateTimeToLong, dateTimeToString}
-import com.gu.mobile.notifications.client.models.liveActitivites.{EndLiveActivityEvent, EventBridgeEvent, FootballMatchContentState, LiveActivityPayload, StartLiveActivityEvent, UpdateLiveActivityEvent}
-
+import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
+import scala.util.{Failure, Success, Try}
 
 
 
 object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
 
-
+  val broadcastApiClient = new BroadcastApiClient(authentication, config.bundleId, config.sendingToProdServer)
+  val broadcastService = new BroadcastService(repository, broadcastApiClient)
 
   def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
     Json.parse(input).validate[EventBridgeEvent] match {

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration.DurationInt
 
 object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
 
-  val broadcastApiClient = new BroadcastApiClient(authentication, config.bundleId, config.sendingToProdServer)
+
 
   def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
     Json.parse(input).validate[EventBridgeEvent] match {
@@ -58,8 +58,7 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
 
     // todo this needs to be tidied to support live activities other than football
     val matchId: String = requestPayload.liveActivityID
-    val eventId: String = requestPayload.id.toString
-    val eventTime: ZonedDateTime = dateTimeFromLong(requestPayload.eventTimestamp) // time triggering event was received and processed in football lambda
+
     val contentState: FootballMatchContentState = requestPayload.broadcastContentStateData match {
       case Some(cs: FootballMatchContentState) => cs
       case Some(other) =>
@@ -68,7 +67,6 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
         throw new Exception(s"Missing content state for match ID $matchId")
     }
 
-
     val shouldEndBroadcast: Boolean = requestPayload.eventType match {
       case EndLiveActivityEvent => true
       case StartLiveActivityEvent => false
@@ -76,48 +74,9 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
       case _ =>
         logger.error(s"Unexpected event type ${requestPayload.eventType} for broadcast payload")
         throw new Exception(s"Unexpected event type ${requestPayload.eventType} for broadcast payload")
-
     }
 
-    val broadcastFuture = repository.getMappingById(matchId).flatMap { mapping =>
-      // If the mapping is not live, but it HAS a lastEventId, it means it was Live once and has now Ended.
-      // We want to skip any further updates in this terminal state.
-      // But we don't want to fail the lambda because it's expected that the source may continue
-      // to send update events after a session has ended. Therefore, we treat these as expected no-ops.
-      val broadcastNotAllowed = !shouldEndBroadcast && !mapping.isLive && mapping.lastEventId.isDefined
-
-      if (broadcastNotAllowed) {
-        logger.warn(s"${requestPayload.eventType.asString} event ID $eventId not allowed after ${EndLiveActivityEvent.asString} for match ID $matchId")
-        Future.successful(mapping.channelId)
-      } else {
-        for {
-          _ <- if (!mapping.isChannelActive) {
-            logger.error(s"Channel not active for match ID $matchId")
-            Future.failed(new LiveActivityInvalidStateException(matchId, "Channel not active"))
-          } else Future.successful(())
-
-          _ <- if (mapping.lastEventId.contains(eventId)) {
-            logger.warn(s"Duplicate event ID $eventId for match ID $matchId")
-            Future.failed(new LiveActivityInvalidStateException(matchId, "Duplicate event ID"))
-          } else Future.successful(())
-
-          _ <- if (mapping.lastEventAt.exists(lastEventAt => eventTime.isBefore(lastEventAt))) {
-            logger.warn(s"Out of order event time ${dateTimeToString(eventTime)} for match ID $matchId")
-            Future.failed(new LiveActivityInvalidStateException(matchId, "Out of order event time"))
-          } else Future.successful(())
-
-          // TODO - determine expiry time and priority
-
-          _ = logger.info(s"Sending broadcast for match ID $matchId to channel ID ${mapping.channelId}")
-          broadcastPayload = BroadcastBody(contentState, shouldEndBroadcast)
-          _ <- broadcastApiClient.sendToChannel(mapping.channelId, None, None, broadcastPayload)
-          _ = logger.info(s"Broadcast ${requestPayload.eventType.asString} sent successfully for match ID $matchId to channel ID ${mapping.channelId}")
-
-          _ <- repository.updateMappingLiveAndLastEvent(matchId, isLive = !shouldEndBroadcast, Some(eventId), Some(eventTime))
-          _ = logger.info(s"Record updated successfully for match ID $matchId")
-        } yield mapping.channelId
-      }
-    }
+    val broadcastFuture = broadcastService.processBroadcast(requestPayload, shouldEndBroadcast, contentState)
 
     //Timeout set to 160 seconds to provide a safety buffer.
     // While the sum of downstream timeouts is at most ~110s,

--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastService.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastService.scala
@@ -1,0 +1,60 @@
+package com.gu.liveactivities
+
+import com.gu.liveactivities.models.{BroadcastBody, LiveActivityInvalidStateException}
+import com.gu.liveactivities.service.{BroadcastApiClient, ChannelMappingsRepository}
+import com.gu.liveactivities.util.DateTimeHelper.{dateTimeFromLong, dateTimeToString}
+import com.gu.liveactivities.util.Logging
+import com.gu.mobile.notifications.client.models.liveActitivites.{ContentState, EndLiveActivityEvent, FootballMatchContentState, LiveActivityPayload}
+
+import java.time.ZonedDateTime
+import scala.concurrent.{ExecutionContext, Future}
+
+class BroadcastService(repository: ChannelMappingsRepository, broadcastApiClient: BroadcastApiClient)(implicit ec: ExecutionContext) extends Logging {
+
+  def processBroadcast(requestPayload: LiveActivityPayload, shouldEndBroadcast: Boolean, contentState: ContentState): Future[String] = {
+    val matchId = requestPayload.liveActivityID
+    val eventId: String = requestPayload.id.toString
+    val eventTime: ZonedDateTime = dateTimeFromLong(requestPayload.eventTimestamp) // time triggering event was received and processed in football lambda
+    val broadcastFuture = repository.getMappingById(matchId).flatMap { mapping =>
+      // If the mapping is not live, but it HAS a lastEventId, it means it was Live once and has now Ended.
+      // We want to skip any further updates in this terminal state.
+      // But we don't want to fail the lambda because it's expected that the source may continue
+      // to send update events after a session has ended. Therefore, we treat these as expected no-ops.
+      val broadcastNotAllowed = !shouldEndBroadcast && !mapping.isLive && mapping.lastEventId.isDefined
+
+      if (broadcastNotAllowed) {
+        logger.warn(s"${requestPayload.eventType.asString} event ID $eventId not allowed after ${EndLiveActivityEvent.asString} for match ID $matchId")
+        Future.successful(mapping.channelId)
+      } else {
+        for {
+          _ <- if (!mapping.isChannelActive) {
+            logger.error(s"Channel not active for match ID $matchId")
+            Future.failed(new LiveActivityInvalidStateException(matchId, "Channel not active"))
+          } else Future.successful(())
+
+          _ <- if (mapping.lastEventId.contains(eventId)) {
+            logger.warn(s"Duplicate event ID $eventId for match ID $matchId")
+            Future.failed(new LiveActivityInvalidStateException(matchId, "Duplicate event ID"))
+          } else Future.successful(())
+
+          _ <- if (mapping.lastEventAt.exists(lastEventAt => eventTime.isBefore(lastEventAt))) {
+            logger.warn(s"Out of order event time ${dateTimeToString(eventTime)} for match ID $matchId")
+            Future.failed(new LiveActivityInvalidStateException(matchId, "Out of order event time"))
+          } else Future.successful(())
+
+          // TODO - determine expiry time and priority
+
+          _ = logger.info(s"Sending broadcast for match ID $matchId to channel ID ${mapping.channelId}")
+          broadcastPayload = BroadcastBody(contentState, shouldEndBroadcast)
+          _ <- broadcastApiClient.sendToChannel(mapping.channelId, None, None, broadcastPayload)
+          _ = logger.info(s"Broadcast ${requestPayload.eventType.asString} sent successfully for match ID $matchId to channel ID ${mapping.channelId}")
+
+          _ <- repository.updateMappingLiveAndLastEvent(matchId, isLive = !shouldEndBroadcast, Some(eventId), Some(eventTime))
+          _ = logger.info(s"Record updated successfully for match ID $matchId")
+        } yield mapping.channelId
+      }
+    }
+
+    broadcastFuture
+  }
+}

--- a/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
@@ -41,8 +41,6 @@ trait Lambda extends Logging{
       .build()
 
   val repository = new LiveActivityChannelRepository(dynamoDbClient, s"mobile-notifications-liveactivities-${config.stage}")
-  val broadcastApiClient = new BroadcastApiClient(authentication, config.bundleId, config.sendingToProdServer)
-  val broadcastService = new BroadcastService(repository, broadcastApiClient)
 
   private val eventBusName = s"liveactivities-eventbus-${config.stage}"
   lazy val liveActivityPusher = new LiveActivityPusher(eventBusName, logger)

--- a/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
@@ -1,6 +1,6 @@
 package com.gu.liveactivities
 
-import com.gu.liveactivities.service.{Authentication, LiveActivityChannelRepository}
+import com.gu.liveactivities.service.{Authentication, BroadcastApiClient, LiveActivityChannelRepository}
 import com.gu.liveactivities.util.{Configuration, IosConfiguration, Logging}
 import com.gu.mobile.liveactivities.event.bus.LiveActivityPusher
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, DefaultCredentialsProvider, ProfileCredentialsProvider}
@@ -41,6 +41,8 @@ trait Lambda extends Logging{
       .build()
 
   val repository = new LiveActivityChannelRepository(dynamoDbClient, s"mobile-notifications-liveactivities-${config.stage}")
+  val broadcastApiClient = new BroadcastApiClient(authentication, config.bundleId, config.sendingToProdServer)
+  val broadcastService = new BroadcastService(repository, broadcastApiClient)
 
   private val eventBusName = s"liveactivities-eventbus-${config.stage}"
   lazy val liveActivityPusher = new LiveActivityPusher(eventBusName, logger)

--- a/liveactivities/src/test/scala/com/gu/liveactivities/BroadcastServiceSpec.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/BroadcastServiceSpec.scala
@@ -1,0 +1,155 @@
+package com.gu.liveactivities
+
+import com.gu.liveactivities.models.{LiveActivityData, LiveActivityMapping}
+import com.gu.liveactivities.service.{BroadcastApiClient, ChannelMappingsRepository}
+import com.gu.liveactivities.util.DateTimeHelper
+import com.gu.mobile.notifications.client.models.liveActitivites._
+import org.slf4j
+import org.slf4j.Logger
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import java.time.ZonedDateTime
+import java.util.UUID
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
+
+class BroadcastServiceSpec(implicit ee: ExecutionEnv) extends Specification with Mockito {
+
+  trait Context extends Scope{
+    val channelManagerRepositoryMock: ChannelMappingsRepository = mock[ChannelMappingsRepository]
+    val broadcastApiClientMock: BroadcastApiClient = mock[BroadcastApiClient]
+    val mockLogger: Logger = mock[org.slf4j.Logger]
+
+    val broadcastService: BroadcastService = new BroadcastService(channelManagerRepositoryMock, broadcastApiClientMock)(ee.ec) {
+      override val logger: slf4j.Logger = mockLogger
+    }
+  }
+  val now = ZonedDateTime.now()
+  val matchId = "matchId1"
+  val defaultContentState = FootballMatchContentState(
+    matchStatus = FirstHalf,
+    kickOffTimestamp = now.toEpochSecond - 1800, // 30min ago
+    homeTeam = TeamState(name = "Arsenal", score = 1),
+    awayTeam = TeamState(name = "Chelsea", score = 0),
+    competition = Competition(id = "100", name = "Premier League", round = Some("League")),
+    commentary = Some("Arsenal dominating."),
+    currentMinute = Some(30),
+    articleUrl = None,
+    matchInfoUrl = "http://www.theguardian.com/football/match/some-match-id"
+  )
+  val defaultPayload = new LiveActivityPayload(
+    id = UUID.nameUUIDFromBytes("test-match-event".getBytes),
+    eventType = UpdateLiveActivityEvent,
+    liveActivityType = FootballLiveActivity,
+    liveActivityID = matchId,
+    dynamoStoreData = None,
+    broadcastContentStateData =  Some(defaultContentState),
+    eventTimestamp = now.toEpochSecond - 60L,  // 1min ago
+  )
+
+  val liveActivityMappingAtCreateChannelState = LiveActivityMapping(
+    id = matchId,
+    channelId = "channelId1",
+    isChannelActive = true,
+    isLive = false,
+    lastEventId = None,
+    lastEventAt = None,
+    createdAt = now.minusHours(1),
+    lastModifiedAt = now.minusHours(1),
+    ttlInEpochSeconds = Some(now.toEpochSecond + 14 * 24 * 3600),
+    data = Some(LiveActivityData.toLiveActivityData(defaultContentState))
+  )
+
+  "BroadcastService.processBroadcast" should {
+    "return a failed future when there is no mapping in dynamo for given liveActivityID" in new Context {
+      // Setup
+      channelManagerRepositoryMock.getMappingById("matchId1") returns Future.failed(new RuntimeException("No mapping found"))
+
+      // Execute
+      val broadcastFuture: Future[String] = broadcastService.processBroadcast(defaultPayload, shouldEndBroadcast = false, defaultContentState)
+
+      // Verify
+      broadcastFuture.failed.map(_.getMessage) must beEqualTo("No mapping found").await
+    }
+
+    "not process broadcast but return a successful future given the live activity has ended" in new Context{
+      // Setup
+      val endedLiveActivityMapping: LiveActivityMapping = liveActivityMappingAtCreateChannelState.copy(
+        isLive = false,
+        lastEventId = Some("someEventId"),
+        lastEventAt = Some(now.minusMinutes(5))
+      )
+      channelManagerRepositoryMock.getMappingById("matchId1") returns Future.successful(endedLiveActivityMapping)
+
+      // Execute
+      val broadcastResult: String = Await.result(broadcastService.processBroadcast(defaultPayload, shouldEndBroadcast = false, defaultContentState), 5.seconds)
+
+      // Verify
+      eventually {
+        there was one(mockLogger).warn(s"broadcast-update event ID ${defaultPayload.id.toString} not allowed after broadcast-end for match ID $matchId")
+      }
+      broadcastResult must beEqualTo("channelId1")
+    }
+
+    "return a failed future given the channel is not active anymore" in new Context {
+      // Setup
+      val inActiveLiveActivityMapping: LiveActivityMapping = liveActivityMappingAtCreateChannelState.copy(
+        isChannelActive = false,
+      )
+      channelManagerRepositoryMock.getMappingById(matchId) returns Future.successful(inActiveLiveActivityMapping)
+
+      // Execute
+      val broadcastFuture: Future[String] = broadcastService.processBroadcast(defaultPayload, shouldEndBroadcast = false, defaultContentState)
+
+      // Verify
+      eventually {
+        there was one(mockLogger).error(s"Channel not active for match ID $matchId")
+      }
+      broadcastFuture.failed.map(_.getMessage) must beEqualTo(s"Live activity invalid state for id $matchId: Channel not active").await
+    }
+
+    "return a failed future given the event id is the same as the last event id" in new Context {
+      // Setup
+      val duplicateLiveActivityMapping: LiveActivityMapping = liveActivityMappingAtCreateChannelState.copy(
+        isLive = true,
+        lastEventId = Some(defaultPayload.id.toString)
+      )
+      channelManagerRepositoryMock.getMappingById(matchId) returns Future.successful(duplicateLiveActivityMapping)
+
+      // Execute
+      val broadcastFuture: Future[String] = broadcastService.processBroadcast(defaultPayload, shouldEndBroadcast = false, defaultContentState)
+
+      // Verify
+      eventually {
+        there was one(mockLogger).warn(s"Duplicate event ID ${defaultPayload.id.toString} for match ID $matchId")
+      }
+      broadcastFuture.failed.map(_.getMessage) must beEqualTo(s"Live activity invalid state for id $matchId: Duplicate event ID").await
+    }
+
+    "return a failed future given the current event time is before the last event time" in new Context {
+      // Setup
+      val existingLiveActivityMapping: LiveActivityMapping = liveActivityMappingAtCreateChannelState.copy(
+        isLive = true,
+        lastEventId = Some("someEventId2"),
+        lastEventAt = Some(now.minusMinutes(1))
+      )
+      val outOfOrderPayload: LiveActivityPayload = defaultPayload.copy(
+        eventTimestamp = now.toEpochSecond - 10L // 10 seconds ago, which is before the lastEventAt of the mapping
+      )
+      channelManagerRepositoryMock.getMappingById(matchId) returns Future.successful(existingLiveActivityMapping)
+
+      // Execute
+      val broadcastFuture: Future[String] = broadcastService.processBroadcast(outOfOrderPayload, shouldEndBroadcast = false, defaultContentState)
+      val eventZonedDateTimeStr: String = DateTimeHelper.dateTimeToString(DateTimeHelper.dateTimeFromLong(outOfOrderPayload.eventTimestamp))
+
+      // Verify
+      eventually {
+        there was one(mockLogger).warn(s"Out of order event time $eventZonedDateTimeStr for match ID $matchId")
+      }
+      broadcastFuture.failed.map(_.getMessage) must beEqualTo(s"Live activity invalid state for id $matchId: Out of order event time").await
+    }
+  }
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Updated the broadcast logic to gracefully handle update events for matches that have already ended. Instead of failing with a LiveActivityInvalidStateException, the system now treats these as expected "no-ops" to avoid unnecessary Lambda retries and lambda dead letter log noise.

**Changes:**
- Added a check to identify terminal states (!isLive and lastEventId.isDefined).
- If an update is received for an ended match, the Lambda now returns a successful mapping.channelId without calling the Broadcast API or updating the database.
- Moving the broadcast logic into a `BroadcastService` class 
- Write unit tests for BroadcastService covering most of the scenarios up until the `sendToChannel` 

**Why:**
The upstream source may continue to send update events after a Live Activity has technically ended. This change acknowledges this as valid post-match traffic rather than an error scenario.

The main states for live activity:
- **Initial State:** isLive: false, lastEventId: None (Allows first update)

- **Live State:** isLive: true (Allows updates)

- **Ended State:** isLive: false, lastEventId: Some (Blocks further updates)