### PR TITLE
Fix fulltime match status for updates

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
@@ -70,12 +70,12 @@ object MatchStatus {
     ("ETS", ExtraTimeFirstHalf), // Extra Time has Started.
     ("ETHT", ExtraTimeHalfTime), // Extra Time Half Time has been called.
     ("ETSHS", ExtraTimeSecondHalf), // Extra Time, Second Half has Started.
-    ("ETFT", ExtraTimeSecondHalf), // Extra Time, Full Time has been blown.
+    ("ETFT", FullTime), // Extra Time, Full Time has been blown.
 
     ("FTPT", PenaltiesToBePlayed), // Full Time, Penalties are To be played.
     ("ETFTPT", PenaltiesToBePlayed), // Extra Time, Full Time, Penalties are To be played.
     ("PT", Penalties), // Penalty ShooT Out has started.
-    ("PTFT", Penalties), // Penalty ShooT Full Time.
+    ("PTFT", FullTime), // Penalty ShooT Full Time.
 
     // edge cases
     ("Suspended", Suspended), // Match has been Suspended.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Per an email from PA, these three status indicate full time right before a match is considered completed: FT, ETFT, PTFT.

Updates the status mappings we are sending to the app to reflect this. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
