### PR TITLE
filter matches based on the competitions data in S3

### DIFF
--- a/cdk/lib/__snapshots__/footballnotificationslambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/footballnotificationslambda.test.ts.snap
@@ -759,6 +759,11 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for CODE 1`]
                 ],
               },
             },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::mobile-pa-football-data/*",
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -1592,6 +1597,11 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for PROD 1`]
                   ],
                 ],
               },
+            },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::mobile-pa-football-data/*",
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/footballnotificationslambda.ts
+++ b/cdk/lib/footballnotificationslambda.ts
@@ -125,6 +125,14 @@ export class FootballNotificationsLambda extends GuStack {
 			}),
 		);
 
+		footballnotificationslambda.addToRolePolicy(
+			new PolicyStatement({
+				actions: ['s3:GetObject'],
+				effect: Effect.ALLOW,
+				resources: [`arn:aws:s3:::mobile-pa-football-data/*`],
+			}),
+		);
+
 		// Read Throttle Events Alarm
 		new GuAlarm(this, 'MobileNotificationsFootballConsumedReadThrottleEvents', {
 			app,

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Configuration.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Configuration.scala
@@ -6,7 +6,6 @@ import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
 import com.typesafe.config.Config
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain => AwsCredentialsProviderChainV2, DefaultCredentialsProvider => DefaultCredentialsProviderV2, ProfileCredentialsProvider => ProfileCredentialsProviderV2}
 import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
-import software.amazon.awssdk.regions.Region.EU_WEST_1
 
 class Configuration extends Logging {
 
@@ -47,4 +46,5 @@ class Configuration extends Logging {
   val notificationsApiKey = conf.getString("notifications-client.api-key")
   val mapiHost = conf.getString("mapi.host")
   val capiApiKey = conf.getString("capi.key")
+  val paDataBucket = conf.getString("buckets.football-feed-data")
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Configuration.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Configuration.scala
@@ -46,5 +46,4 @@ class Configuration extends Logging {
   val notificationsApiKey = conf.getString("notifications-client.api-key")
   val mapiHost = conf.getString("mapi.host")
   val capiApiKey = conf.getString("capi.key")
-  val paDataBucket = conf.getString("buckets.football-feed-data")
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -5,9 +5,10 @@ import java.time.ZonedDateTime
 import java.util.concurrent.TimeUnit
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.gu.contentapi.client.GuardianContentClient
 import com.gu.mobile.liveactivities.event.bus.LiveActivityPusher
-import com.gu.mobile.notifications.football.lib.{ArticleSearcher, DynamoDistinctCheck, DynamoMatchLiveActivity, DynamoMatchNotification, EventConsumer, EventFilter, FootballData, LiveActivityEventConsumer, NotificationHttpProvider, NotificationSender, NotificationsApiClient, PaFootballClient, SyntheticMatchEventGenerator}
+import com.gu.mobile.notifications.football.lib.{ArticleSearcher, DynamoDistinctCheck, DynamoMatchLiveActivity, DynamoMatchNotification, EventConsumer, EventFilter, FootballData, LiveActivityEventConsumer, NotificationHttpProvider, NotificationSender, NotificationsApiClient, PACompetition, PaFootballClient, S3DataStore, SyntheticMatchEventGenerator}
 import com.gu.mobile.notifications.football.notificationbuilders.{MatchStatusLiveActivityPayloadBuilder, MatchStatusNotificationBuilder}
 import play.api.libs.json.Json
 
@@ -22,6 +23,7 @@ import com.gu.mobile.notifications.football.models.MatchDataWithArticle
 
 import scala.concurrent.Future
 import org.scanamo.generic.auto._
+import pa.Competition
 
 object Lambda extends Logging {
 
@@ -56,7 +58,14 @@ object Lambda extends Logging {
 
   val apiClient = new NotificationsApiClient(configuration)
 
-  lazy val footballData = new FootballData(paFootballClient, syntheticMatchEventGenerator)
+  lazy val s3Client: AmazonS3 = AmazonS3ClientBuilder.standard
+    .withRegion(Regions.EU_WEST_1)
+    .withCredentials(configuration.credentials)
+    .build()
+
+  lazy val competitionsDataStore = new S3DataStore[PACompetition](s3Client, configuration.paDataBucket)
+
+  lazy val footballData = new FootballData(paFootballClient, syntheticMatchEventGenerator, competitionsDataStore, configuration.stage)
 
   lazy val articleSearcher = new ArticleSearcher(capiClient)
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -31,6 +31,7 @@ object Lambda extends Logging {
 
   def tableName = s"mobile-notifications-football-notifications-${configuration.stage}"
   def liveActivitiesTableName = s"mobile-notifications-liveactivities-payload-${configuration.stage}"
+  lazy val paDataBucket = "mobile-pa-football-data"
 
   lazy val configuration: Configuration = {
     logger.debug("Creating configuration")
@@ -63,7 +64,7 @@ object Lambda extends Logging {
     .withCredentials(configuration.credentials)
     .build()
 
-  lazy val competitionsDataStore = new S3DataStore[PACompetition](s3Client, configuration.paDataBucket)
+  lazy val competitionsDataStore = new S3DataStore[PACompetition](s3Client, paDataBucket)
 
   lazy val footballData = new FootballData(paFootballClient, syntheticMatchEventGenerator, competitionsDataStore, configuration.stage)
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -1,11 +1,11 @@
 package com.gu.mobile.notifications.football.lib
 
-import java.time.ZonedDateTime
-
-import com.gu.mobile.notifications.football.Logging
+import java.time.{LocalDate, ZonedDateTime}
+import com.gu.mobile.notifications.football.{Configuration, Logging}
 import com.gu.mobile.notifications.football.models.RawMatchData
 import org.joda.time.DateTime
 import pa.MatchDay
+import play.api.libs.json.{Format, Json}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -14,9 +14,24 @@ import scala.util.{Failure, Success, Try}
 
 case class EndedMatch(matchId: String, startTime: DateTime)
 
+case class PACompetition(
+                        id: String,
+                        tag: String,
+                        fullName: String,
+                        shortName: String,
+                        startDate: Option[LocalDate] = None,
+                        endDate: Option[LocalDate] = None,
+                      )
+
+object PACompetition {
+  implicit val competitionFormat: Format[PACompetition] = Json.format[PACompetition]
+}
+
 class FootballData(
-  paClient: PaFootballClient,
-  syntheticEvents: SyntheticMatchEventGenerator
+                    paClient: PaFootballClient,
+                    syntheticEvents: SyntheticMatchEventGenerator,
+                    competitionsDataStore: S3DataStore[PACompetition],
+                    stage: String
 ) extends Logging {
 
   implicit class RichMatchDay(matchDay: MatchDay) {
@@ -92,13 +107,29 @@ class FootballData(
       }.getOrElse(false) //Shouldn't ever happen
     }
 
+    def competitionIsSupported(supportedCompetitions: List[PACompetition])(matchDay: MatchDay): Boolean =
+      matchDay.competition.exists { matchComp =>
+        supportedCompetitions.exists(_.id == matchComp.id)
+      }
+
     logger.info(s"Retrieving matches on or around $dateTime from PA")
-    val matches = paClient.aroundToday(dateTime)
-    matches.map(
-      _.filter(inProgress)
-       .filter(paProvideAlerts)
-       .filterNot(isMidnight)
-    )
+    for {
+       matches <- paClient.aroundToday(dateTime)
+       competitions <- competitionsDataStore
+         .fetch(s"${stage}/competition/competitions.json")
+         .recover { case exception =>
+           // We don't want to fail the whole process if we can't retrieve the list of competitions,
+           // we'll just assume all competitions are supported and log the error
+           logger.error(s"Failed to retrieve list of competitions: ${exception.getMessage}", exception)
+           List.empty[PACompetition]
+         }
+    } yield {
+      matches
+        .filter(m => competitions.isEmpty || competitionIsSupported(competitions)(m))
+        .filter(inProgress)
+        .filter(paProvideAlerts)
+        .filterNot(isMidnight)
+    }
   }
 
   private def processMatch(matchDay: MatchDay): Future[Option[RawMatchData]] = {

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -109,7 +109,9 @@ class FootballData(
 
     def competitionIsSupported(supportedCompetitions: List[PACompetition])(matchDay: MatchDay): Boolean =
       matchDay.competition.exists { matchComp =>
-        supportedCompetitions.exists(_.id == matchComp.id)
+        val isSupported = supportedCompetitions.exists(_.id == matchComp.id)
+        if (!isSupported) logger.warn(s"match ${matchDay.id} from competition ${matchComp.id} is not supported")
+        isSupported
       }
 
     logger.info(s"Retrieving matches on or around $dateTime from PA")

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/S3DataStore.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/S3DataStore.scala
@@ -22,7 +22,7 @@ class S3DataStore[T](s3Client: AmazonS3, bucketName: String) extends Logging {
   private def parseS3Object(path: String)(implicit format: Format[T]) : List[T] = {
     Json.fromJson[List[T]](Json.parse(asString(s3Client.getObject(bucketName, path)))) match {
       case JsSuccess(list, __) =>
-        logger.info(s"Got ${list.length} items from s3, path $path")
+        logger.debug(s"Got ${list.length} items from s3 $bucketName, path $path")
         list
       case JsError(errors) =>
         val errorPaths = errors.map { error => error._1.toString() }.mkString(",")

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/S3DataStore.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/S3DataStore.scala
@@ -1,0 +1,43 @@
+package com.gu.mobile.notifications.football.lib
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.S3Object
+import com.amazonaws.util.IOUtils
+import com.gu.mobile.notifications.football.Logging
+import play.api.libs.json.{Format, JsError, JsSuccess, Json}
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+
+class S3DataStore[T](s3Client: AmazonS3, bucketName: String) extends Logging {
+  def fetch(path: String)(implicit format: Format[T]) : Future[List[T]] = {
+    Try(parseS3Object(path)) match {
+      case Success(list) => Future.successful(list)
+      case Failure(ex) =>
+        logger.error(s"Error retrieving items from s3. Bucket: $bucketName, Path: $path")
+        Future.failed(ex)
+    }
+  }
+
+  private def parseS3Object(path: String)(implicit format: Format[T]) : List[T] = {
+    Json.fromJson[List[T]](Json.parse(asString(s3Client.getObject(bucketName, path)))) match {
+      case JsSuccess(list, __) =>
+        logger.info(s"Got ${list.length} items from s3, path $path")
+        list
+      case JsError(errors) =>
+        val errorPaths = errors.map { error => error._1.toString() }.mkString(",")
+        logger.error(s"Error parsing S3 items on path $path. Error path(s): $errorPaths")
+        throw new Exception(s"could not extract list $path. Errors paths(s): $errors")
+    }
+  }
+
+  private def asString(s3Object: S3Object): String = {
+    val s3ObjectContent = s3Object.getObjectContent
+    try {
+      IOUtils.toString(s3ObjectContent)
+    }
+    finally {
+      s3ObjectContent.close()
+    }
+  }
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR introduces a filtering mechanism to ensure only matches from supported competitions are processed. The list of supported competitions is now fetched from a JSON configuration file stored in S3.

Tested this in CODE