### PR TITLE
Remove unused batch sending code

### DIFF
--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/AndroidSender.scala
@@ -5,10 +5,10 @@ import _root_.models.Topic
 import cats.effect.{ContextShift, IO, Timer}
 import com.gu.notifications.worker.cleaning.CleaningClientImpl
 import com.gu.notifications.worker.delivery.DeliveryException.InvalidToken
-import com.gu.notifications.worker.delivery.{BatchDeliverySuccess, DeliveryClient, DeliveryException}
+import com.gu.notifications.worker.delivery.{DeliveryClient, DeliveryException}
 import com.gu.notifications.worker.delivery.fcm.{Fcm, FcmClient}
 import com.gu.notifications.worker.models.{LatencyMetrics, SendingResults}
-import com.gu.notifications.worker.tokens.{BatchNotification, ChunkedTokens, IndividualNotification}
+import com.gu.notifications.worker.tokens.{ChunkedTokens, IndividualNotification}
 import com.gu.notifications.worker.utils.{Cloudwatch, CloudwatchImpl, Reporting}
 import fs2.{Pipe, Stream}
 
@@ -82,49 +82,5 @@ class AndroidSender(val config: FcmWorkerConfiguration, val firebaseAppName: Opt
       .parJoin(maxConcurrency)
       .evalTap(Reporting.log(s"Sending failure: "))
     } yield resp
-  }
-  def reportBatchSuccesses[C <: DeliveryClient](chunkedTokens: ChunkedTokens, sentTime: Long, functionStartTime: Instant, sqsMessageBatchSize: Int, awsRequestId: String): Pipe[IO, Either[DeliveryException, BatchDeliverySuccess], Unit] = { input =>
-    val notificationLog = s"(notification: ${chunkedTokens.notification.id} ${chunkedTokens.range})"
-    val enableAwsMetric = chunkedTokens.notification.dryRun match {
-      case Some(true) => false
-      case _ => true
-    }
-    input
-      .fold(SendingResults.empty) { case (acc, resp) => SendingResults.aggregateBatch(acc, chunkedTokens.tokens.size, resp) }
-      .evalTap(logInfoWithFields(logFields(env, chunkedTokens.notification, chunkedTokens.tokens.size, sentTime, functionStartTime, Configuration.platform, sqsMessageBatchSize, messagingApi = "Batch", awsRequestId = awsRequestId), prefix = s"Results $notificationLog: ").andThen(_.map(cloudwatch.sendPerformanceMetrics(env.stage, enableAwsMetric))))
-      .through(cloudwatch.sendResults(env.stage, Configuration.platform))
-  }
-
-  def reportBatchLatency[C <: DeliveryClient](chunkedTokens: ChunkedTokens, metadata: NotificationMetadata): Pipe[IO, Either[DeliveryException, BatchDeliverySuccess], Unit] = { input =>
-    val shouldPushMetricsToAws = chunkedTokens.notification.dryRun match {
-      case Some(true) => false
-      case _ => true
-    }
-    input
-      .fold(List.empty[Long]) { case (acc, resp) => LatencyMetrics.collectBatchLatency(acc, resp, metadata.notificationAppReceivedTime) }
-      .through(cloudwatch.sendLatencyMetrics(shouldPushMetricsToAws, env.stage, Configuration.platform, metadata.audienceSize))
-  }
-
-  def cleanupBatchFailures[C <: DeliveryClient](notificationId: UUID): Pipe[IO, Either[Throwable, BatchDeliverySuccess], Unit] = { input =>
-    input
-      .collect {
-        case Right(batchSuccess) =>
-          batchSuccess.responses.foldLeft(List[String]())((acc, res) => res match {
-            case Left(InvalidToken(_, token, _, _)) =>
-              logger.debug(Map("notificationId" -> notificationId), s"Invalid token $token")
-              token :: acc
-            case Left(_) => acc
-            case Right(_) => acc
-          })
-      }
-      .chunkN(1000)
-      .through(cleaningClient.sendInvalidBatchTokensToCleaning)
-  }
-
-  def trackBatchProgress[C <: DeliveryClient](notificationId: UUID): Pipe[IO, Either[Throwable, BatchDeliverySuccess], Unit] = {
-    input => input.evalMap(chunk => IO.delay(chunk match {
-      case Left(_) => () // we log in other places if there's a catastrophic batch error
-      case Right(batchSuccess) => logger.info(Map("notificationId" -> notificationId), s"Processed ${batchSuccess.responses.size} individual notification(s)")
-    }))
   }
 }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/cleaning/CleaningClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/cleaning/CleaningClient.scala
@@ -33,13 +33,4 @@ class CleaningClientImpl(sqsUrl: String) extends CleaningClient {
         sendTokensToQueue(chunk.toList)
       }
     }
-
-  def sendInvalidBatchTokensToCleaning(implicit logger: Logger): Pipe[IO, Chunk[List[String]], Unit] = {
-    _.evalMap { chunk =>
-      IO.delay {
-        sendTokensToQueue(chunk.toList.flatten)
-      }
-    }
-  }
-
 }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryClient.scala
@@ -10,7 +10,6 @@ trait DeliveryClient {
 
   type Success <: DeliverySuccess
   type Payload <: DeliveryPayload
-  type BatchSuccess <: BatchDeliverySuccess
 
   def sendNotification(notificationId: UUID, token: String, payload: Payload, dryRun: Boolean)
     (onComplete: Either[DeliveryException, Success] => Unit)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryException.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliveryException.scala
@@ -45,11 +45,6 @@ object DeliveryException {
     override def getMessage = s"Request failed (Notification: $notificationId, Token: $token)"
   }
 
-  case class BatchCallFailedRequest(notificationId: UUID, failure: String) extends DeliveryException {
-    override def getMessage = s"Entire batch request failed (Notification: $notificationId, $failure)"
-  }
-
-
   case class InvalidPayload(notificationId: UUID) extends DeliveryException {
     override def getMessage = s"Cannot generate payload (Notification: $notificationId)"
   }

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliverySuccess.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/DeliverySuccess.scala
@@ -9,13 +9,5 @@ sealed trait DeliverySuccess {
   val deliveryTime: Instant
 }
 
-sealed trait BatchDeliverySuccess {
-  def responses: List[Either[DeliveryException, DeliverySuccess]]
-}
 case class ApnsDeliverySuccess(token: String, deliveryTime: Instant, dryRun: Boolean = false) extends DeliverySuccess
 case class FcmDeliverySuccess(token: String, messageId: String, deliveryTime: Instant, dryRun: Boolean = false) extends DeliverySuccess
-case class FcmBatchDeliverySuccess(responses: List[Either[DeliveryException, FcmDeliverySuccess]], notificationId: String) extends BatchDeliverySuccess
-
-case class ApnsBatchDeliverySuccess(responses: List[Either[DeliveryException, ApnsDeliverySuccess]], notificationId: String) extends BatchDeliverySuccess
-
-

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/apns/ApnsClient.scala
@@ -26,7 +26,6 @@ class ApnsClient(private val underlying: PushyApnsClient, val config: ApnsConfig
 
   type Success = ApnsDeliverySuccess
   type Payload = ApnsPayload
-  type BatchSuccess = ApnsBatchDeliverySuccess
   val dryRun = config.dryRun
   implicit val logger: Logger = LoggerFactory.getLogger(this.getClass)
   private val timer = new Timer("ios-worker-timeout", true)

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/delivery/fcm/FcmClient.scala
@@ -6,11 +6,11 @@ import com.google.api.client.json.JsonFactory
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import com.google.firebase.messaging._
 import com.google.firebase.{ErrorCode, FirebaseApp, FirebaseOptions}
-import com.gu.notifications.worker.delivery.DeliveryException.{BatchCallFailedRequest, FailedRequest, InvalidToken, UnknownReasonFailedRequest}
+import com.gu.notifications.worker.delivery.DeliveryException.{FailedRequest, InvalidToken, UnknownReasonFailedRequest}
 import com.gu.notifications.worker.delivery.fcm.models.FcmConfig
 import com.gu.notifications.worker.delivery.fcm.models.payload.FcmPayloadBuilder
 import com.gu.notifications.worker.delivery.fcm.oktransport.OkGoogleHttpTransport
-import com.gu.notifications.worker.delivery.{DeliveryClient, DeliveryException, FcmBatchDeliverySuccess, FcmDeliverySuccess, FcmPayload}
+import com.gu.notifications.worker.delivery.{DeliveryClient, DeliveryException, FcmDeliverySuccess, FcmPayload}
 import com.gu.notifications.worker.utils.Logging
 import org.slf4j.{Logger, LoggerFactory}
 import com.gu.notifications.worker.utils.UnwrappingExecutionException
@@ -19,7 +19,6 @@ import java.io.ByteArrayInputStream
 import java.time.{Duration, Instant}
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future, Promise}
-import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
@@ -29,7 +28,6 @@ class FcmClient (firebaseMessaging: FirebaseMessaging, firebaseApp: FirebaseApp,
   extends DeliveryClient with Logging {
 
   type Success = FcmDeliverySuccess
-  type BatchSuccess = FcmBatchDeliverySuccess
   type Payload = FcmPayload
   val dryRun = config.dryRun
 

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/models/SendingResults.scala
@@ -1,6 +1,6 @@
 package com.gu.notifications.worker.models
 
-import com.gu.notifications.worker.delivery.{BatchDeliverySuccess, DeliveryException, DeliverySuccess}
+import com.gu.notifications.worker.delivery.{DeliveryException, DeliverySuccess}
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.time.{Duration, Instant}
@@ -22,12 +22,6 @@ object SendingResults {
     case Right(success) if success.dryRun => previous.copy(dryRunCount = previous.dryRunCount + 1)
     case Right(_) => previous.copy(successCount = previous.successCount + 1)
     case Left(_) => previous.copy(failureCount = previous.failureCount + 1)
-  }
-
-  def aggregateBatch(previous: SendingResults, batchSize: Int, res: Either[Throwable, BatchDeliverySuccess]): SendingResults = res match {
-    case Right(batchSuccess) =>
-      batchSuccess.responses.foldLeft(previous)((acc, resp) => SendingResults.aggregate(acc, resp))
-    case Left(_) => SendingResults(previous.successCount, previous.failureCount + batchSize, previous.dryRunCount)
   }
 }
 
@@ -68,21 +62,6 @@ object LatencyMetrics {
       val duration = Duration.between(notificationSentTime, timeOfDeliveries).toSeconds
       previous :+ duration
     }.getOrElse(previous) // If the delivery was a failure just return the previous result
-  }
-
-  def collectBatchLatency(previous: List[Long], result: Either[Throwable, BatchDeliverySuccess], notificationSentTime: Instant): List[Long] = {
-    result.toOption.flatMap { batchSuccess =>
-      val successes = batchSuccess.responses.collect { case Right(success) => success }
-      successes.headOption.map { firstDelivery =>
-        val successfulDeliveries = successes.size
-        val timeOfDeliveries: Instant = firstDelivery.deliveryTime
-        val duration = Duration.between(notificationSentTime, timeOfDeliveries).toSeconds
-        // The batch are all delivered at the same time so we dont need to recalculate for every delivery in the batch.
-        // However we do want to record a time for each delivery.
-        val batchDeliveryTimes = List.fill(successfulDeliveries)(duration)
-        previous ++ batchDeliveryTimes
-      }
-    }.getOrElse(previous) // If the overall batch was a failure (or the batch only contained failures) just return the previous result
   }
 
   def audienceSizeBucket(audienceSize: Option[Int]): String = audienceSize match {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/tokens/TokenService.scala
@@ -13,11 +13,9 @@ import java.time.Instant
 import scala.concurrent.ExecutionContextExecutor
 
 case class IndividualNotification(notification: Notification, token: String)
-case class BatchNotification(notification: Notification, token: List[String])
 
 case class ChunkedTokens(notification: Notification, tokens: List[String], range: ShardRange, metadata: NotificationMetadata) {
   def toNotificationToSends: List[IndividualNotification] = tokens.map(IndividualNotification(notification, _))
-  def toBatchNotificationToSends: List[BatchNotification] = tokens.grouped(500).map(BatchNotification(notification, _)).toList
 }
 
 object ChunkedTokens {

--- a/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Reporting.scala
+++ b/notificationworkerlambda/src/main/scala/com/gu/notifications/worker/utils/Reporting.scala
@@ -2,7 +2,7 @@ package com.gu.notifications.worker.utils
 
 import cats.effect.IO
 import com.gu.notifications.worker.delivery.DeliveryException.{FailedRequest, InvalidToken}
-import com.gu.notifications.worker.delivery.{BatchDeliverySuccess, DeliveryClient, DeliveryException, DeliverySuccess}
+import com.gu.notifications.worker.delivery.{DeliveryClient, DeliveryException, DeliverySuccess}
 import models.{Notification, NotificationType}
 import org.slf4j.Logger
 
@@ -20,20 +20,9 @@ object Reporting {
     case Right(_) => () // doing nothing when success
   }
 
-
   def log[C <: DeliveryClient](prefix: String)(implicit logger: Logger): Either[DeliveryException, DeliverySuccess] => IO[Unit] = { resp =>
     IO.delay {
       logMatchCase(resp, prefix)
     }
   }
-
-  def logBatch[C <: DeliveryClient](prefix: String)(implicit logger: Logger): Either[DeliveryException, BatchDeliverySuccess] => IO[Unit] = { resp =>
-    IO.delay {
-      resp match {
-        case Left(e) => logger.error(prefix, e)
-        case Right(batchSuccess) => batchSuccess.responses.foreach(resp => logMatchCase(resp, prefix))
-      }
-    }
-  }
-
 }

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/SenderRequestHandlerSpec.scala
@@ -10,7 +10,7 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
 import com.gu.notifications.worker.cleaning.CleaningClient
 import com.gu.notifications.worker.delivery.DeliveryException.InvalidToken
 import com.gu.notifications.worker.delivery.apns.ApnsClient
-import com.gu.notifications.worker.delivery.{ApnsBatchDeliverySuccess, ApnsDeliverySuccess, BatchDeliverySuccess, DeliveryException, DeliveryService}
+import com.gu.notifications.worker.delivery.{ApnsDeliverySuccess, DeliveryException, DeliveryService}
 import com.gu.notifications.worker.models.SendingResults
 import com.gu.notifications.worker.tokens.ChunkedTokens
 import com.gu.notifications.worker.utils.Cloudwatch

--- a/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/fcm/FcmClientTest.scala
+++ b/notificationworkerlambda/src/test/scala/com/gu/notifications/worker/delivery/fcm/FcmClientTest.scala
@@ -6,9 +6,9 @@ import _root_.models.Link._
 import _root_.models.TopicTypes._
 import com.google.api.core.ApiFuture
 import com.google.firebase.{ErrorCode, FirebaseApp}
-import com.google.firebase.messaging.{BatchResponse, FirebaseMessaging, FirebaseMessagingException, SendResponse}
-import com.gu.notifications.worker.delivery.DeliveryException.{BatchCallFailedRequest, FailedRequest, InvalidToken, UnknownReasonFailedRequest}
-import com.gu.notifications.worker.delivery.{BatchDeliverySuccess, DeliveryException, FcmBatchDeliverySuccess, FcmDeliverySuccess, FcmPayload}
+import com.google.firebase.messaging.{FirebaseMessaging, FirebaseMessagingException, SendResponse}
+import com.gu.notifications.worker.delivery.DeliveryException.{FailedRequest, InvalidToken, UnknownReasonFailedRequest}
+import com.gu.notifications.worker.delivery.{DeliveryException, FcmDeliverySuccess, FcmPayload}
 import com.gu.notifications.worker.delivery.fcm.models.payload.FcmPayloadBuilder
 import models.FcmConfig
 import org.specs2.mutable.Specification
@@ -76,31 +76,6 @@ trait FcmScope extends Scope {
   var failedRequest = 0
   var unknownReasonFailedRequest = 0
   var otherResponse = 0
-  var deliveryBatchSuccess = 0
-  var otherBatchResponse = 0
-  var catastrophicBatchSendResponse = 0
-  val batchInvalidTokens = ListBuffer.empty[String]
-
-  def onCompleteCb(message: Either[DeliveryException, BatchDeliverySuccess]): Unit = {
-    message match {
-      case Right(FcmBatchDeliverySuccess(responses, _)) =>
-            responses.foreach {
-              case Right(_) =>
-                deliverySuccess += 1
-              case Left(InvalidToken(_, token, _, _)) =>
-                invalidTokens += 1
-                batchInvalidTokens += token
-              case Left(FailedRequest(_, _, _, _)) =>
-                failedRequest += 1
-              case Left(UnknownReasonFailedRequest(_, _)) =>
-                unknownReasonFailedRequest += 1
-              case _ => otherResponse += 1
-            }
-      case Left(BatchCallFailedRequest(_, _)) =>
-        catastrophicBatchSendResponse += 1
-      case _ => otherResponse += 1
-    }
-  }
 
   val dryRun = false
   val app: FirebaseApp = Mockito.mock[FirebaseApp]


### PR DESCRIPTION
To send Android notifications, the worker lambda sends requests to Firebase. A few years ago, Firebase introduced a multicast/batching API, allowing consumers to group multiple notifications into a single request. The team experimented to see if it would improve performance:

- https://github.com/guardian/mobile-n10n/pull/747

Some time later, Firebase dropped support for this API, and recommended using HTTP/2 instead. The team therefore switched back to sending requests individually, and removed much of the batching code:

- https://github.com/guardian/mobile-n10n/pull/1216
- https://github.com/guardian/mobile-n10n/pull/1235

There is still some unused code left over, so this change removes most of what remains.
