### PR TITLE
Add DLQ alarms on live activities stack

### DIFF
--- a/cdk/lib/__snapshots__/liveactivities.test.ts.snap
+++ b/cdk/lib/__snapshots__/liveactivities.test.ts.snap
@@ -4,9 +4,12 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
+      "GuAlarm",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
+      "GuAlarm",
       "GuLambdaFunction",
+      "GuAlarm",
       "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
@@ -22,7 +25,7 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
     "BroadcastDlq8DE17B20": {
       "DeletionPolicy": "Delete",
       "Properties": {
-        "MessageRetentionPeriod": 604800,
+        "MessageRetentionPeriod": 1209600,
         "QueueName": "liveactivities-broadcast-dlq-CODE",
         "Tags": [
           {
@@ -116,7 +119,7 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
     "ChannelCleanerDlq9CA723C0": {
       "DeletionPolicy": "Delete",
       "Properties": {
-        "MessageRetentionPeriod": 604800,
+        "MessageRetentionPeriod": 1209600,
         "QueueName": "liveactivities-channel-cleaner-dlq-CODE",
         "Tags": [
           {
@@ -199,7 +202,7 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
     "ChannelManagerDlq58D33B75": {
       "DeletionPolicy": "Delete",
       "Properties": {
-        "MessageRetentionPeriod": 604800,
+        "MessageRetentionPeriod": 1209600,
         "QueueName": "liveactivities-channel-manager-dlq-CODE",
         "Tags": [
           {
@@ -379,6 +382,69 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "liveactivitiesbroadcastdlqCODEAlarm3AB74C54": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "More than 1 message in liveactivities-broadcast-dlq-CODE",
+        "AlarmName": "liveactivities-broadcast-dlq-CODE-alarm",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "BroadcastDlq8DE17B20",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "liveactivitiesbroadcastlambdaC288C367": {
       "DependsOn": [
@@ -665,6 +731,69 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "liveactivitieschannelcleanerdlqCODEAlarm3EA37F66": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "More than 1 message in liveactivities-channel-cleaner-dlq-CODE",
+        "AlarmName": "liveactivities-channel-cleaner-dlq-CODE-alarm",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "ChannelCleanerDlq9CA723C0",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "liveactivitieschannelcleanerlambda569C0617": {
       "DependsOn": [
         "liveactivitieschannelcleanerlambdaServiceRoleDefaultPolicy2D93C4FB",
@@ -949,6 +1078,69 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "liveactivitieschannelmanagerdlqCODEAlarmB1763C34": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":mobile-server-side",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "More than 1 message in liveactivities-channel-manager-dlq-CODE",
+        "AlarmName": "liveactivities-channel-manager-dlq-CODE-alarm",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "ChannelManagerDlq58D33B75",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "liveactivitieschannelmanagerlambda398DC149": {
       "DependsOn": [

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -1,8 +1,14 @@
+import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
 import { Duration, Tags } from 'aws-cdk-lib';
+import {
+	ComparisonOperator,
+	Metric,
+	TreatMissingData,
+} from 'aws-cdk-lib/aws-cloudwatch';
 import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { EventBus, Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
@@ -10,6 +16,26 @@ import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { SqsDestination } from 'aws-cdk-lib/aws-lambda-destinations';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
+
+const addDlqAlarm = (scope: GuStack, app: string, dlq: Queue, name: string) => {
+	new GuAlarm(scope, `${name}Alarm`, {
+		app: app,
+		alarmName: `${name}-alarm`,
+		alarmDescription: `More than 1 message in ${name}`,
+		metric: new Metric({
+			namespace: 'AWS/SQS',
+			metricName: 'ApproximateNumberOfMessagesVisible',
+			dimensionsMap: { QueueName: dlq.queueName },
+			statistic: 'Sum',
+			period: Duration.minutes(1),
+		}),
+		threshold: 1,
+		evaluationPeriods: 1,
+		comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+		treatMissingData: TreatMissingData.NOT_BREACHING,
+		snsTopicName: 'mobile-server-side',
+	});
+};
 
 export class LiveActivities extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
@@ -32,8 +58,14 @@ export class LiveActivities extends GuStack {
 		const channelManagerDlq = new Queue(this, 'ChannelManagerDlq', {
 			queueName: `${app}-channel-manager-dlq-${stage}`,
 			visibilityTimeout: Duration.minutes(4),
-			retentionPeriod: Duration.days(7),
+			retentionPeriod: Duration.days(14),
 		});
+		addDlqAlarm(
+			this,
+			app,
+			channelManagerDlq,
+			`${app}-channel-manager-dlq-${stage}`,
+		);
 
 		const channelLambda = new GuLambdaFunction(
 			this,
@@ -92,8 +124,9 @@ export class LiveActivities extends GuStack {
 		const broadcastDlq = new Queue(this, 'BroadcastDlq', {
 			queueName: `${app}-broadcast-dlq-${stage}`,
 			visibilityTimeout: Duration.minutes(4),
-			retentionPeriod: Duration.days(7),
+			retentionPeriod: Duration.days(14),
 		});
+		addDlqAlarm(this, app, broadcastDlq, `${app}-broadcast-dlq-${stage}`);
 
 		const broadcastLambda = new GuLambdaFunction(
 			this,
@@ -145,8 +178,14 @@ export class LiveActivities extends GuStack {
 		const channelCleanerDlq = new Queue(this, 'ChannelCleanerDlq', {
 			queueName: `${app}-channel-cleaner-dlq-${stage}`,
 			visibilityTimeout: Duration.minutes(4),
-			retentionPeriod: Duration.days(7),
+			retentionPeriod: Duration.days(14),
 		});
+		addDlqAlarm(
+			this,
+			app,
+			channelCleanerDlq,
+			`${app}-channel-cleaner-dlq-${stage}`,
+		);
 
 		const channelCleanerLambda = new GuLambdaFunction(
 			this,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We have DLQs for the 3 live activity lambdas that receive messages on failed execution, but no alarms. This adds alarming. 

Also increased the DLQ message retention to 14 days. 

- [x] tested in code. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
