### PR TITLE
TEST: Football EventConsumer synthetic event filtering

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
@@ -33,12 +33,12 @@ class EventConsumer(
         "start-live-activity",
         "end-live-activity",
         // additional synthetic match phase events for live activities
-        "extra-time-to-be-played",
-        "extra-time-first-half",
-        "extra-time-half-time",
-        "extra-time-second-half",
-        "penalties-to-be-played",
-        "penalties",
+//        "extra-time-to-be-played",
+//        "extra-time-first-half",
+//        "extra-time-half-time",
+//        "extra-time-second-half",
+//        "penalties-to-be-played",
+//        "penalties",
         "suspended",
         "resumed",
         "abandoned",
@@ -88,7 +88,20 @@ class LiveActivityEventConsumer(
   def eventsToLiveActivityPayload(
       matchData: MatchDataWithArticle
   ): List[LiveActivityPayload] = {
-    matchData.allEvents.flatMap { event =>
+
+    val footballOnlyEventTypes =
+      List(
+        // use end-broadcast instead
+        "full-time"
+      )
+
+    val filteredMatchData = matchData.copy(allEvents =
+      matchData.allEvents.filterNot(e =>
+        footballOnlyEventTypes.contains(e.eventType)
+      )
+    )
+
+    filteredMatchData.allEvents.flatMap { event =>
       processForLiveActivities(
         matchData.matchDay,
         matchData.allEvents,

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -2,6 +2,7 @@ package com.gu.mobile.notifications.football.notificationbuilders
 
 import com.gu.mobile.notifications.client.models.liveActitivites.{Competition, CreateChannelEvent, EndLiveActivityEvent, FootballLiveActivity, FootballMatchContentState, LiveActivityPayload, MatchStatus, StartLiveActivityEvent, TeamState, UpdateLiveActivityEvent}
 import com.gu.mobile.notifications.football.models._
+import org.slf4j.{Logger, LoggerFactory}
 import pa.MatchDay
 
 import java.net.URI
@@ -15,6 +16,8 @@ class MatchStatusLiveActivityPayloadBuilder {
       previousEvents: List[FootballMatchEvent],
       articleId: Option[String]
   ): LiveActivityPayload = {
+
+    val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
     val allEvents = triggeringEvent :: previousEvents
     val goals = allEvents.collect { case g: Goal => g }
@@ -31,6 +34,8 @@ class MatchStatusLiveActivityPayloadBuilder {
       case phase: MatchPhaseEvent => phase.currentMinute
       case _ => None
     }
+
+    logger.info(s"Building LiveActivityPayload for match ${matchInfo.id} with triggering event ${triggeringEvent.eventId}, Match status: ${matchInfo.matchStatus}")
 
     // TODO this is hard coded mostly for now.
     val contentState = FootballMatchContentState(

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -364,9 +364,9 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
       result must contain(beAnInstanceOf[FootballPenaltyShootoutPayload])
     }
 
-    "NOT generate notification payload for extra time match phase events" in new MatchEventsContext {
+    "NOT generate notification payload for abandoned match phase events" in new MatchEventsContext {
       override def matchDayLA: MatchDay =
-        super.matchDayLA.copy(date = ZonedDateTime.now(), matchStatus = "ETS")
+        super.matchDayLA.copy(date = ZonedDateTime.now(), matchStatus = "Abandoned")
 
       val result: List[NotificationPayload] =
         eventConsumer.eventsToNotifications(matchDataLA)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
