### PR TITLE
Fix bug in isUncoveredInternationalFriendly

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -38,7 +38,7 @@ class FootballData(
 
     private lazy val internationalTeamsForFriendlies = Set(
       "497", // England,
-      "499", // 'Scotland,
+      "499", // Scotland,
       "630", // Wales,
       "494", // Republic of Ireland,
       "964", // Northern Ireland,
@@ -58,8 +58,10 @@ class FootballData(
       "23104", // Brazil
     )
 
+    // Checks if neither team are in the internationalTeamsForFriendlies set — i.e., the match is "uncovered".
+    // As long as one team id is in the set, the match should be covered.
     lazy val isUncoveredInternationalFriendly: Boolean =
-      Set(matchDay.homeTeam.id, matchDay.awayTeam.name).intersect(internationalTeamsForFriendlies).isEmpty
+      Set(matchDay.homeTeam.id, matchDay.awayTeam.id).intersect(internationalTeamsForFriendlies).isEmpty
 
     lazy val isEarlyQualifyingRound: Boolean = Try(matchDay.round.roundNumber.toInt) match {
       case Success(r) => r < 3
@@ -106,6 +108,22 @@ class FootballData(
     }
   }
 
+
+  // Theres some stuff that PA don't provide data for and we want to supress alerts for these matches
+  def paProvideAlerts(matchDay: MatchDay): Boolean = {
+    matchDay.competition
+      .map { c =>
+        c.id match {
+          // International friendly: Must involve at least one of a whitelisted set of teams
+          case "721" if matchDay.isUncoveredInternationalFriendly => false
+          // FA cup qualifying rounds not covererd before round 3
+          case "303" if matchDay.isEarlyQualifyingRound => false
+          case _                                        => true
+        }
+      }
+      .getOrElse(false) // Shouldn't ever happen
+  }
+
   def matchIdsInProgress(dateTime: ZonedDateTime): Future[List[MatchDay]] = {
     def inProgress(m: MatchDay): Boolean =
       m.date.minusHours(2).isBefore(dateTime) && m.date.plusHours(4).isAfter(dateTime)
@@ -115,21 +133,6 @@ class FootballData(
     def isMidnight(matchDay: MatchDay): Boolean = {
       val localDate = matchDay.date.toLocalTime
       localDate.getHour() == 0 && localDate.getMinute() == 0
-    }
-
-    // Theres some stuff that PA don't provide data for and we want to supress alerts for these matches
-    def paProvideAlerts(matchDay: MatchDay): Boolean = {
-      matchDay.competition
-        .map { c =>
-          c.id match {
-            // International friendly: Must involve at least one of a whitelisted set of teams
-            case "721" if matchDay.isUncoveredInternationalFriendly => false
-            // FA cup qualifying rounds not covererd before round 3
-            case "303" if matchDay.isEarlyQualifyingRound => false
-            case _                                        => true
-          }
-        }
-        .getOrElse(false) // Shouldn't ever happen
     }
 
     logger.info(s"Retrieving matches on or around $dateTime from PA")

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/FootballDataSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/FootballDataSpec.scala
@@ -102,5 +102,79 @@ class FootballDataSpec extends Specification {
       footballData.competitionIsSupported(List.empty, supportedCompetitions) must beEmpty
     }
   }
-}
 
+  "paProvideAlerts" should {
+
+    val footballData = new FootballData(null, null, null, "test")
+
+    def matchWith(competitionId: String, homeId: String = "1", awayId: String = "2", roundNumber: String = "5"): MatchDay =
+      MatchDay(
+        id = "match-1",
+        date = ZonedDateTime.parse("2026-05-18T15:00:00Z"),
+        competition = Some(Competition(competitionId, "Test Competition")),
+        stage = Stage("1"),
+        round = Round(roundNumber, None),
+        leg = "1",
+        liveMatch = true,
+        result = false,
+        previewAvailable = false,
+        reportAvailable = false,
+        lineupsAvailable = false,
+        matchStatus = "FH",
+        attendance = None,
+        homeTeam = MatchDayTeam(homeId, "Home", None, None, None, None),
+        awayTeam = MatchDayTeam(awayId, "Away", None, None, None, None),
+        referee = None,
+        venue = None,
+        comments = None
+      )
+
+    // Normal competitions
+    "return true for a regular competition (e.g. Premier League)" in {
+      footballData.paProvideAlerts(matchWith("100")) must beTrue
+    }
+
+    "return false when match has no competition" in {
+      val m = matchWith("100").copy(competition = None)
+      footballData.paProvideAlerts(m) must beFalse
+    }
+
+    // International friendlies (competition id 721)
+    "return true for an international friendly where home team is covered (e.g. England 497)" in {
+      footballData.paProvideAlerts(matchWith("721", homeId = "497", awayId = "37293")) must beTrue
+    }
+
+    "return true for an international friendly where away team is covered (e.g. Denmark 986)" in {
+      footballData.paProvideAlerts(matchWith("721", homeId = "37293", awayId = "986")) must beTrue
+    }
+
+    "return true for an international friendly where both teams are covered" in {
+      footballData.paProvideAlerts(matchWith("721", homeId = "629", awayId = "986")) must beTrue
+    }
+
+    "return false for an international friendly where neither team is covered (e.g. Congo DR v Algeria)" in {
+      footballData.paProvideAlerts(matchWith("721", homeId = "37293", awayId = "37264")) must beFalse
+    }
+
+    // FA Cup qualifying (competition id 303)
+    "return false for FA Cup round 1 (early qualifying)" in {
+      footballData.paProvideAlerts(matchWith("303", roundNumber = "1")) must beFalse
+    }
+
+    "return false for FA Cup round 2 (early qualifying)" in {
+      footballData.paProvideAlerts(matchWith("303", roundNumber = "2")) must beFalse
+    }
+
+    "return true for FA Cup round 3 (not early qualifying)" in {
+      footballData.paProvideAlerts(matchWith("303", roundNumber = "3")) must beTrue
+    }
+
+    "return true for FA Cup round 4" in {
+      footballData.paProvideAlerts(matchWith("303", roundNumber = "4")) must beTrue
+    }
+
+    "return true for FA Cup when round number is non-numeric" in {
+      footballData.paProvideAlerts(matchWith("303", roundNumber = "Final")) must beTrue
+    }
+  }
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We observed no events or alerts beign fired for some international friendly matches yesterday.  Out of 4 matches, only one was processed as expected. 

This behavious is explaing by a combination of International Friendlies being excluded unless one playing team is specifcally whitelisted AND a longstand bug in the code where we were checking if the AwayTeam's name string was in the id set, not the actual id. This bug was excluding more matches than expected from being processed for alerts. 

The PR fixes the bug, and also add tests for `def paProvideAlerts`

We will decide an a future PR if we expand or remove the whitelist once we have more infomartion on PA coverage. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

Tested in Code:
- [x] Luxembourg v Italy -  Notification received
- [x] Netherlands v Algeria - Notification NOT received as expected based on the whitelist
- [x] Poland v Nigeria - Notification received
- [x] DR Congo v Denmark -  Notification received


<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
