### PR TITLE
Filter out "League" from competition round string.

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -57,7 +57,7 @@ class MatchStatusLiveActivityPayloadBuilder {
       competition = Competition(
         id = matchInfo.competition.map(_.id).getOrElse(""),
         name = matchInfo.competition.map(_.name).getOrElse(""),
-        round = matchInfo.round.name // World Cup Group
+        round = matchInfo.round.name.filter(_ != "League") // Round includes world cup grouping, "semi-final" etc.
       ),
       commentary = matchInfo.comments,
       lineupsAvailable = matchInfo.lineupsAvailable,

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
@@ -36,6 +36,26 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
       contentState.articleUrl mustEqual Some("http://www.theguardian.com/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
       contentState.matchInfoUrl mustEqual "http://www.theguardian.com/football/match/some-match-id"
     }
+
+
+    "Filter out league round name" in new MatchEventsContext {
+      val result = builder.build(
+        baseGoal,
+        matchInfo.copy(round = Round("1", Some("League"))),
+        List.empty,
+        Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
+      )
+
+      result.eventType mustEqual UpdateLiveActivityEvent
+      result.liveActivityType mustEqual FootballLiveActivity
+      result.liveActivityID mustEqual "some-match-id"
+      result.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/".getBytes)
+
+      val contentState = result.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState]
+      contentState.competition.name mustEqual "FA Cup"
+      contentState.competition.round mustEqual None
+    }
+
   }
 
   trait MatchEventsContext extends Scope {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We don't want "League" appearing twice but we do want world cup grouping and general Round info (semi final, fina, play off, etc) appearing. This PR filters out this field if it's just a string matching "League"

<img width="323" height="151" alt="image" src="https://github.com/user-attachments/assets/d33cc86c-74ec-4d31-91c8-07416ba55d97" />
<img width="333" height="115" alt="image" src="https://github.com/user-attachments/assets/1ef63cfc-7024-4e98-aee4-2176b6c0f87a" />



<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
