### PR TITLE
Add "tap to enable live updates" push notification for iOS live activities

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
@@ -29,7 +29,6 @@ class EventConsumer(
       List(
         // additional synthetic live activity life cycle events
         "create-channel",
-        "start-live-activity",
         "end-live-activity",
         // additional synthetic match phase events for live activities
         "extra-time-to-be-played",
@@ -88,10 +87,9 @@ class LiveActivityEventConsumer(
       matchData: MatchDataWithArticle
   ): List[LiveActivityPayload] = {
 
-    // only "end-live-activity" synthetic event when there is a result
     val duplicatePhaseEventTypes =
       List(
-        "full-time",
+        "full-time", // only send "end-live-activity" synthetic event
       )
 
     val filteredMatchData =

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -149,6 +149,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     } else None
   }
 
+  // sent to push notification service to trigger live activity start (not to the  liveactivities service)
   private val startLiveActivity: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
     if (koWithin20Minutes(matchDay.date.toEpochSecond)) Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/start-live-activity".getBytes).toString),

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -1,6 +1,6 @@
 package com.gu.mobile.notifications.football.notificationbuilders
 
-import com.gu.mobile.notifications.client.models.liveActitivites.{Competition, CreateChannelEvent, EndLiveActivityEvent, FootballLiveActivity, FootballMatchContentState, LiveActivityPayload, MatchStatus, StartLiveActivityEvent, TeamState, UpdateLiveActivityEvent}
+import com.gu.mobile.notifications.client.models.liveActitivites.{Competition, CreateChannelEvent, EndLiveActivityEvent, FootballLiveActivity, FootballMatchContentState, LiveActivityPayload, MatchStatus, TeamState, UpdateLiveActivityEvent}
 import com.gu.mobile.notifications.football.models._
 import pa.MatchDay
 
@@ -71,7 +71,6 @@ class MatchStatusLiveActivityPayloadBuilder {
       case Abandoned(_) => EndLiveActivityEvent
       case Cancelled(_) => EndLiveActivityEvent
       case CreateChannel(_) => CreateChannelEvent
-//      case StartLiveActivity(_) => StartLiveActivityEvent // we do not want to use start yet
       case EndLiveActivity(_) => EndLiveActivityEvent
       case _ => UpdateLiveActivityEvent
     }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -110,7 +110,7 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
       case _: StartLiveActivity => footballPayload.copy(
         title =  Some(s"""${matchInfo.homeTeam.name} v ${matchInfo.awayTeam.name}"""),
         message = Some("Tap to enable live updates"),
-        matchInfoUri = new URI(s"https://www.theguardian.com/football/match/${matchInfo.id}?liveactivity=true"),
+        matchInfoUri = new URI(s"$mapiHost/sport/football/matches/${matchInfo.id}?liveactivity=true"),
         topic = liveActivityTopics // only send to iOS users subscribed to the live activity topics
       )
       case _ => footballPayload

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -29,7 +29,7 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
       Topic(TopicTypes.FootballTeam, matchInfo.homeTeam.id),
       Topic(TopicTypes.FootballTeam, matchInfo.awayTeam.id),
       Topic(TopicTypes.FootballMatch, matchInfo.id)
-    ) ++ (if (triggeringEvent.isInstanceOf[KickOff]) liveActivityTopics else Nil)
+    )
 
     val allEvents = triggeringEvent :: previousEvents
     val goals = allEvents.collect { case g: Goal => g }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import com.gu.mobile.notifications.client.models.Importance.{Importance, Major, Minor}
 import com.gu.mobile.notifications.client.models._
 import com.gu.mobile.notifications.client.models.liveActitivites.MatchStatus
-import com.gu.mobile.notifications.football.models.{Dismissal, FootballMatchEvent, FullTime, Goal, HalfTime, KickOff, PenaltyShootoutKick, PenaltyShootoutScore, RedCards, Score, SecondHalf}
+import com.gu.mobile.notifications.football.models.{Dismissal, FootballMatchEvent, FullTime, Goal, HalfTime, KickOff, PenaltyShootoutKick, PenaltyShootoutScore, RedCards, Score, SecondHalf, StartLiveActivity}
 import pa.{MatchDay, MatchDayTeam}
 
 import scala.PartialFunction.condOpt
@@ -18,20 +18,18 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
     previousEvents: List[FootballMatchEvent],
     articleId: Option[String]
   ): NotificationPayload = {
-    val liveActivityTopics =
-      if (triggeringEvent.isInstanceOf[KickOff])
-        List(
-          Topic(TopicTypes.FootballTeamLiveActivity, matchInfo.homeTeam.id),
-          Topic(TopicTypes.FootballTeamLiveActivity, matchInfo.awayTeam.id),
-          Topic(TopicTypes.FootballMatchLiveActivity, matchInfo.id)
-        )
-      else Nil
+
+    val liveActivityTopics = List(
+      Topic(TopicTypes.FootballTeamLiveActivity, matchInfo.homeTeam.id),
+      Topic(TopicTypes.FootballTeamLiveActivity, matchInfo.awayTeam.id),
+      Topic(TopicTypes.FootballMatchLiveActivity, matchInfo.id)
+    )
 
     val topics = List(
       Topic(TopicTypes.FootballTeam, matchInfo.homeTeam.id),
       Topic(TopicTypes.FootballTeam, matchInfo.awayTeam.id),
       Topic(TopicTypes.FootballMatch, matchInfo.id)
-    ) ++ liveActivityTopics
+    ) ++ (if (triggeringEvent.isInstanceOf[KickOff]) liveActivityTopics else Nil)
 
     val allEvents = triggeringEvent :: previousEvents
     val goals = allEvents.collect { case g: Goal => g }
@@ -43,8 +41,40 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
 
     val status = statuses.getOrElse(matchInfo.matchStatus, matchInfo.matchStatus)
 
+   val footballPayload =   FootballMatchStatusPayload(
+     title = Some(eventTitle(triggeringEvent)),
+     message = Some(mainMessage(triggeringEvent, transformTeamName(matchInfo.homeTeam.name), transformTeamName(matchInfo.awayTeam.name), score, status)),
+     sender = "mobile-notifications-football-lambda",
+     awayTeamName = transformTeamName(matchInfo.awayTeam.name),
+     awayTeamScore = score.away,
+     awayTeamMessage = teamMessage(matchInfo.awayTeam, allEvents),
+     awayTeamId = matchInfo.awayTeam.id,
+     awayTeamRedCards = redCards.away,
+     homeTeamName = transformTeamName(matchInfo.homeTeam.name),
+     homeTeamScore = score.home,
+     homeTeamMessage = teamMessage(matchInfo.homeTeam, allEvents),
+     homeTeamId = matchInfo.homeTeam.id,
+     homeTeamRedCards = redCards.home,
+     competitionName = matchInfo.competition.map(_.name),
+     roundName = matchInfo.round.name,
+     venue = matchInfo.venue.map(_.name).filter(_.nonEmpty),
+     matchId = matchInfo.id,
+     matchInfoUri = new URI(s"$mapiHost/sport/football/matches/${matchInfo.id}"),
+     articleUri = articleId.map(id => new URI(s"$mapiHost/items/$id")),
+     importance = importance(triggeringEvent),
+     topic = topics,
+     matchStatus = status,
+     eventId = UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
+     kickOffTimestamp = Some(matchInfo.date.toEpochSecond),
+     lineupsAvailable = Some(matchInfo.lineupsAvailable),
+     detailedMatchStatus = Some(MatchStatus.fromString(matchInfo.matchStatus).status),
+     debug = false,
+     dryRun = None
+   )
+
     triggeringEvent match {
       case _: PenaltyShootoutKick =>
+        // todo reuse the football payload and pattern match on `type` in notifications service?
         FootballPenaltyShootoutPayload(
           title = Some(eventTitle(triggeringEvent)),
           message = Some(mainMessage(triggeringEvent, transformTeamName(matchInfo.homeTeam.name), transformTeamName(matchInfo.awayTeam.name), score, status)),
@@ -77,37 +107,13 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
           debug = false,
           dryRun = None
         )
-      case _ =>
-        FootballMatchStatusPayload(
-          title = Some(eventTitle(triggeringEvent)),
-          message = Some(mainMessage(triggeringEvent, transformTeamName(matchInfo.homeTeam.name), transformTeamName(matchInfo.awayTeam.name), score, status)),
-          sender = "mobile-notifications-football-lambda",
-          awayTeamName = transformTeamName(matchInfo.awayTeam.name),
-          awayTeamScore = score.away,
-          awayTeamMessage = teamMessage(matchInfo.awayTeam, allEvents),
-          awayTeamId = matchInfo.awayTeam.id,
-          awayTeamRedCards = redCards.away,
-          homeTeamName = transformTeamName(matchInfo.homeTeam.name),
-          homeTeamScore = score.home,
-          homeTeamMessage = teamMessage(matchInfo.homeTeam, allEvents),
-          homeTeamId = matchInfo.homeTeam.id,
-          homeTeamRedCards = redCards.home,
-          competitionName = matchInfo.competition.map(_.name),
-          roundName = matchInfo.round.name,
-          venue = matchInfo.venue.map(_.name).filter(_.nonEmpty),
-          matchId = matchInfo.id,
-          matchInfoUri = new URI(s"$mapiHost/sport/football/matches/${matchInfo.id}"),
-          articleUri = articleId.map(id => new URI(s"$mapiHost/items/$id")),
-          importance = importance(triggeringEvent),
-          topic = topics,
-          matchStatus = status,
-          eventId = UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
-          kickOffTimestamp = Some(matchInfo.date.toEpochSecond),
-          lineupsAvailable = Some(matchInfo.lineupsAvailable),
-          detailedMatchStatus = Some(MatchStatus.fromString(matchInfo.matchStatus).status),
-          debug = false,
-          dryRun = None
-        )
+      case _: StartLiveActivity => footballPayload.copy(
+        title =  Some(s"""${matchInfo.homeTeam.name} v ${matchInfo.awayTeam.name}"""),
+        message = Some("Tap to enable live updates"),
+        matchInfoUri = new URI(s"https://www.theguardian.com/football/match/${matchInfo.id}?liveactivity=true"),
+        topic = liveActivityTopics // only send to iOS users subscribed to the live activity topics
+      )
+      case _ => footballPayload
     }
   }
 

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -68,10 +68,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
         topic = List(
           Topic(FootballTeam, "1006"),
           Topic(FootballTeam, "29"),
-          Topic(FootballMatch, "4011135"),
-          Topic(FootballTeamLiveActivity, "1006"),
-          Topic(FootballTeamLiveActivity, "29"),
-          Topic(FootballMatchLiveActivity, "4011135")
+          Topic(FootballMatch, "4011135")
         ),
         matchStatus = "1st",
         eventId = "7e730fbe-b013-3a0e-89cb-12b46260d7be",

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -3,18 +3,12 @@ package com.gu.mobile.notifications.football.notificationbuilders
 import java.net.URI
 import java.time.ZonedDateTime
 import java.util.UUID
-
-import com.gu.mobile.notifications.client.models.Importance.{Major, Minor}
+import com.gu.mobile.notifications.client.models.Importance.Major
 import com.gu.mobile.notifications.client.models._
-import com.gu.mobile.notifications.football.lib.SyntheticMatchEventGenerator
-import com.gu.mobile.notifications.football.models.{Dismissal, FootballMatchEvent, FullTime, Goal, GoalContext, KickOff, PenaltyShootoutKick, Score}
+import com.gu.mobile.notifications.football.models.{Dismissal,  FullTime, Goal, GoalContext, KickOff, PenaltyShootoutKick, Score, StartLiveActivity}
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import pa.{Competition, MatchDay, MatchDayTeam, Parser, Round, Stage, Venue}
-
-import java.time.ZonedDateTime
-import scala.io.Source
-
+import pa.{Competition, MatchDay, MatchDayTeam, Round, Stage, Venue}
 
 class MatchStatusNotificationBuilderSpec extends Specification {
 
@@ -130,6 +124,17 @@ class MatchStatusNotificationBuilderSpec extends Specification {
       val notification = builder.build(baseGoal, matchInfo, List(dismissal), None)
       notification must not(beAnInstanceOf[FootballPenaltyShootoutPayload])
     }
+
+    "Build a start-live-activity payload correctly from matchInfo" in new MatchEventsContext {
+      val laTopics = List(Topic(TopicTypes.FootballTeamLiveActivity, "1"), Topic(TopicTypes.FootballTeamLiveActivity, "2"), Topic(TopicTypes.FootballMatchLiveActivity, "some-match-id"))
+      val startEvent = StartLiveActivity("event-abc")
+      val notification = builder.build(startEvent, matchInfo, List.empty, None).asInstanceOf[FootballMatchStatusPayload]
+      notification.title shouldEqual Some("Liverpool v Plymouth")
+      notification.message shouldEqual Some("Tap to enable live updates")
+      notification.matchInfoUri shouldEqual(new URI("https://www.theguardian.com/football/match/some-match-id?liveactivity=true"))
+      notification.topic.mustEqual(laTopics)
+    }
+
   }
 
   trait MatchEventsContext extends Scope {

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -131,7 +131,7 @@ class MatchStatusNotificationBuilderSpec extends Specification {
       val notification = builder.build(startEvent, matchInfo, List.empty, None).asInstanceOf[FootballMatchStatusPayload]
       notification.title shouldEqual Some("Liverpool v Plymouth")
       notification.message shouldEqual Some("Tap to enable live updates")
-      notification.matchInfoUri shouldEqual(new URI("https://www.theguardian.com/football/match/some-match-id?liveactivity=true"))
+      notification.matchInfoUri shouldEqual(new URI("http://localhost/sport/football/matches/some-match-id?liveactivity=true"))
       notification.topic.mustEqual(laTopics)
     }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Starts sending "start-live-activity" synthetic events to the MatchStatusNotificationBuilder
- The builder pattern matches on this event type and adapts the payload accordingly - this is ONLY shipped to live activity topics which currently are only used on iOS. 
- New test is added. 
- Stops the Kick Off notification from being sent to live activity topics

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

Tested in CODE

- [x] iOS device receives the notification on schedule
- [x] iOS device does NOT receive the kick off notification
- [x] tapping through opens correct match info page on Debug app. 
- [x] only being sent to live activity topics so Android will not receive - confirmed 0 android tokens subscribe to live activity topics in the CODE registrations db. 
- [x] Kick off notification not received on iOS live activity subscriptions, payload still sent to non-liveactivity topics. 

<img width="225" height="64" alt="image" src="https://github.com/user-attachments/assets/7b615283-e20c-4c74-ab6f-becb30c78913" />


<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
