### PR TITLE
Add the new live activity topics in notification topic type

### DIFF
--- a/common/src/main/scala/models/TopicType.scala
+++ b/common/src/main/scala/models/TopicType.scala
@@ -15,6 +15,8 @@ object TopicTypes {
   object TagBlog extends TopicType("tag-blog", 1)
   object FootballTeam extends TopicType("football-team", 1)
   object FootballMatch extends TopicType("football-match", 1)
+  object FootballTeamLiveActivity extends TopicType("football-team-live-activity", 1)
+  object FootballMatchLiveActivity extends TopicType("football-match-live-activity", 1)
   object Newsstand extends TopicType("newsstand", 100)
   object NewsstandShard extends TopicType("newsstand-shard", 100)
   object Editions extends TopicType("editions", 100)
@@ -33,7 +35,9 @@ object TopicType {
     case "tag-blog" => TagBlog
     case "football-team" => FootballTeam
     case "football-match" => FootballMatch
+    case "football-team-live-activity" => FootballTeamLiveActivity
     case "newsstand" => TopicTypes.Newsstand
+    case "football-match-live-activity" => FootballMatchLiveActivity
     case "newsstand-shard" => TopicTypes.NewsstandShard
     case "live-notification" => LiveNotification
     case "editions" => Editions


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
<img width="1159" height="633" alt="image" src="https://github.com/user-attachments/assets/c2e8547a-233b-4525-8402-53c7c3abb58c" />

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
