### PR TITLE
Log PA football `matchDay.result` and `matchStatus`

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -157,7 +157,7 @@ class FootballData(
 
   private def processMatch(matchDay: MatchDay): Future[Option[RawMatchData]] = {
     if (matchDay.result) // TODO: remove this logging once PA result/liveMatch behaviour is understood
-      logger.warn(s"Match ${matchDay.id} matchStatus=${matchDay.matchStatus} result=${matchDay.result} liveMatch=${matchDay.liveMatch}")
+      logger.info(s"[PA_RESULT_TRUE] matchId=${matchDay.id} | matchStatus=${matchDay.matchStatus} | result=${matchDay.result} | liveMatch=${matchDay.liveMatch}")
     val matchData = for {
       (matchDay, events) <- paClient.eventsForMatch(matchDay, syntheticEvents)
     } yield Some(RawMatchData(matchDay, events))

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -156,6 +156,8 @@ class FootballData(
   }
 
   private def processMatch(matchDay: MatchDay): Future[Option[RawMatchData]] = {
+    if (matchDay.result)
+      logger.info(s"Match ${matchDay.id} has matchDay.result=true, matchStatus=${matchDay.matchStatus}")
     val matchData = for {
       (matchDay, events) <- paClient.eventsForMatch(matchDay, syntheticEvents)
     } yield Some(RawMatchData(matchDay, events))

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -156,7 +156,7 @@ class FootballData(
   }
 
   private def processMatch(matchDay: MatchDay): Future[Option[RawMatchData]] = {
-    if (matchDay.result)
+    if (matchDay.result) // TODO: remove this logging once PA result/liveMatch behaviour is understood
       logger.warn(s"Match ${matchDay.id} matchStatus=${matchDay.matchStatus} result=${matchDay.result} liveMatch=${matchDay.liveMatch}")
     val matchData = for {
       (matchDay, events) <- paClient.eventsForMatch(matchDay, syntheticEvents)

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -157,7 +157,7 @@ class FootballData(
 
   private def processMatch(matchDay: MatchDay): Future[Option[RawMatchData]] = {
     if (matchDay.result)
-      logger.info(s"Match ${matchDay.id} has matchDay.result=true, matchStatus=${matchDay.matchStatus}")
+      logger.warn(s"Match ${matchDay.id} matchStatus=${matchDay.matchStatus} result=${matchDay.result} liveMatch=${matchDay.liveMatch}")
     val matchData = for {
       (matchDay, events) <- paClient.eventsForMatch(matchDay, syntheticEvents)
     } yield Some(RawMatchData(matchDay, events))


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
To test the suspicion that the `matchDay.result` boolean field in the PA football matchDay data gets set to true before the match is fully over (including the penalties), add logging for:
- matchStatus
- result
- liveWatch
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->


