### PR TITLE
Add isEnabled flag

### DIFF
--- a/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/BroadcastLambda.scala
@@ -7,7 +7,7 @@ import com.gu.mobile.notifications.client.models.liveActitivites._
 import play.api.libs.json._
 
 import java.io.{InputStream, OutputStream}
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success, Try}
 
@@ -65,7 +65,9 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
         throw new Exception(s"Unexpected event type ${requestPayload.eventType} for broadcast payload")
     }
 
-    val broadcastFuture = broadcastService.processBroadcast(requestPayload, shouldEndBroadcast, contentState)
+    val broadcastFuture = if (!config.isEnabled) {
+        Future.successful(s"Broadcast lambda is currently disabled by config. Skipping broadcast with id ${requestPayload.id} for match ID $matchId")
+    } else {broadcastService.processBroadcast(requestPayload, shouldEndBroadcast, contentState)}
 
     //Timeout set to 160 seconds to provide a safety buffer.
     // While the sum of downstream timeouts is at most ~110s,
@@ -73,9 +75,8 @@ object BroadcastLambda extends RequestStreamHandler with Lambda with Logging {
     // authentication token fetches, and potential network congestion
     // to ensure the Lambda doesn't fail a healthy request that is just running slow.
     Try(Await.result(broadcastFuture, 160.seconds)) match {
-      case Success(_) => {
-        // todo
-        logger.info(s"Broadcast ${requestPayload.eventType.asString} successfully processed for liveActivityID $matchId")
+      case Success(msg) => {
+        logger.info(msg) // Broadcast successfully processed or processing is disabled by config msg.
       }
       case Failure(exception) => {
         logger.error(s"Failed to send broadcast ${if(shouldEndBroadcast)"END"} for liveActivityID $matchId: ${exception.getMessage}")

--- a/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/ChannelManagerLambda.scala
@@ -74,8 +74,15 @@ object ChannelManagerLambda extends RequestStreamHandler with Lambda with Loggin
   private def processRequest(request: LiveActivityPayload, context: Context): Unit = {
     val channelFuture = request.eventType match {
       case CreateChannelEvent =>
-        val eventData = request.broadcastContentStateData.map(LiveActivityData.toLiveActivityData)
-        processCreateChannelRequest(request.liveActivityID, eventData, request.broadcastContentStateData)
+
+        if (!config.isEnabled) {
+          logger.warn(s"Received ${CreateChannelEvent.asString} event for match ID ${request.liveActivityID} but channel creation is disabled by config")
+          Future.unit
+        } else {
+          val eventData = request.broadcastContentStateData.map(LiveActivityData.toLiveActivityData)
+          processCreateChannelRequest(request.liveActivityID, eventData, request.broadcastContentStateData)
+        }
+
       case DeleteChannelEvent =>
         processCloseChannelRequest(request.liveActivityID)
       case other =>

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/BroadcastService.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/BroadcastService.scala
@@ -42,8 +42,6 @@ class BroadcastService(repository: ChannelMappingsRepository, broadcastApiClient
             Future.failed(new LiveActivityInvalidStateException(matchId, "Out of order event time"))
           } else Future.successful(())
 
-          // TODO - determine expiry time and priority
-
           _ = logger.info(s"Sending broadcast for match ID $matchId to channel ID ${mapping.channelId}")
           broadcastPayload = BroadcastBody(contentState, shouldEndBroadcast)
           _ <- broadcastApiClient.sendToChannel(mapping.channelId, None, priorityLevel, broadcastPayload)
@@ -51,7 +49,7 @@ class BroadcastService(repository: ChannelMappingsRepository, broadcastApiClient
 
           _ <- repository.updateMappingLiveAndLastEvent(matchId, isLive = !shouldEndBroadcast, Some(eventId), Some(eventTime))
           _ = logger.info(s"Record updated successfully for match ID $matchId")
-        } yield mapping.channelId
+        } yield s"Broadcast ${requestPayload.eventType.asString} successfully processed for liveActivityID $matchId"
       }
     }
 

--- a/liveactivities/src/main/scala/com/gu/liveactivities/util/Configuration.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/util/Configuration.scala
@@ -15,7 +15,8 @@ case class IosConfiguration(
   certificate: String,
   sendingToProdServer: Boolean = false,
   stage: String,
-  region: String
+  region: String,
+  isEnabled: Boolean = true
 )
 
 object Configuration extends Logging {
@@ -54,7 +55,8 @@ object Configuration extends Logging {
       certificate = config.getString("apns.certificate"),
       sendingToProdServer = config.getBoolean("apns.sendingToProdServer"),
       stage = config.getString("stage"),
-      region = config.getString("region")
+      region = config.getString("region"),
+      isEnabled = config.getBoolean("isEnabled")
     )
   }
 }


### PR DESCRIPTION

Set ssm parameter for prod before merging. 
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a config flag that stops both the channel manager and broadcast lambdas from processing events.  Clean up lambda will still run. 

New channels will not be created. End events to delete channels will not be processed so activites already live will not receive an end broadcast and go stale. Apples auto dismissal policy is max 8hr per for each live activity on the dynamic island, and 4hrs on the lock screent (worst case 12hrs total from start) 



## How has this change been tested?

Tested in CODE:

1. Switching channel mapping to isLive=false for single match
- [x] Broadcast updates stopped being sent.
- [x] Logs observed: `"broadcast-update event ID 81da91bc-ac3a-36f3-83c2-8c1f4e937901 not allowed after broadcast-end for match ID 4550484"` 
- [x] Football live activity payload matching UUID recorded in deduping table.

2. Switching config isEnabled flag to false
- [x] logs observed: `"Received channel-create event for match ID 4550484 but channel creation is disabled by config"`
- [x] new match channels not created. 
- [x] logs observed: `"Broadcast lambda is currently disabled by config. Skipping broadcast with id 224309f8-0dde-334e-8f30-1eca6b7fe305 for match ID 4550484"`
- [x] broadcasts not sent for a live match
- [x] Football live activity payloads recorded for deduping. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
