### PR TITLE
Simplify creation of penalty score push notification payloads in Football Lamba

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/Payloads.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/Payloads.scala
@@ -101,7 +101,6 @@ object NotificationPayload {
       case n: BreakingNewsPayload => BreakingNewsPayload.jf.writes(n)
       case n: ContentAlertPayload => ContentAlertPayload.jf.writes(n)
       case n: FootballMatchStatusPayload => FootballMatchStatusPayload.jf.writes(n)
-      case n: FootballPenaltyShootoutPayload => FootballPenaltyShootoutPayload.jf.writes(n)
     }
   }
 }
@@ -166,75 +165,7 @@ case class ContentAlertPayload(
 object FootballMatchStatusPayload {
   implicit val jf: Writes[FootballMatchStatusPayload] = (o: FootballMatchStatusPayload) => Json.obj(
     "id" -> o.id,
-    "type" -> FootballMatchStatus.toString,
-    "title" -> o.title,
-    "message" -> o.message,
-    "thumbnailUrl" -> o.thumbnailUrl,
-    "sender" -> o.sender,
-    "awayTeamName" -> o.awayTeamName,
-    "awayTeamScore" -> o.awayTeamScore,
-    "awayTeamMessage" -> o.awayTeamMessage,
-    "awayTeamId" -> o.awayTeamId,
-    "awayTeamRedCards" -> o.awayTeamRedCards,
-    "homeTeamName" -> o.homeTeamName,
-    "homeTeamScore" -> o.homeTeamScore,
-    "homeTeamMessage" -> o.homeTeamMessage,
-    "homeTeamId" -> o.homeTeamId,
-    "homeTeamRedCards" -> o.homeTeamRedCards,
-    "competitionName" -> o.competitionName,
-    "roundName" -> o.roundName,
-    "venue" -> o.venue,
-    "matchId" -> o.matchId,
-    "matchInfoUri" -> o.matchInfoUri,
-    "articleUri" -> o.articleUri,
-    "importance" -> o.importance,
-    "topic" -> o.topic,
-    "matchStatus" -> o.matchStatus,
-    "eventId" -> o.eventId,
-    "kickOffTimestamp" -> o.kickOffTimestamp,
-    "lineupsAvailable" -> o.lineupsAvailable,
-    "detailedMatchStatus" -> o.detailedMatchStatus,
-    "debug" -> o.debug
-  )
-}
-case class FootballMatchStatusPayload(
-  title: Option[String],
-  message: Option[String],
-  thumbnailUrl: Option[URI] = None,
-  sender: String,
-  awayTeamName: String,
-  awayTeamScore: Int,
-  awayTeamMessage: String,
-  awayTeamId: String,
-  awayTeamRedCards: Int = 0,
-  homeTeamName: String,
-  homeTeamScore: Int,
-  homeTeamMessage: String,
-  homeTeamId: String,
-  homeTeamRedCards: Int = 0,
-  competitionName: Option[String],
-  roundName: Option[String] = None,
-  venue: Option[String],
-  matchId: String,
-  matchInfoUri: URI,
-  articleUri: Option[URI],
-  importance: Importance,
-  topic: List[Topic],
-  matchStatus: String,
-  eventId: String,
-  kickOffTimestamp: Option[Long] = None,
-  lineupsAvailable: Option[Boolean] = None,
-  detailedMatchStatus: Option[String] = None,
-  debug: Boolean,
-  dryRun: Option[Boolean]
-) extends NotificationPayload with derivedId {
-  val `type` = FootballMatchStatus
-  override val derivedId = s"football-match-status/$matchId/$eventId"
-}
-object FootballPenaltyShootoutPayload {
-  implicit val jf: Writes[FootballPenaltyShootoutPayload] = (o: FootballPenaltyShootoutPayload) => Json.obj(
-    "id" -> o.id,
-    "type" -> FootballPenaltyShootout.toString,
+    "type" -> o.`type`.toString,
     "title" -> o.title,
     "message" -> o.message,
     "thumbnailUrl" -> o.thumbnailUrl,
@@ -267,7 +198,7 @@ object FootballPenaltyShootoutPayload {
     "debug" -> o.debug
   )
 }
-case class FootballPenaltyShootoutPayload(
+case class FootballMatchStatusPayload(
   title: Option[String],
   message: Option[String],
   thumbnailUrl: Option[URI] = None,
@@ -300,8 +231,9 @@ case class FootballPenaltyShootoutPayload(
   debug: Boolean,
   dryRun: Option[Boolean]
 ) extends NotificationPayload with derivedId {
-  val `type` = FootballPenaltyShootout
-  override val derivedId = s"football-penalty-shootout/$matchId/$eventId"
+  private val hasPenalties = homeTeamPenalties.isDefined || awayTeamPenalties.isDefined
+  val `type` = if (hasPenalties) FootballPenaltyShootout else FootballMatchStatus
+  override val derivedId = if (hasPenalties) s"football-penalty-shootout/$matchId/$eventId" else s"football-match-status/$matchId/$eventId"
 }
 
 trait derivedId {

--- a/common/src/main/scala/models/Notification.scala
+++ b/common/src/main/scala/models/Notification.scala
@@ -126,7 +126,7 @@ object ContentNotification {
   implicit val jf: OFormat[ContentNotification] = Json.format[ContentNotification]
 }
 
-
+// Duplicates live activities PenaltyShootoutState in common api-models
 case class PenaltyScore(scored: Int = 0, missed: Int = 0, saved: Int = 0)
 object PenaltyScore {
   implicit val jf: OFormat[PenaltyScore] = Json.format[PenaltyScore]

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -43,72 +43,41 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
 
     val status = statuses.getOrElse(matchInfo.matchStatus, matchInfo.matchStatus)
 
-    triggeringEvent match {
-      case _: PenaltyShootoutKick =>
-        FootballPenaltyShootoutPayload(
-          title = Some(eventTitle(triggeringEvent)),
-          message = Some(mainMessage(triggeringEvent, transformTeamName(matchInfo.homeTeam.name), transformTeamName(matchInfo.awayTeam.name), score, status)),
-          sender = "mobile-notifications-football-lambda",
-          awayTeamName = transformTeamName(matchInfo.awayTeam.name),
-          awayTeamScore = score.away,
-          awayTeamMessage = teamMessage(matchInfo.awayTeam, allEvents),
-          awayTeamId = matchInfo.awayTeam.id,
-          awayTeamRedCards = redCards.away,
-          awayTeamPenalties = PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, isHomeTeam = false),
-          homeTeamName = transformTeamName(matchInfo.homeTeam.name),
-          homeTeamScore = score.home,
-          homeTeamMessage = teamMessage(matchInfo.homeTeam, allEvents),
-          homeTeamId = matchInfo.homeTeam.id,
-          homeTeamRedCards = redCards.home,
-          homeTeamPenalties = PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, isHomeTeam = true),
-          competitionName = matchInfo.competition.map(_.name),
-          roundName = matchInfo.round.name,
-          venue = matchInfo.venue.map(_.name).filter(_.nonEmpty),
-          matchId = matchInfo.id,
-          matchInfoUri = new URI(s"$mapiHost/sport/football/matches/${matchInfo.id}"),
-          articleUri = articleId.map(id => new URI(s"$mapiHost/items/$id")),
-          importance = importance(triggeringEvent),
-          topic = topics,
-          matchStatus = status,
-          eventId = UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
-          kickOffTimestamp = Some(matchInfo.date.toEpochSecond),
-          lineupsAvailable = Some(matchInfo.lineupsAvailable),
-          detailedMatchStatus = Some("PENALTIES"),
-          debug = false,
-          dryRun = None
-        )
-      case _ =>
-        FootballMatchStatusPayload(
-          title = Some(eventTitle(triggeringEvent)),
-          message = Some(mainMessage(triggeringEvent, transformTeamName(matchInfo.homeTeam.name), transformTeamName(matchInfo.awayTeam.name), score, status)),
-          sender = "mobile-notifications-football-lambda",
-          awayTeamName = transformTeamName(matchInfo.awayTeam.name),
-          awayTeamScore = score.away,
-          awayTeamMessage = teamMessage(matchInfo.awayTeam, allEvents),
-          awayTeamId = matchInfo.awayTeam.id,
-          awayTeamRedCards = redCards.away,
-          homeTeamName = transformTeamName(matchInfo.homeTeam.name),
-          homeTeamScore = score.home,
-          homeTeamMessage = teamMessage(matchInfo.homeTeam, allEvents),
-          homeTeamId = matchInfo.homeTeam.id,
-          homeTeamRedCards = redCards.home,
-          competitionName = matchInfo.competition.map(_.name),
-          roundName = matchInfo.round.name,
-          venue = matchInfo.venue.map(_.name).filter(_.nonEmpty),
-          matchId = matchInfo.id,
-          matchInfoUri = new URI(s"$mapiHost/sport/football/matches/${matchInfo.id}"),
-          articleUri = articleId.map(id => new URI(s"$mapiHost/items/$id")),
-          importance = importance(triggeringEvent),
-          topic = topics,
-          matchStatus = status,
-          eventId = UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
-          kickOffTimestamp = Some(matchInfo.date.toEpochSecond),
-          lineupsAvailable = Some(matchInfo.lineupsAvailable),
-          detailedMatchStatus = Some(MatchStatus.fromString(matchInfo.matchStatus).status),
-          debug = false,
-          dryRun = None
-        )
-    }
+    val footballPayload =
+      FootballMatchStatusPayload(
+      title = Some(eventTitle(triggeringEvent)),
+      message = Some(mainMessage(triggeringEvent, transformTeamName(matchInfo.homeTeam.name), transformTeamName(matchInfo.awayTeam.name), score, status)),
+      sender = "mobile-notifications-football-lambda",
+      awayTeamName = transformTeamName(matchInfo.awayTeam.name),
+      awayTeamScore = score.away,
+      awayTeamMessage = teamMessage(matchInfo.awayTeam, allEvents),
+      awayTeamId = matchInfo.awayTeam.id,
+      awayTeamRedCards = redCards.away,
+        awayTeamPenalties =  PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, isHomeTeam = false),
+      homeTeamName = transformTeamName(matchInfo.homeTeam.name),
+      homeTeamScore = score.home,
+      homeTeamMessage = teamMessage(matchInfo.homeTeam, allEvents),
+      homeTeamId = matchInfo.homeTeam.id,
+      homeTeamRedCards = redCards.home,
+        homeTeamPenalties = PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, isHomeTeam = true),
+      competitionName = matchInfo.competition.map(_.name),
+      roundName = matchInfo.round.name,
+      venue = matchInfo.venue.map(_.name).filter(_.nonEmpty),
+      matchId = matchInfo.id,
+      matchInfoUri = new URI(s"$mapiHost/sport/football/matches/${matchInfo.id}"),
+      articleUri = articleId.map(id => new URI(s"$mapiHost/items/$id")),
+      importance = importance(triggeringEvent),
+      topic = topics,
+      matchStatus = status,
+      detailedMatchStatus = if (penaltyShootoutScore.isDefined) Some("PENALTIES") else Some(MatchStatus.fromString(matchInfo.matchStatus).status),
+      eventId = UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
+      kickOffTimestamp = Some(matchInfo.date.toEpochSecond),
+      lineupsAvailable = Some(matchInfo.lineupsAvailable),
+      debug = false,
+      dryRun = None
+    )
+
+     footballPayload
   }
 
   def transformTeamName(name: String): String = name.replace(" Ladies", "")
@@ -178,7 +147,6 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
          |${dismissal.playerName} (${dismissal.team.name}) ${dismissal.minute}min$extraInfo""".stripMargin
     }
 
-
     triggeringEvent match {
       case g: Goal => goalMsg(g)
       case dismissal: Dismissal => dismissalMsg(dismissal)
@@ -193,7 +161,7 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
     case SecondHalf(_) => "Second-half start"
     case FullTime(_) => "Full-Time"
     case _:Dismissal => "Red card"
-    case _:PenaltyShootoutKick  => "Penalty Kick" // needed for spec. We are filtering these out in the EventConsumer for now.
+    case _:PenaltyShootoutKick  => "Penalty Kick"
     case _ => "The Guardian"
   }
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -41,7 +41,8 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
 
     val status = statuses.getOrElse(matchInfo.matchStatus, matchInfo.matchStatus)
 
-   val footballPayload =   FootballMatchStatusPayload(
+   val footballPayload =
+     FootballMatchStatusPayload(
      title = Some(eventTitle(triggeringEvent)),
      message = Some(mainMessage(triggeringEvent, transformTeamName(matchInfo.homeTeam.name), transformTeamName(matchInfo.awayTeam.name), score, status)),
      sender = "mobile-notifications-football-lambda",
@@ -50,11 +51,13 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
      awayTeamMessage = teamMessage(matchInfo.awayTeam, allEvents),
      awayTeamId = matchInfo.awayTeam.id,
      awayTeamRedCards = redCards.away,
+     awayTeamPenalties =  PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, isHomeTeam = false),
      homeTeamName = transformTeamName(matchInfo.homeTeam.name),
      homeTeamScore = score.home,
      homeTeamMessage = teamMessage(matchInfo.homeTeam, allEvents),
      homeTeamId = matchInfo.homeTeam.id,
      homeTeamRedCards = redCards.home,
+     homeTeamPenalties = PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, isHomeTeam = true),
      competitionName = matchInfo.competition.map(_.name),
      roundName = matchInfo.round.name,
      venue = matchInfo.venue.map(_.name).filter(_.nonEmpty),
@@ -64,49 +67,15 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
      importance = importance(triggeringEvent),
      topic = topics,
      matchStatus = status,
+     detailedMatchStatus = if (penaltyShootoutScore.isDefined) Some("PENALTIES") else Some(MatchStatus.fromString(matchInfo.matchStatus).status),
      eventId = UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
      kickOffTimestamp = Some(matchInfo.date.toEpochSecond),
      lineupsAvailable = Some(matchInfo.lineupsAvailable),
-     detailedMatchStatus = Some(MatchStatus.fromString(matchInfo.matchStatus).status),
      debug = false,
      dryRun = None
    )
 
     triggeringEvent match {
-      case _: PenaltyShootoutKick =>
-        // todo reuse the football payload and pattern match on `type` in notifications service?
-        FootballPenaltyShootoutPayload(
-          title = Some(eventTitle(triggeringEvent)),
-          message = Some(mainMessage(triggeringEvent, transformTeamName(matchInfo.homeTeam.name), transformTeamName(matchInfo.awayTeam.name), score, status)),
-          sender = "mobile-notifications-football-lambda",
-          awayTeamName = transformTeamName(matchInfo.awayTeam.name),
-          awayTeamScore = score.away,
-          awayTeamMessage = teamMessage(matchInfo.awayTeam, allEvents),
-          awayTeamId = matchInfo.awayTeam.id,
-          awayTeamRedCards = redCards.away,
-          awayTeamPenalties = PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, isHomeTeam = false),
-          homeTeamName = transformTeamName(matchInfo.homeTeam.name),
-          homeTeamScore = score.home,
-          homeTeamMessage = teamMessage(matchInfo.homeTeam, allEvents),
-          homeTeamId = matchInfo.homeTeam.id,
-          homeTeamRedCards = redCards.home,
-          homeTeamPenalties = PenaltyShootoutScore.toPenaltyShootoutState(penaltyShootoutScore, isHomeTeam = true),
-          competitionName = matchInfo.competition.map(_.name),
-          roundName = matchInfo.round.name,
-          venue = matchInfo.venue.map(_.name).filter(_.nonEmpty),
-          matchId = matchInfo.id,
-          matchInfoUri = new URI(s"$mapiHost/sport/football/matches/${matchInfo.id}"),
-          articleUri = articleId.map(id => new URI(s"$mapiHost/items/$id")),
-          importance = importance(triggeringEvent),
-          topic = topics,
-          matchStatus = status,
-          detailedMatchStatus = Some("PENALTIES"),
-          eventId = UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
-          kickOffTimestamp = Some(matchInfo.date.toEpochSecond),
-          lineupsAvailable = Some(matchInfo.lineupsAvailable),
-          debug = false,
-          dryRun = None
-        )
       case _: StartLiveActivity => footballPayload.copy(
         title =  Some(s"""${matchInfo.homeTeam.name} v ${matchInfo.awayTeam.name}"""),
         message = Some("Tap to enable live updates"),

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -3,21 +3,11 @@ package com.gu.mobile.notifications.football.lib
 import java.net.URI
 import com.gu.mobile.notifications.client.models.{liveActitivites, _}
 import com.gu.mobile.notifications.client.models.Importance.{Major, Minor}
-import com.gu.mobile.notifications.client.models.TopicTypes.{
-  FootballMatch,
-  FootballTeam,
-  FootballTeamLiveActivity,
-  FootballMatchLiveActivity
-}
-import com.gu.mobile.notifications.football.models.{
-  MatchDataWithArticle,
-  PenaltyShootoutKick
-}
+import com.gu.mobile.notifications.client.models.NotificationPayloadType.FootballPenaltyShootout
+import com.gu.mobile.notifications.client.models.TopicTypes.{FootballMatch, FootballMatchLiveActivity, FootballTeam, FootballTeamLiveActivity}
+import com.gu.mobile.notifications.football.models.{MatchDataWithArticle, PenaltyShootoutKick}
 import com.gu.mobile.notifications.client.models.liveActitivites._
-import com.gu.mobile.notifications.football.notificationbuilders.{
-  MatchStatusLiveActivityPayloadBuilder,
-  MatchStatusNotificationBuilder
-}
+import com.gu.mobile.notifications.football.notificationbuilders.{MatchStatusLiveActivityPayloadBuilder, MatchStatusNotificationBuilder}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
@@ -342,26 +332,17 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
   }
 
   "A Notification EventConsumer" should {
-    "not generate normal notifications for penalty shootout kicks" in new MatchEventsContext {
+
+    "generate FootballPenaltyShootout TYPE Payload for shootout events" in new MatchEventsContext {
       override def matchDayLA: MatchDay =
         super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
 
       val result: List[NotificationPayload] =
         eventConsumer.eventsToNotifications(matchDataLA)
 
-      result must not contain((payload: NotificationPayload) =>
-        payload.isInstanceOf[FootballMatchStatusPayload] && payload.title.contains("Penalty Kick")
+      result must contain((payload: NotificationPayload) =>
+        payload.isInstanceOf[FootballMatchStatusPayload] && payload.title.contains("Penalty Kick") && payload.`type` == FootballPenaltyShootout
       )
-    }
-
-    "generate FootballPenaltyShootoutPayload for shootout events" in new MatchEventsContext {
-      override def matchDayLA: MatchDay =
-        super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
-
-      val result: List[NotificationPayload] =
-        eventConsumer.eventsToNotifications(matchDataLA)
-
-      result must contain(beAnInstanceOf[FootballPenaltyShootoutPayload])
     }
 
     "NOT generate notification payload for extra time match phase events" in new MatchEventsContext {

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -3,21 +3,11 @@ package com.gu.mobile.notifications.football.lib
 import java.net.URI
 import com.gu.mobile.notifications.client.models.{liveActitivites, _}
 import com.gu.mobile.notifications.client.models.Importance.{Major, Minor}
-import com.gu.mobile.notifications.client.models.TopicTypes.{
-  FootballMatch,
-  FootballTeam,
-  FootballTeamLiveActivity,
-  FootballMatchLiveActivity
-}
-import com.gu.mobile.notifications.football.models.{
-  MatchDataWithArticle,
-  PenaltyShootoutKick
-}
+import com.gu.mobile.notifications.client.models.NotificationPayloadType.FootballPenaltyShootout
+import com.gu.mobile.notifications.client.models.TopicTypes.{FootballMatch, FootballMatchLiveActivity, FootballTeam, FootballTeamLiveActivity}
+import com.gu.mobile.notifications.football.models.{MatchDataWithArticle, PenaltyShootoutKick}
 import com.gu.mobile.notifications.client.models.liveActitivites._
-import com.gu.mobile.notifications.football.notificationbuilders.{
-  MatchStatusLiveActivityPayloadBuilder,
-  MatchStatusNotificationBuilder
-}
+import com.gu.mobile.notifications.football.notificationbuilders.{MatchStatusLiveActivityPayloadBuilder, MatchStatusNotificationBuilder}
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
@@ -339,26 +329,17 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
   }
 
   "A Notification EventConsumer" should {
-    "not generate normal notifications for penalty shootout kicks" in new MatchEventsContext {
+
+    "generate FootballPenaltyShootout TYPE Payload for shootout events" in new MatchEventsContext {
       override def matchDayLA: MatchDay =
         super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
 
       val result: List[NotificationPayload] =
         eventConsumer.eventsToNotifications(matchDataLA)
 
-      result must not contain((payload: NotificationPayload) =>
-        payload.isInstanceOf[FootballMatchStatusPayload] && payload.title.contains("Penalty Kick")
+      result must contain((payload: NotificationPayload) =>
+        payload.isInstanceOf[FootballMatchStatusPayload] && payload.title.contains("Penalty Kick") && payload.`type` == FootballPenaltyShootout
       )
-    }
-
-    "generate FootballPenaltyShootoutPayload for shootout events" in new MatchEventsContext {
-      override def matchDayLA: MatchDay =
-        super.matchDayLA.copy(date = ZonedDateTime.now().plusHours(1))
-
-      val result: List[NotificationPayload] =
-        eventConsumer.eventsToNotifications(matchDataLA)
-
-      result must contain(beAnInstanceOf[FootballPenaltyShootoutPayload])
     }
 
     "NOT generate notification payload for extra time match phase events" in new MatchEventsContext {

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -3,8 +3,8 @@ package com.gu.mobile.notifications.football.notificationbuilders
 import java.net.URI
 import java.time.ZonedDateTime
 import java.util.UUID
-
 import com.gu.mobile.notifications.client.models.Importance.{Major, Minor}
+import com.gu.mobile.notifications.client.models.NotificationPayloadType.{FootballMatchStatus, FootballPenaltyShootout}
 import com.gu.mobile.notifications.client.models._
 import com.gu.mobile.notifications.football.lib.SyntheticMatchEventGenerator
 import com.gu.mobile.notifications.football.models.{Dismissal, FootballMatchEvent, FullTime, Goal, GoalContext, KickOff, PenaltyShootoutKick, Score}
@@ -113,22 +113,24 @@ class MatchStatusNotificationBuilderSpec extends Specification {
       notification.awayTeamRedCards shouldEqual 0
     }
 
-    "Return FootballPenaltyShootoutPayload for a penalty shootout kick" in new MatchEventsContext {
+    "Return FootballPenaltyShootoutPayload type for a penalty shootout kick" in new MatchEventsContext {
       val shootoutKick = PenaltyShootoutKick(ScoredShootoutResult, "Player", home, away, 1, "event-1")
       val notification = builder.build(shootoutKick, matchInfo.copy(matchStatus = "PT"), List.empty, None)
-      notification must beAnInstanceOf[FootballPenaltyShootoutPayload]
-      notification must not(beAnInstanceOf[FootballMatchStatusPayload])
+      notification.`type` mustEqual FootballPenaltyShootout
+      notification must beAnInstanceOf[FootballMatchStatusPayload]
     }
 
-    "Not return FootballPenaltyShootoutPayload for a goal" in new MatchEventsContext {
+    "Not return FootballPenaltyShootoutPayload type for a goal" in new MatchEventsContext {
       val notification = builder.build(baseGoal, matchInfo, List.empty, None)
-      notification must not(beAnInstanceOf[FootballPenaltyShootoutPayload])
+      notification.`type` mustEqual FootballMatchStatus
+      notification must beAnInstanceOf[FootballMatchStatusPayload]
     }
 
     "Not return FootballPenaltyShootoutPayload for dismissal" in new MatchEventsContext {
       val dismissal = Dismissal("e2", "Player B", home, 80, None)
       val notification = builder.build(baseGoal, matchInfo, List(dismissal), None)
-      notification must not(beAnInstanceOf[FootballPenaltyShootoutPayload])
+      notification.`type` mustEqual FootballMatchStatus
+      notification must beAnInstanceOf[FootballMatchStatusPayload]
     }
   }
 

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -193,7 +193,7 @@ class MatchStatusNotificationBuilderSpec extends Specification {
       notification.awayTeamMessage shouldEqual " "
       notification.awayTeamRedCards shouldEqual 0
     }
-
+    
     "Ignore deleted penalty events" in new MatchEventsContext {
       val notification = builder.build(
         PenaltyShootoutKick(ScoredShootoutResult, "Player One", home, away, 90, "event-1"),
@@ -202,8 +202,9 @@ class MatchStatusNotificationBuilderSpec extends Specification {
           PenaltyShootoutKick(ScoredShootoutResult, "Player Two", away, home, 90, "event-2", isDeleted = true)
         ),
         Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
-      ).asInstanceOf[FootballPenaltyShootoutPayload]
+      ).asInstanceOf[FootballMatchStatusPayload]
 
+      notification.`type` mustEqual FootballPenaltyShootout
       notification.homeTeamPenalties shouldEqual Some(PenaltyShootoutState(1, 0, 0))
       notification.awayTeamPenalties shouldEqual Some(PenaltyShootoutState(0, 0, 0))
     }

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -4,6 +4,7 @@ import java.net.URI
 import java.time.ZonedDateTime
 import java.util.UUID
 import com.gu.mobile.notifications.client.models.Importance.Major
+import com.gu.mobile.notifications.client.models.NotificationPayloadType.{FootballMatchStatus, FootballPenaltyShootout}
 import com.gu.mobile.notifications.client.models._
 import com.gu.mobile.notifications.client.models.liveActitivites.PenaltyShootoutState
 import com.gu.mobile.notifications.football.models.{Dismissal, FullTime, Goal, GoalContext, KickOff, PenaltyShootoutKick, PreMatch, Score, StartLiveActivity}
@@ -109,22 +110,24 @@ class MatchStatusNotificationBuilderSpec extends Specification {
       notification.awayTeamRedCards shouldEqual 0
     }
 
-    "Return FootballPenaltyShootoutPayload for a penalty shootout kick" in new MatchEventsContext {
+    "Return FootballPenaltyShootoutPayload type for a penalty shootout kick" in new MatchEventsContext {
       val shootoutKick = PenaltyShootoutKick(ScoredShootoutResult, "Player", home, away, 1, "event-1")
       val notification = builder.build(shootoutKick, matchInfo.copy(matchStatus = "PT"), List.empty, None)
-      notification must beAnInstanceOf[FootballPenaltyShootoutPayload]
-      notification must not(beAnInstanceOf[FootballMatchStatusPayload])
+      notification.`type` mustEqual FootballPenaltyShootout
+      notification must beAnInstanceOf[FootballMatchStatusPayload]
     }
 
-    "Not return FootballPenaltyShootoutPayload for a goal" in new MatchEventsContext {
+    "Not return FootballPenaltyShootoutPayload type for a goal" in new MatchEventsContext {
       val notification = builder.build(baseGoal, matchInfo, List.empty, None)
-      notification must not(beAnInstanceOf[FootballPenaltyShootoutPayload])
+      notification.`type` mustEqual FootballMatchStatus
+      notification must beAnInstanceOf[FootballMatchStatusPayload]
     }
 
     "Not return FootballPenaltyShootoutPayload for dismissal" in new MatchEventsContext {
       val dismissal = Dismissal("e2", "Player B", home, 80, None)
       val notification = builder.build(baseGoal, matchInfo, List(dismissal), None)
-      notification must not(beAnInstanceOf[FootballPenaltyShootoutPayload])
+      notification.`type` mustEqual FootballMatchStatus
+      notification must beAnInstanceOf[FootballMatchStatusPayload]
     }
 
     "Show the correct title and message for the pre-match notifcation" in new MatchEventsContext {


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

https://github.com/guardian/mobile-n10n/pull/1779/ recently was merged allowing us to send penalty push notifications to some Android devices. This functionality depends on pattern matching on the Notification`type` [here](https://github.com/guardian/mobile-n10n/blob/b88736a1d26486ff09850aadea0f4825ff7ac5c9/common/src/main/scala/models/Notification.scala#L43)

However, in the football lambda we were creating two different Payload classes rather than just differentiating the payload type so this PR attempts to make the Football `MatchStatusNotificationBuilder` more DRY so it can be more easily iterated on. 





<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

- [x] Deployed football lambda to CODE and rabn recent match with penalities - observed expected notifications on Android emulator. 

<img width="335" height="262" alt="image" src="https://github.com/user-attachments/assets/b6f77ff6-8fad-4ec5-9118-c3cdaf89e47e" />
<img width="345" height="271" alt="image" src="https://github.com/user-attachments/assets/0c5b9b92-ddb4-421c-9c10-86e3ddbbd8ba" />
<img width="317" height="238" alt="image" src="https://github.com/user-attachments/assets/a8072caa-0636-43c3-b41f-bb6229d6ad8d" />



<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
