### PR TITLE
Add debug logging to repo writes.

### DIFF
--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
@@ -114,7 +114,13 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
         }
 
         result.flatMap {
-          case Right(_) => Future.successful(())
+          case Right(_) =>
+            logger.info(
+              s"Updated live activity DB mapping id $id with updates: ${
+                ups.map(exp => s"${exp.attributes.names} = ${exp.attributes.values}").toString()
+              }"
+            )
+            Future.successful(())
           case Left(ex) =>
             val errorMsg = s"Error updating live activity mapping for id $id - ${DynamoReadError.describe(ex)}"
             logger.error(errorMsg)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We want to verify what repo updates are happening in what order when concurrently lambdas are running. We may need to implement conditional locking. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
