### PR TITLE
Fix structured logging in football lambda

### DIFF
--- a/cdk/lib/__snapshots__/footballnotificationslambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/footballnotificationslambda.test.ts.snap
@@ -476,7 +476,7 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for CODE 1`]
         "FunctionName": "football-CODE",
         "Handler": "com.gu.mobile.notifications.football.Lambda::handler",
         "LoggingConfig": {
-          "LogFormat": "Text",
+          "LogFormat": "JSON",
         },
         "MemorySize": 1024,
         "Role": {
@@ -1315,7 +1315,7 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for PROD 1`]
         "FunctionName": "football-PROD",
         "Handler": "com.gu.mobile.notifications.football.Lambda::handler",
         "LoggingConfig": {
-          "LogFormat": "Text",
+          "LogFormat": "JSON",
         },
         "MemorySize": 1024,
         "Role": {

--- a/cdk/lib/footballnotificationslambda.ts
+++ b/cdk/lib/footballnotificationslambda.ts
@@ -13,7 +13,7 @@ import {
 import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { LogGroup, MetricFilter } from 'aws-cdk-lib/aws-logs';
 
 export class FootballNotificationsLambda extends GuStack {
@@ -33,7 +33,6 @@ export class FootballNotificationsLambda extends GuStack {
 				functionName: [app, stage].join('-'),
 				fileName: `${app}.jar`,
 				monitoringConfiguration: { noMonitoring: true },
-				loggingFormat: LoggingFormat.TEXT,
 				//MinuteEvent
 				rules: [
 					{


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Change lambda logging format from TEXT to JSON to fix structured log shipping to ELK stack. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
