### PR TITLE
Live activities clean up - Fix Dynamo AttemptCalloutException

### DIFF
--- a/cdk/lib/__snapshots__/liveactivities.test.ts.snap
+++ b/cdk/lib/__snapshots__/liveactivities.test.ts.snap
@@ -853,7 +853,7 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
             "Value": "CODE",
           },
         ],
-        "Timeout": 180,
+        "Timeout": 660,
       },
       "Type": "AWS::Lambda::Function",
     },

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -198,7 +198,7 @@ export class LiveActivities extends GuStack {
 				fileName: `${app}.jar`,
 				runtime: Runtime.JAVA_11,
 				memorySize: 1024,
-				timeout: Duration.minutes(3),
+				timeout: Duration.minutes(11),
 				onFailure: new SqsDestination(channelCleanerDlq),
 				retryAttempts: 2,
 				environment: {

--- a/liveactivities/src/main/scala/com/gu/liveactivities/ChannelCleanUpLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/ChannelCleanUpLambda.scala
@@ -23,8 +23,8 @@ object ChannelCleanUpLambda extends Lambda with Logging {
       deletedChannels <- cleanUpService.deleteChannelsForEndedBroadcasts()
       _ = logger.info(s"${deletedChannels.size} channels deleted:  [${deletedChannels.map(_.id).mkString(", ")}]")
       // orphanChannels <- deleteOrphanChannelsInAPNS() // channels that exist in APNS but corresponding mapping is missing in Dynamo
-      // staleMappings <- markInactiveStaleMappings // mapping still "LIVE" that missed an end activity update and need to be deleted - observed Mapi may return channel id otherwise
-      // orphanMappings <- markInactiveOrphanMappings // mapping still "active" but channel has been deleted. - observed 4551548
+      // staleMappings <- markInactiveStaleMappings // mapping still "LIVE" that missed an end activity update and need to be deleted - Mapi may return channel id otherwise
+      // orphanMappings <- markInactiveOrphanMappings // mapping still "active" but channel has been deleted.
       cleanupSummary = {
         deletedChannels
 //        orphanChannels,

--- a/liveactivities/src/main/scala/com/gu/liveactivities/ChannelCleanUpLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/ChannelCleanUpLambda.scala
@@ -12,7 +12,8 @@ import scala.util.{Failure, Success, Try}
 object ChannelCleanUpLambda extends Lambda with Logging {
 
   private val channelApiClient = new ChannelApiClient(authentication, config.bundleId, config.sendingToProdServer)
-  private val cleanUpService = new ChannelCleanUpService(repository, channelApiClient)
+  private val dynamoRepository = getRepositoryWithCustomTimeouts(10, 40)
+  private val cleanUpService = new ChannelCleanUpService(dynamoRepository, channelApiClient)
 
   // we need a scheduledEvent input here so we have some metadata to capture in the DLQ if there is a failure.
   def handleRequest(input: ScheduledEvent, context: Context): Unit = {
@@ -20,9 +21,10 @@ object ChannelCleanUpLambda extends Lambda with Logging {
 
     val future = for {
       deletedChannels <- cleanUpService.deleteChannelsForEndedBroadcasts()
+      _ = logger.info(s"${deletedChannels.size} channels deleted:  [${deletedChannels.map(_.id).mkString(", ")}]")
       // orphanChannels <- deleteOrphanChannelsInAPNS() // channels that exist in APNS but corresponding mapping is missing in Dynamo
-      // staleMappings <- markInactiveStaleMappings // mapping still "LIVE" that missed an end activity update and need to be deleted - Mapi may return channel id otherwise
-      // orphanMappings <- markInactiveOrphanMappings // mapping still "active" but channel has been deleted.
+      // staleMappings <- markInactiveStaleMappings // mapping still "LIVE" that missed an end activity update and need to be deleted - observed Mapi may return channel id otherwise
+      // orphanMappings <- markInactiveOrphanMappings // mapping still "active" but channel has been deleted. - observed 4551548
       cleanupSummary = {
         deletedChannels
 //        orphanChannels,
@@ -31,7 +33,7 @@ object ChannelCleanUpLambda extends Lambda with Logging {
       }
     } yield cleanupSummary
 
-    Try(Await.result(future, 160.seconds)) match {
+    Try(Await.result(future, 600.seconds)) match {
       case Success(_) => {
         logger.info("Channel clean up completed successfully")
       }

--- a/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/Lambda.scala
@@ -24,23 +24,28 @@ trait Lambda extends Logging{
     DefaultCredentialsProvider.builder.build(),
   )
 
-  val dynamoDbClient =
+  private def buildDbClient(attemptTimeout: Int = 2, timeout: Int = 10): DynamoDbAsyncClient = {
     DynamoDbAsyncClient
       .builder()
       .credentialsProvider(credentialsv2)
       .region(Region.of(config.region))
       .overrideConfiguration(
         ClientOverrideConfiguration.builder()
-          .apiCallAttemptTimeout(Duration.ofSeconds(2)) // limit for one single try
-          .apiCallTimeout(Duration.ofSeconds(10)) // limit for the entire operation
+          .apiCallAttemptTimeout(Duration.ofSeconds(attemptTimeout)) // limit for one single try
+          .apiCallTimeout(Duration.ofSeconds(timeout)) // limit for the entire operation
           .retryStrategy(DefaultRetryStrategy.standardStrategyBuilder()
             .maxAttempts(3)
             .build())
           .build()
       )
       .build()
+  }
 
-  val repository = new LiveActivityChannelRepository(dynamoDbClient, s"mobile-notifications-liveactivities-${config.stage}")
+  private val dynamoTableName = s"mobile-notifications-liveactivities-${config.stage}"
+  val repository = new LiveActivityChannelRepository(buildDbClient(), dynamoTableName)
+  def getRepositoryWithCustomTimeouts(attemptTimeout: Int, timeout: Int): LiveActivityChannelRepository = {
+    new LiveActivityChannelRepository(buildDbClient(attemptTimeout, timeout), dynamoTableName)
+  }
 
   private val eventBusName = s"liveactivities-eventbus-${config.stage}"
   lazy val liveActivityPusher = new LiveActivityPusher(eventBusName, logger)

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/ChannelCleanUpService.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/ChannelCleanUpService.scala
@@ -23,7 +23,7 @@ class ChannelCleanUpService(
         hasLastEvent = true,
       )
       _ = logger.info(s"Channels identified for possible deletion: ${channelsForPossibleDeletion.size}")
-      // todo these sequence failures will not currently throw
+      // todo this sequence failures will not currently throw
       _ <- Future.sequence(
         channelsForPossibleDeletion.map { mapping =>
         {
@@ -36,14 +36,19 @@ class ChannelCleanUpService(
               .closeChannel(mapping.channelId)
               .flatMap { _ =>
                 val f = repository.updateMappingActiveChannel(mapping.id, isActive = false)
-                channelsDeleted ++= List(mapping)
-                logger.info(s"Channel successfully marked inactive with channel ID: ${mapping.channelId} for match ID ${mapping.id}")
+                  .map { result =>
+                    channelsDeleted ++= List(mapping)
+                    logger.info(s"Channel successfully marked inactive with channel ID: ${mapping.channelId} for match ID ${mapping.id}")
+                    result
+                  }
                 f
               }
               .recover { case exception =>
-                // todo Handle exception better and throw when needed. Some errorw will be handled by rest of the Cleanup tasks.
+                // todo handle exception better and throw when needed. Some errors will be handled by rest of the Cleanup tasks.
                 logger.error(s"Failed to delete channel with ID ${mapping.channelId} for match ID ${mapping.id} - ${exception.getMessage}")
               }
+
+
           }
         }
         },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We observed a number of live activity mappings failing to complete -> channel was sucessfully deleted on Apple, but attempt to update the `isChannelActive` attribute on Dynamo resulted in time out failures:

```
Unable to execute HTTP request: software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException: HTTP request execution did not complete before the specified timeout configuration: 2000 millis (SDK Attempt Count: 2)
```

This PR increases the dynamo client `attemptTimeout` and `totalTimeout` used for the Cleaner Lambda dynamo. repository

It also increases the overall lambda timeout to 10min, and the cdk timeout to 11min. 
It also fixes logging in the deletion service that was running syncronously in error. 

We anticipate anywhere from 1 to 75 games per day to delete. The last few days with ~50 games took 22-31seconds overall. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

1/ LiveActivities cleaner lambda deployed to CODE and triggerd manually. 
2/ 10 channels marked inactive and deleted successfully. 
3/ No timeouts observed (though none have been observed in CODE to date, only in PROD) 

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
