### PR TITLE
Generate pre-match football push notifications

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -76,10 +76,9 @@ object Lambda extends Logging {
 
   def getZonedDateTime(): ZonedDateTime = {
     val zonedDateTime = if (configuration.stage == "CODE") {
-      // val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
-      // val json = Json.parse(Source.fromInputStream(is).mkString)
-      // ZonedDateTime.parse((json \ "currentDate").as[String])
-      ZonedDateTime.now()
+      val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
+      val json = Json.parse(Source.fromInputStream(is).mkString)
+      ZonedDateTime.parse((json \ "currentDate").as[String])
     } else {
       ZonedDateTime.now()
     }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -76,9 +76,10 @@ object Lambda extends Logging {
 
   def getZonedDateTime(): ZonedDateTime = {
     val zonedDateTime = if (configuration.stage == "CODE") {
-      val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
-      val json = Json.parse(Source.fromInputStream(is).mkString)
-      ZonedDateTime.parse((json \ "currentDate").as[String])
+      // val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
+      // val json = Json.parse(Source.fromInputStream(is).mkString)
+      // ZonedDateTime.parse((json \ "currentDate").as[String])
+      ZonedDateTime.now()
     } else {
       ZonedDateTime.now()
     }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -18,6 +18,15 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
 
   private type MatchEventGenerator = (MatchDay, List[pa.MatchEvent]) => Option[MatchEvent]
 
+  // generate a push notification 20 minutes before the scheduled kick off
+  private val preMatch: MatchEventGenerator = { (matchDay: MatchDay, _) =>
+    if (koWithin20Minutes(matchDay.date.toEpochSecond)) Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/pre-match".getBytes).toString),
+      eventType = "pre-match"
+    ))
+    else None
+  }
+
   private val fullTime: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
     if (matchDay.result) Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/full-time".getBytes).toString),
@@ -157,14 +166,6 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val preMatch: MatchEventGenerator = { (matchDay: MatchDay, _) =>
-    if (koWithin20Minutes(matchDay.date.toEpochSecond)) Some(emptyMatchEvent.copy(
-      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/pre-match".getBytes).toString),
-      eventType = "pre-match"
-    ))
-    else None
-  }
-
   // Note: matches may be abandoned after kick off with no result, in which case rely on "stale-date" to end the activity (4hrs)
   // todo: add end conditions for Abandoned and cancelled?
   private val endLiveActivity: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
@@ -176,6 +177,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
   }
 
   private val generators: List[MatchEventGenerator] = List(
+    preMatch,
     fullTime,
     halfTime,
     secondHalf,
@@ -192,7 +194,6 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     cancelled,
     createChannel,
     startLiveActivity,
-    preMatch,
     endLiveActivity)
 
   private def emptyMatchEvent = MatchEvent(

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -157,6 +157,14 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
+  private val preMatch: MatchEventGenerator = { (matchDay: MatchDay, _) =>
+    if (koWithin20Minutes(matchDay.date.toEpochSecond)) Some(emptyMatchEvent.copy(
+      id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/pre-match".getBytes).toString),
+      eventType = "pre-match"
+    ))
+    else None
+  }
+
   // Note: matches may be abandoned after kick off with no result, in which case rely on "stale-date" to end the activity (4hrs)
   // todo: add end conditions for Abandoned and cancelled?
   private val endLiveActivity: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
@@ -184,6 +192,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     cancelled,
     createChannel,
     startLiveActivity,
+    preMatch,
     endLiveActivity)
 
   private def emptyMatchEvent = MatchEvent(

--- a/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
@@ -204,6 +204,7 @@ object MatchPhaseEvent {
   }
 }
 
+case class PreMatch(eventId: String) extends MatchPhaseEvent
 case class KickOff(eventId: String) extends MatchPhaseEvent
 case class FullTime(eventId: String) extends MatchPhaseEvent
 case class HalfTime(eventId: String) extends MatchPhaseEvent
@@ -221,7 +222,6 @@ case class Abandoned(eventId: String) extends MatchPhaseEvent
 case class Postponed(eventId: String) extends MatchPhaseEvent
 case class Cancelled(eventId: String) extends MatchPhaseEvent
 
-case class PreMatch(eventId: String) extends MatchPhaseEvent
 
 // Live Activity phase events
 case class CreateChannel(eventId: String) extends MatchPhaseEvent

--- a/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
@@ -222,7 +222,6 @@ case class Abandoned(eventId: String) extends MatchPhaseEvent
 case class Postponed(eventId: String) extends MatchPhaseEvent
 case class Cancelled(eventId: String) extends MatchPhaseEvent
 
-
 // Live Activity phase events
 case class CreateChannel(eventId: String) extends MatchPhaseEvent
 case class StartLiveActivity(eventId: String) extends MatchPhaseEvent

--- a/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
@@ -181,6 +181,7 @@ object MatchPhaseEvent {
     val eventId = event.id.getOrElse("")
     condOpt(event.eventType) {
       case "timeline" if event.matchTime.contains("0:00") => KickOff(eventId)
+      case "pre-match"                                    => PreMatch(eventId)
       case "full-time"                                    => FullTime(eventId)
       case "half-time"                                    => HalfTime(eventId)
       case "second-half"                                  => SecondHalf(eventId)
@@ -195,7 +196,6 @@ object MatchPhaseEvent {
       case "abandoned"                                    => Abandoned(eventId)
       case "postponed"                                    => Postponed(eventId)
       case "cancelled"                                    => Cancelled(eventId)
-      case "pre-match"                                    => PreMatch(eventId)
       case "create-channel"                               => CreateChannel(eventId)
       case "start-live-activity"                          => StartLiveActivity(eventId)
       case "end-live-activity"                            => EndLiveActivity(eventId)

--- a/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
@@ -195,6 +195,7 @@ object MatchPhaseEvent {
       case "abandoned"                                    => Abandoned(eventId)
       case "postponed"                                    => Postponed(eventId)
       case "cancelled"                                    => Cancelled(eventId)
+      case "pre-match"                                    => PreMatch(eventId)
       case "create-channel"                               => CreateChannel(eventId)
       case "start-live-activity"                          => StartLiveActivity(eventId)
       case "end-live-activity"                            => EndLiveActivity(eventId)
@@ -219,6 +220,8 @@ case class Resumed(eventId: String) extends MatchPhaseEvent
 case class Abandoned(eventId: String) extends MatchPhaseEvent
 case class Postponed(eventId: String) extends MatchPhaseEvent
 case class Cancelled(eventId: String) extends MatchPhaseEvent
+
+case class PreMatch(eventId: String) extends MatchPhaseEvent
 
 // Live Activity phase events
 case class CreateChannel(eventId: String) extends MatchPhaseEvent

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -42,7 +42,7 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
     val penaltyShootoutScore = PenaltyShootoutScore.fromPenaltyShootoutKicks(matchInfo.homeTeam, matchInfo.awayTeam, penaltyShootoutKicks)
 
     val status = triggeringEvent match {
-      case _: PreMatch => "PRE_MATCH"
+      case _: PreMatch => "Pre" // show "Pre" instead of "1st" on old Android clients (3 char limit)
       case _ => statuses.getOrElse(matchInfo.matchStatus, matchInfo.matchStatus)
     }
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -70,10 +70,10 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
           importance = importance(triggeringEvent),
           topic = topics,
           matchStatus = status,
+          detailedMatchStatus = Some("PENALTIES"),
           eventId = UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
           kickOffTimestamp = Some(matchInfo.date.toEpochSecond),
           lineupsAvailable = Some(matchInfo.lineupsAvailable),
-          detailedMatchStatus = Some("PENALTIES"),
           debug = false,
           dryRun = None
         )
@@ -101,10 +101,10 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
           importance = importance(triggeringEvent),
           topic = topics,
           matchStatus = status,
+          detailedMatchStatus = Some(MatchStatus.fromString(matchInfo.matchStatus).status),
           eventId = UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
           kickOffTimestamp = Some(matchInfo.date.toEpochSecond),
           lineupsAvailable = Some(matchInfo.lineupsAvailable),
-          detailedMatchStatus = Some(MatchStatus.fromString(matchInfo.matchStatus).status),
           debug = false,
           dryRun = None
         )

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import com.gu.mobile.notifications.client.models.Importance.{Importance, Major, Minor}
 import com.gu.mobile.notifications.client.models._
 import com.gu.mobile.notifications.client.models.liveActitivites.MatchStatus
-import com.gu.mobile.notifications.football.models.{Dismissal, FootballMatchEvent, FullTime, Goal, HalfTime, KickOff, PenaltyShootoutKick, PenaltyShootoutScore, RedCards, Score, SecondHalf}
+import com.gu.mobile.notifications.football.models.{Dismissal, FootballMatchEvent, FullTime, Goal, HalfTime, KickOff, PenaltyShootoutKick, PenaltyShootoutScore, PreMatch, RedCards, Score, SecondHalf}
 import pa.{MatchDay, MatchDayTeam}
 
 import scala.PartialFunction.condOpt
@@ -194,6 +194,7 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
     case FullTime(_) => "Full-Time"
     case _:Dismissal => "Red card"
     case _:PenaltyShootoutKick  => "Penalty Kick" // needed for spec. We are filtering these out in the EventConsumer for now.
+    case _:PreMatch => "Kick-off starting soon"
     case _ => "The Guardian"
   }
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -178,10 +178,10 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
          |${dismissal.playerName} (${dismissal.team.name}) ${dismissal.minute}min$extraInfo""".stripMargin
     }
 
-
     triggeringEvent match {
       case g: Goal => goalMsg(g)
       case dismissal: Dismissal => dismissalMsg(dismissal)
+      case prematch: PreMatch => s"""${homeTeamName} v ${awayTeamName}"""
       case _ => s"""${homeTeamName} ${score.home}-${score.away} ${awayTeamName} ($matchStatus)"""
     }
   }
@@ -193,8 +193,8 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
     case SecondHalf(_) => "Second-half start"
     case FullTime(_) => "Full-Time"
     case _:Dismissal => "Red card"
-    case _:PenaltyShootoutKick  => "Penalty Kick" // needed for spec. We are filtering these out in the EventConsumer for now.
-    case _:PreMatch => "Kick-off starting soon"
+    case _:PenaltyShootoutKick  => "Penalty Kick"
+    case _:PreMatch => "Kick off starting soon"
     case _ => "The Guardian"
   }
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -41,10 +41,7 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
     val penaltyShootoutKicks = allEvents.collect { case psr: PenaltyShootoutKick => psr }
     val penaltyShootoutScore = PenaltyShootoutScore.fromPenaltyShootoutKicks(matchInfo.homeTeam, matchInfo.awayTeam, penaltyShootoutKicks)
 
-    val status = triggeringEvent match {
-      case _: PreMatch => "Pre" // show "Pre" instead of "1st" on old Android clients (3 char limit)
-      case _ => statuses.getOrElse(matchInfo.matchStatus, matchInfo.matchStatus)
-    }
+    val status = statuses.getOrElse(matchInfo.matchStatus, matchInfo.matchStatus)
 
     triggeringEvent match {
       case _: PenaltyShootoutKick =>
@@ -197,7 +194,7 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
     case FullTime(_) => "Full-Time"
     case _:Dismissal => "Red card"
     case _:PenaltyShootoutKick  => "Penalty Kick"
-    case _:PreMatch => "Kick off starting soon"
+    case _:PreMatch => "Kick off soon"
     case _ => "The Guardian"
   }
 
@@ -230,8 +227,8 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
 
     ("Suspended", "S"), // Match has been Suspended.
 
-    ("Fixture", "1st"), // fixture maps to 1st just in case the matchInfo and event feed are out of sync
-    ("-", "1st"), // same as above
+    ("Fixture", "Pre"), // pre-match fixture
+    ("-", "Pre"), // same as above
 
     // don't really expect to see these (the way we handle data)
     ("Resumed", "R"), // Match has been Resumed.

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -41,7 +41,10 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
     val penaltyShootoutKicks = allEvents.collect { case psr: PenaltyShootoutKick => psr }
     val penaltyShootoutScore = PenaltyShootoutScore.fromPenaltyShootoutKicks(matchInfo.homeTeam, matchInfo.awayTeam, penaltyShootoutKicks)
 
-    val status = statuses.getOrElse(matchInfo.matchStatus, matchInfo.matchStatus)
+    val status = triggeringEvent match {
+      case _: PreMatch => "PRE_MATCH"
+      case _ => statuses.getOrElse(matchInfo.matchStatus, matchInfo.matchStatus)
+    }
 
     triggeringEvent match {
       case _: PenaltyShootoutKick =>

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
@@ -142,7 +142,7 @@ class SyntheticMatchEventGeneratorSpec extends Specification {
 
     "Add a startLiveActivity event if match kick off is within 20min" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusMinutes(15))).head.eventType mustEqual "start-live-activity"
+      generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusMinutes(15))).map(_.eventType) must contain("start-live-activity")
     }
 
     "Add id to first timeline event" in new TestScope {

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
@@ -154,5 +154,11 @@ class SyntheticMatchEventGeneratorSpec extends Specification {
       val generator = new SyntheticMatchEventGenerator(currentTime)
       generator.generate(List(timelineEvent), "match-id", matchInfo.copy(result = true, liveMatch = false)).reverse.head.eventType mustEqual "end-live-activity"
     }
+
+    "Add a pre-match event if match kick off is within 20min" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator(currentTime)
+      val events = generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusMinutes(15)))
+      events.map(_.eventType) must contain("pre-match")
+    }
   }
 }

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -134,8 +134,8 @@ class MatchStatusNotificationBuilderSpec extends Specification {
     "Use 'Kick-off starting soon' as title and message for a pre-match event" in new MatchEventsContext {
       val preMatch = PreMatch("pre-match-event-id")
       val notification = builder.build(preMatch, matchInfo, List.empty, None).asInstanceOf[FootballMatchStatusPayload]
-      notification.title shouldEqual Some("Kick-off starting soon")
-      notification.message shouldEqual Some("Liverpool v Plymouth\nKick-off starting soon")
+      notification.title shouldEqual Some("Kick off starting soon")
+      notification.message shouldEqual Some("Liverpool v Plymouth")
     }
   }
 

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -131,10 +131,11 @@ class MatchStatusNotificationBuilderSpec extends Specification {
       notification must not(beAnInstanceOf[FootballPenaltyShootoutPayload])
     }
 
-    "Use 'Kick-off starting soon' as title for a pre-match event" in new MatchEventsContext {
+    "Use 'Kick-off starting soon' as title and message for a pre-match event" in new MatchEventsContext {
       val preMatch = PreMatch("pre-match-event-id")
       val notification = builder.build(preMatch, matchInfo, List.empty, None).asInstanceOf[FootballMatchStatusPayload]
       notification.title shouldEqual Some("Kick-off starting soon")
+      notification.message shouldEqual Some("Liverpool v Plymouth\nKick-off starting soon")
     }
   }
 

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -136,6 +136,7 @@ class MatchStatusNotificationBuilderSpec extends Specification {
       val notification = builder.build(preMatch, matchInfo, List.empty, None).asInstanceOf[FootballMatchStatusPayload]
       notification.title shouldEqual Some("Kick off starting soon")
       notification.message shouldEqual Some("Liverpool v Plymouth")
+      notification.matchStatus shouldEqual "PRE_MATCH"
     }
   }
 

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -136,7 +136,7 @@ class MatchStatusNotificationBuilderSpec extends Specification {
       val notification = builder.build(preMatch, matchInfo, List.empty, None).asInstanceOf[FootballMatchStatusPayload]
       notification.title shouldEqual Some("Kick off starting soon")
       notification.message shouldEqual Some("Liverpool v Plymouth")
-      notification.matchStatus shouldEqual "PRE_MATCH"
+      notification.matchStatus shouldEqual "Pre"
     }
   }
 

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -7,7 +7,7 @@ import java.util.UUID
 import com.gu.mobile.notifications.client.models.Importance.{Major, Minor}
 import com.gu.mobile.notifications.client.models._
 import com.gu.mobile.notifications.football.lib.SyntheticMatchEventGenerator
-import com.gu.mobile.notifications.football.models.{Dismissal, FootballMatchEvent, FullTime, Goal, GoalContext, KickOff, PenaltyShootoutKick, Score}
+import com.gu.mobile.notifications.football.models.{Dismissal, FootballMatchEvent, FullTime, Goal, GoalContext, KickOff, PenaltyShootoutKick, PreMatch, Score}
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import pa.{Competition, MatchDay, MatchDayTeam, Parser, Round, Stage, Venue}
@@ -129,6 +129,12 @@ class MatchStatusNotificationBuilderSpec extends Specification {
       val dismissal = Dismissal("e2", "Player B", home, 80, None)
       val notification = builder.build(baseGoal, matchInfo, List(dismissal), None)
       notification must not(beAnInstanceOf[FootballPenaltyShootoutPayload])
+    }
+
+    "Use 'Kick-off starting soon' as title for a pre-match event" in new MatchEventsContext {
+      val preMatch = PreMatch("pre-match-event-id")
+      val notification = builder.build(preMatch, matchInfo, List.empty, None).asInstanceOf[FootballMatchStatusPayload]
+      notification.title shouldEqual Some("Kick-off starting soon")
     }
   }
 

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -131,11 +131,22 @@ class MatchStatusNotificationBuilderSpec extends Specification {
       notification must not(beAnInstanceOf[FootballPenaltyShootoutPayload])
     }
 
-    "Use 'Kick-off starting soon' as title and message for a pre-match event" in new MatchEventsContext {
+    "Show the correct title and message for the pre-match notifcation" in new MatchEventsContext {
       val preMatch = PreMatch("pre-match-event-id")
-      val notification = builder.build(preMatch, matchInfo, List.empty, None).asInstanceOf[FootballMatchStatusPayload]
-      notification.title shouldEqual Some("Kick off starting soon")
+      val notification = builder.build(preMatch, matchInfo.copy(matchStatus = "Fixture"), List.empty, None).asInstanceOf[FootballMatchStatusPayload]
+      notification.title shouldEqual Some("Kick off soon")
       notification.message shouldEqual Some("Liverpool v Plymouth")
+    }
+
+    "Override the payload matchStatus to be 'Pre' when PA's match status is 'Fixture'" in new MatchEventsContext {
+      val preMatch = PreMatch("pre-match-event-id")
+      val notification = builder.build(preMatch, matchInfo.copy(matchStatus = "Fixture"), List.empty, None).asInstanceOf[FootballMatchStatusPayload]
+      notification.matchStatus shouldEqual "Pre"
+    }
+
+    "Override the payload matchStatus to be 'Pre' when PA matchStatus is '-'" in new MatchEventsContext {
+      val preMatch = PreMatch("pre-match-event-id")
+      val notification = builder.build(preMatch, matchInfo.copy(matchStatus = "-"), List.empty, None).asInstanceOf[FootballMatchStatusPayload]
       notification.matchStatus shouldEqual "Pre"
     }
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- Generate a push notification 20 minutes before a match kick off using the existing `koWithin20Minutes` helper
- Android builds which have the latest live updates beta will display the kick off information
- Old Android builds with the old notifications UI will display "Pre" as the match status

## How has this change been tested?
Deployed to football CODE and used football time machine and tested that around 20 minutes before a match kick off, a push notification is received to indicate the kick off starting soon
- [x] Android latest beta
- [x] iOS push notifications
- [x] Android older builds

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?
prematch push notifications are sent correctly
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
- Tested

## Images
Android with latest live updates UI (displays kick off time in the prematch specific UI)
<img width="300" alt="Screenshot_20260609_162644" src="https://github.com/user-attachments/assets/46f4da49-f95d-4b85-9c55-22fd81f4017c" />

Android with old UI (shows "Pre" as the match status since it doesn't have prematch specific UI)
<img width="300" alt="Screenshot_20260609_165932" src="https://github.com/user-attachments/assets/30b05922-441f-40c6-8130-a38369771cf7" />

