### PR TITLE
Add team id to football content state

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
@@ -99,6 +99,7 @@ case class PenaltyShootoutState(
 )
 
 case class TeamState(
+    id: String,
     name: String,
     logoAssetName: Option[String] = None,
     teamUrl: Option[String] = None,

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -37,6 +37,7 @@ class MatchStatusLiveActivityPayloadBuilder {
       matchStatus = MatchStatus.fromString(matchInfo.matchStatus),
       kickOffTimestamp = matchInfo.date.toEpochSecond, // included date and time
       homeTeam = TeamState(
+        id = matchInfo.homeTeam.id,
         name = transformTeamName(matchInfo.homeTeam.name),
         score = score.home,
         logoAssetName = None, // tbc
@@ -45,6 +46,7 @@ class MatchStatusLiveActivityPayloadBuilder {
         penaltyScore = PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, isHomeTeam = true)
       ),
       awayTeam = TeamState(
+        id = matchInfo.awayTeam.id,
         name = transformTeamName(matchInfo.awayTeam.name),
         score = score.away,
         logoAssetName = None, // tbc

--- a/liveactivities/src/test/scala/com/gu/liveactivities/BroadcastServiceSpec.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/BroadcastServiceSpec.scala
@@ -32,8 +32,8 @@ class BroadcastServiceSpec(implicit ee: ExecutionEnv) extends Specification with
   val defaultContentState = FootballMatchContentState(
     matchStatus = FirstHalf,
     kickOffTimestamp = now.toEpochSecond - 1800, // 30min ago
-    homeTeam = TeamState(name = "Arsenal", score = 1),
-    awayTeam = TeamState(name = "Chelsea", score = 0),
+    homeTeam = TeamState(id = "1", name = "Arsenal", score = 1),
+    awayTeam = TeamState(id = "2", name = "Chelsea", score = 0),
     competition = Competition(id = "100", name = "Premier League", round = Some("League")),
     commentary = Some("Arsenal dominating."),
     currentMinute = Some(30),

--- a/liveactivities/src/test/scala/com/gu/liveactivities/models/BroadcastPayloadsSpec.scala
+++ b/liveactivities/src/test/scala/com/gu/liveactivities/models/BroadcastPayloadsSpec.scala
@@ -10,8 +10,8 @@ class BroadcastPayloadsSpec extends Specification {
   trait BroadcastScope extends Scope {
     val now = System.currentTimeMillis() / 1000
 
-    val homeTeam = TeamState(name = "Arsenal", score = 1)
-    val awayTeam = TeamState(name = "Chelsea", score = 0)
+    val homeTeam = TeamState(id = "1", name = "Arsenal", score = 1)
+    val awayTeam = TeamState(id = "2", name = "Chelsea", score = 0)
     val competition = Competition(id = "100", name = "Premier League", round = Some("League"))
 
     val contentState = FootballMatchContentState(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Fixing crest in live activity. The device needs to get the team id in the payload in order to load the correct crest for the team in live activity

Tested in CODE
