### PR TITLE
Mj/fix delay in ko updates

### DIFF
--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/BroadcastApiClient.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/BroadcastApiClient.scala
@@ -43,7 +43,8 @@ class BroadcastApiClient(
       priority: Option[Int],
       broadcastPayload: BroadcastBody
   ): Future[String] = {
-    logger.info(s"Broadcasting to channel $channelId for match")
+    val defaultPriority = "1"
+    logger.info(s"Broadcasting to channel $channelId for match with priority ${priority.getOrElse(defaultPriority)}")
 
     val broadcastPayloadJson: String = Json.stringify(
       Json.toJson(broadcastPayload)(BroadcastBody.broadcastBodyFormat)
@@ -63,7 +64,7 @@ class BroadcastApiClient(
           .getEpochSecond
           .toString
       )
-      .header("apns-priority", priority.map(_.toString).getOrElse("1"))
+      .header("apns-priority", priority.map(_.toString).getOrElse(defaultPriority))
       .header("apns-push-type", "Liveactivity")
       .POST(HttpRequest.BodyPublishers.ofString(broadcastPayloadJson, charSet))
       .timeout(Duration.ofSeconds(60))

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/BroadcastService.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/BroadcastService.scala
@@ -49,7 +49,7 @@ class BroadcastService(repository: ChannelMappingsRepository, broadcastApiClient
 
           _ = logger.info(s"Sending broadcast for match ID $matchId to channel ID ${mapping.channelId}")
           broadcastPayload = BroadcastBody(contentState, shouldEndBroadcast)
-          _ <- broadcastApiClient.sendToChannel(mapping.channelId, None, None, broadcastPayload)
+          _ <- broadcastApiClient.sendToChannel(mapping.channelId, None, Some(10), broadcastPayload)
           _ = logger.info(s"Broadcast ${requestPayload.eventType.asString} sent successfully for match ID $matchId to channel ID ${mapping.channelId}")
 
           _ <- repository.updateMappingLiveAndLastEvent(matchId, isLive = !shouldEndBroadcast, Some(eventId), Some(eventTime))

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/BroadcastService.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/BroadcastService.scala
@@ -3,11 +3,7 @@ package com.gu.liveactivities.service
 import com.gu.liveactivities.models.{BroadcastBody, LiveActivityInvalidStateException}
 import com.gu.liveactivities.util.DateTimeHelper.{dateTimeFromLong, dateTimeToString}
 import com.gu.liveactivities.util.Logging
-import com.gu.mobile.notifications.client.models.liveActitivites.{
-  ContentState,
-  EndLiveActivityEvent,
-  LiveActivityPayload,
-}
+import com.gu.mobile.notifications.client.models.liveActitivites.{ContentState, EndLiveActivityEvent, FootballLiveActivity, LiveActivityPayload}
 
 import java.time.ZonedDateTime
 import scala.concurrent.{ExecutionContext, Future}
@@ -24,6 +20,7 @@ class BroadcastService(repository: ChannelMappingsRepository, broadcastApiClient
       // But we don't want to fail the lambda because it's expected that the source may continue
       // to send update events after a session has ended. Therefore, we treat these as expected no-ops.
       val broadcastNotAllowed = !shouldEndBroadcast && !mapping.isLive && mapping.lastEventId.isDefined
+      val priorityLevel = if (requestPayload.liveActivityType == FootballLiveActivity) Some(10) else None
 
       if (broadcastNotAllowed) {
         logger.warn(s"${requestPayload.eventType.asString} event ID $eventId not allowed after ${EndLiveActivityEvent.asString} for match ID $matchId")
@@ -49,7 +46,7 @@ class BroadcastService(repository: ChannelMappingsRepository, broadcastApiClient
 
           _ = logger.info(s"Sending broadcast for match ID $matchId to channel ID ${mapping.channelId}")
           broadcastPayload = BroadcastBody(contentState, shouldEndBroadcast)
-          _ <- broadcastApiClient.sendToChannel(mapping.channelId, None, Some(10), broadcastPayload)
+          _ <- broadcastApiClient.sendToChannel(mapping.channelId, None, priorityLevel, broadcastPayload)
           _ = logger.info(s"Broadcast ${requestPayload.eventType.asString} sent successfully for match ID $matchId to channel ID ${mapping.channelId}")
 
           _ <- repository.updateMappingLiveAndLastEvent(matchId, isLive = !shouldEndBroadcast, Some(eventId), Some(eventTime))


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Sets notification priority to 10 for football matches. Updates logging to include reference to priority integer.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to `CODE`, and tested manually using the Football Time Machine. Behaviour is now as desired, with football notifications coming through without delay.

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->
