### PR TITLE
Revert "Log PA football `matchDay.result` and `matchStatus`"

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -159,8 +159,6 @@ class FootballData(
   }
 
   private def processMatch(matchDay: MatchDay): Future[Option[RawMatchData]] = {
-    if (matchDay.result) // TODO: remove this logging once PA result/liveMatch behaviour is understood
-      logger.info(s"[PA_RESULT_TRUE] matchId=${matchDay.id} | matchStatus=${matchDay.matchStatus} | result=${matchDay.result} | liveMatch=${matchDay.liveMatch}")
     val matchData = for {
       (matchDay, events) <- paClient.eventsForMatch(matchDay, syntheticEvents)
     } yield Some(RawMatchData(matchDay, events))


### PR DESCRIPTION
Remove the PA data logging which was added in guardian/mobile-n10n#1813 which is no longer needed and which may be contributing to our AWS bill