### PR TITLE
Updated logging when we filter out matched from unsupported competitions

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -90,8 +90,7 @@ class FootballData(
     if (supportedCompetitions.isEmpty) {
       logger.warn("No supported competitions PA list retrieved, assuming all matches are supported")
       return matches
-    }
-    else {
+    } else {
       val (supported, unsupported) = matches.partition { m =>
         m.competition.exists(comp => supportedCompetitions.exists(_.id == comp.id))
       }
@@ -99,7 +98,9 @@ class FootballData(
         val msg = unsupported
           .map(m => s"${m.id} from competition ${m.competition.map(_.id).getOrElse("unknown")}")
           .mkString(", ")
-        logger.warn(s"Unsupported matches: $msg")
+        logger.warn(
+          s"Found ${supported.size} supported matches. Skipping ${unsupported.size} matches from unsupported competitions: $msg",
+        )
       }
       supported
     }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -15,57 +15,58 @@ import scala.util.{Failure, Success, Try}
 case class EndedMatch(matchId: String, startTime: DateTime)
 
 case class PACompetition(
-                        id: String,
-                        tag: String,
-                        fullName: String,
-                        shortName: String,
-                        startDate: Option[LocalDate] = None,
-                        endDate: Option[LocalDate] = None,
-                      )
+    id: String,
+    tag: String,
+    fullName: String,
+    shortName: String,
+    startDate: Option[LocalDate] = None,
+    endDate: Option[LocalDate] = None,
+)
 
 object PACompetition {
   implicit val competitionFormat: Format[PACompetition] = Json.format[PACompetition]
 }
 
 class FootballData(
-                    paClient: PaFootballClient,
-                    syntheticEvents: SyntheticMatchEventGenerator,
-                    competitionsDataStore: S3DataStore[PACompetition],
-                    stage: String
+    paClient: PaFootballClient,
+    syntheticEvents: SyntheticMatchEventGenerator,
+    competitionsDataStore: S3DataStore[PACompetition],
+    stage: String,
 ) extends Logging {
 
   implicit class RichMatchDay(matchDay: MatchDay) {
 
     private lazy val internationalTeamsForFriendlies = Set(
-      "497",    //England,
-      "499",    //'Scotland,
-      "630",    //Wales,
-      "494",    //Republic of Ireland,
-      "964",    //Northern Ireland,
-      "999",    //Spain,
-      "1678",   //Germany,
-      "717",    //Italy,
-      "619",    //France,
-      "997",    //Belgium,
-      "5539",   //Portugal,
-      "1661",   //Turkey,
-      "629",    //Poland,
-      "716",    //Norway,
-      "5845",   //Sweden,
-      "986",    //Denmark,
-      "5827",   //Russia,
-      "965",    //Argentina,
-      "23104"   //Brazil
+      "497", // England,
+      "499", // 'Scotland,
+      "630", // Wales,
+      "494", // Republic of Ireland,
+      "964", // Northern Ireland,
+      "999", // Spain,
+      "1678", // Germany,
+      "717", // Italy,
+      "619", // France,
+      "997", // Belgium,
+      "5539", // Portugal,
+      "1661", // Turkey,
+      "629", // Poland,
+      "716", // Norway,
+      "5845", // Sweden,
+      "986", // Denmark,
+      "5827", // Russia,
+      "965", // Argentina,
+      "23104", // Brazil
     )
 
-    lazy val isUncoveredInternationalFriendly: Boolean = Set(matchDay.homeTeam.id, matchDay.awayTeam.name).intersect(internationalTeamsForFriendlies).isEmpty
+    lazy val isUncoveredInternationalFriendly: Boolean =
+      Set(matchDay.homeTeam.id, matchDay.awayTeam.name).intersect(internationalTeamsForFriendlies).isEmpty
 
     lazy val isEarlyQualifyingRound: Boolean = Try(matchDay.round.roundNumber.toInt) match {
       case Success(r) => r < 3
-      case _ => false
+      case _          => false
     }
   }
-  
+
   def pollFootballData(dateTime: ZonedDateTime): Future[List[RawMatchData]] = {
     logger.info("Starting poll for new match events")
 
@@ -86,7 +87,6 @@ class FootballData(
     def inProgress(m: MatchDay): Boolean =
       m.date.minusHours(2).isBefore(dateTime) && m.date.plusHours(4).isAfter(dateTime)
 
-
     // unfortunately PA provide 00:00 as start date when they don't have the start date
     // so we can't do anything with these matches
     def isMidnight(matchDay: MatchDay): Boolean = {
@@ -94,40 +94,60 @@ class FootballData(
       localDate.getHour() == 0 && localDate.getMinute() == 0
     }
 
-    //Theres some stuff that PA don't provide data for and we want to supress alerts for these matches
-    def paProvideAlerts(matchDay: MatchDay) : Boolean = {
-      matchDay.competition.map {
-        c => c.id match {
-          //International friendly: Must involve at least one of a whitelisted set of teams
-          case "721" if matchDay.isUncoveredInternationalFriendly => false
-          //FA cup qualifying rounds not covererd before round 3
-          case "303" if matchDay.isEarlyQualifyingRound => false
-          case _ => true
+    // Theres some stuff that PA don't provide data for and we want to supress alerts for these matches
+    def paProvideAlerts(matchDay: MatchDay): Boolean = {
+      matchDay.competition
+        .map { c =>
+          c.id match {
+            // International friendly: Must involve at least one of a whitelisted set of teams
+            case "721" if matchDay.isUncoveredInternationalFriendly => false
+            // FA cup qualifying rounds not covererd before round 3
+            case "303" if matchDay.isEarlyQualifyingRound => false
+            case _                                        => true
+          }
         }
-      }.getOrElse(false) //Shouldn't ever happen
+        .getOrElse(false) // Shouldn't ever happen
     }
 
-    def competitionIsSupported(supportedCompetitions: List[PACompetition])(matchDay: MatchDay): Boolean =
-      matchDay.competition.exists { matchComp =>
-        val isSupported = supportedCompetitions.exists(_.id == matchComp.id)
-        if (!isSupported) logger.warn(s"match ${matchDay.id} from competition ${matchComp.id} is not supported")
-        isSupported
+    def competitionIsSupported(
+        matches: List[MatchDay],
+        supportedCompetitions: List[PACompetition],
+    ): List[MatchDay] = {
+      if (supportedCompetitions.isEmpty) then {
+        logger.warn("No supported competitions PA list retrieved, assuming all matches are supported")
+        return matches
       }
+      else {
+        val (supported, unsupported) = matches.partition { m =>
+          m.competition.exists(comp => supportedCompetitions.exists(_.id == comp.id))
+        }
+        if (unsupported.nonEmpty) {
+          val msg = unsupported
+            .map(m => s"${m.id} from competition ${m.competition.map(_.id).getOrElse("unknown")}")
+            .mkString(", ")
+          logger.warn(s"Unsupported matches: $msg")
+        }
+        supported
+      }
+    }
 
     logger.info(s"Retrieving matches on or around $dateTime from PA")
     for {
-       matches <- paClient.aroundToday(dateTime)
-       competitions <- competitionsDataStore
-         .fetch(s"${stage}/competition/competitions.json")
-         .recover { case exception =>
-           // We don't want to fail the whole process if we can't retrieve the list of competitions,
-           // we'll just assume all competitions are supported and log the error
-           logger.error(s"Failed to retrieve list of competitions: ${exception.getMessage}", exception)
-           List.empty[PACompetition]
-         }
+      matches <- paClient.aroundToday(dateTime)
+      competitions <- competitionsDataStore
+        .fetch(s"${stage}/competition/competitions.json")
+        .recover { case exception =>
+          // We don't want to fail the whole process if we can't retrieve the list of competitions,
+          // we'll just assume all competitions are supported and log the error
+          logger.error(s"Failed to retrieve list of competitions: ${exception.getMessage}", exception)
+          List.empty[PACompetition]
+        }
+      matchesInSupportedCompetitions = competitionIsSupported(matches, competitions)
+      _ = logger.info(
+        s"Retrieved ${matches.size} matches from PA, ${matchesInSupportedCompetitions.size} are in supported competitions",
+      )
     } yield {
-      matches
-        .filter(m => competitions.isEmpty || competitionIsSupported(competitions)(m))
+      matchesInSupportedCompetitions
         .filter(inProgress)
         .filter(paProvideAlerts)
         .filterNot(isMidnight)

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -83,6 +83,28 @@ class FootballData(
     }
   }
 
+  def competitionIsSupported(
+      matches: List[MatchDay],
+      supportedCompetitions: List[PACompetition],
+  ): List[MatchDay] = {
+    if (supportedCompetitions.isEmpty) {
+      logger.warn("No supported competitions PA list retrieved, assuming all matches are supported")
+      return matches
+    }
+    else {
+      val (supported, unsupported) = matches.partition { m =>
+        m.competition.exists(comp => supportedCompetitions.exists(_.id == comp.id))
+      }
+      if (unsupported.nonEmpty) {
+        val msg = unsupported
+          .map(m => s"${m.id} from competition ${m.competition.map(_.id).getOrElse("unknown")}")
+          .mkString(", ")
+        logger.warn(s"Unsupported matches: $msg")
+      }
+      supported
+    }
+  }
+
   def matchIdsInProgress(dateTime: ZonedDateTime): Future[List[MatchDay]] = {
     def inProgress(m: MatchDay): Boolean =
       m.date.minusHours(2).isBefore(dateTime) && m.date.plusHours(4).isAfter(dateTime)
@@ -107,28 +129,6 @@ class FootballData(
           }
         }
         .getOrElse(false) // Shouldn't ever happen
-    }
-
-    def competitionIsSupported(
-        matches: List[MatchDay],
-        supportedCompetitions: List[PACompetition],
-    ): List[MatchDay] = {
-      if (supportedCompetitions.isEmpty) then {
-        logger.warn("No supported competitions PA list retrieved, assuming all matches are supported")
-        return matches
-      }
-      else {
-        val (supported, unsupported) = matches.partition { m =>
-          m.competition.exists(comp => supportedCompetitions.exists(_.id == comp.id))
-        }
-        if (unsupported.nonEmpty) {
-          val msg = unsupported
-            .map(m => s"${m.id} from competition ${m.competition.map(_.id).getOrElse("unknown")}")
-            .mkString(", ")
-          logger.warn(s"Unsupported matches: $msg")
-        }
-        supported
-      }
     }
 
     logger.info(s"Retrieving matches on or around $dateTime from PA")

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/FootballDataSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/FootballDataSpec.scala
@@ -1,0 +1,106 @@
+package com.gu.mobile.notifications.football.lib
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import pa.{Competition, MatchDay, MatchDayTeam, Round, Stage}
+
+import java.time.ZonedDateTime
+
+class FootballDataSpec extends Specification {
+
+  trait FootballDataScope extends Scope {
+    val home = MatchDayTeam("1", "Arsenal", None, None, None, None)
+    val away = MatchDayTeam("2", "Chelsea", None, None, None, None)
+
+    def matchDayWithCompetition(competitionId: String, matchId: String = "match-1"): MatchDay = MatchDay(
+      id = matchId,
+      date = ZonedDateTime.parse("2026-05-18T15:00:00Z"),
+      competition = Some(Competition(competitionId, "Test Competition")),
+      stage = Stage("1"),
+      round = Round("1", None),
+      leg = "1",
+      liveMatch = true,
+      result = false,
+      previewAvailable = false,
+      reportAvailable = false,
+      lineupsAvailable = false,
+      matchStatus = "FH",
+      attendance = None,
+      homeTeam = home,
+      awayTeam = away,
+      referee = None,
+      venue = None,
+      comments = None
+    )
+
+    val matchDayNoCompetition: MatchDay = MatchDay(
+      id = "match-no-comp",
+      date = ZonedDateTime.parse("2026-05-18T15:00:00Z"),
+      competition = None,
+      stage = Stage("1"),
+      round = Round("1", None),
+      leg = "1",
+      liveMatch = true,
+      result = false,
+      previewAvailable = false,
+      reportAvailable = false,
+      lineupsAvailable = false,
+      matchStatus = "FH",
+      attendance = None,
+      homeTeam = home,
+      awayTeam = away,
+      referee = None,
+      venue = None,
+      comments = None
+    )
+
+    val premierLeague = PACompetition("100", "football/premierleague", "Premier League 25/26", "PL")
+    val championsLeague = PACompetition("500", "football/championsleague", "Champions League 25/26", "UCL")
+    val supportedCompetitions = List(premierLeague, championsLeague)
+
+  }
+
+  "competitionIsSupported" should {
+
+    val footballData = new FootballData(null, null, null, "test") // pass mocks or nulls as needed
+
+    "return a match when its competition is in the supported list" in new FootballDataScope {
+      val matches = List(matchDayWithCompetition("100"))
+      footballData.competitionIsSupported(matches, supportedCompetitions) must haveSize(1)
+    }
+
+    "filter out a match when its competition is not in the supported list" in new FootballDataScope {
+      val matches = List(matchDayWithCompetition("999"))
+      footballData.competitionIsSupported(matches, supportedCompetitions) must beEmpty
+    }
+
+    "return only supported matches from a mixed list" in new FootballDataScope {
+      val matches = List(
+        matchDayWithCompetition("100", "match-1"),
+        matchDayWithCompetition("500", "match-2"),
+        matchDayWithCompetition("999", "match-3")
+      )
+      val result = footballData.competitionIsSupported(matches, supportedCompetitions)
+      result must haveSize(2)
+      result.map(_.id) must containAllOf(Seq("match-1", "match-2"))
+    }
+
+    "return all matches when supported competitions list is empty" in new FootballDataScope {
+      val matches = List(
+        matchDayWithCompetition("100", "match-1"),
+        matchDayWithCompetition("999", "match-2")
+      )
+      footballData.competitionIsSupported(matches, List.empty) must haveSize(2)
+    }
+
+    "filter out a match with no competition" in new FootballDataScope {
+      val matches = List(matchDayNoCompetition)
+      footballData.competitionIsSupported(matches, supportedCompetitions) must beEmpty
+    }
+
+    "return an empty list when the input matches list is empty" in new FootballDataScope {
+      footballData.competitionIsSupported(List.empty, supportedCompetitions) must beEmpty
+    }
+  }
+}
+


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We should now only be logging once a list of any unsupported matches. 

A test file has been added. 

Tested in code. US soccer cup 762 successfully observed filtered out in logs. 

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
