### PR TITLE
Log invalid registration topic types

### DIFF
--- a/common/src/main/scala/models/Registration.scala
+++ b/common/src/main/scala/models/Registration.scala
@@ -18,15 +18,17 @@ object Registration {
     val base = Json.format[Registration]
     Format(
       Reads { json =>
-        (json \ "topics").asOpt[JsArray].foreach { arr =>
-          arr.value.foreach { v =>
+        val invalid = (json \ "topics").asOpt[JsArray].toSeq.flatMap { arr =>
+          arr.value.flatMap { v =>
             if (v.validate[Topic].isError) {
               val topicType = (v \ "type").asOpt[String].getOrElse("unknown")
               val topicName = (v \ "name").asOpt[String].getOrElse("unknown")
-              logger.warn(s"Invalid topic type=$topicType topic id=$topicName")
-            }
+              Some(s"Topic Type=$topicType (Topic Id=$topicName)")
+            } else None
           }
         }
+        if (invalid.nonEmpty)
+          logger.warn(s"Bad request: request contains invalid topic type(s). ${invalid.mkString(". ")}")
         base.reads(json)
       },
       base

--- a/common/src/main/scala/models/Registration.scala
+++ b/common/src/main/scala/models/Registration.scala
@@ -1,6 +1,7 @@
 package models
 
-import play.api.libs.json.{Format, Json}
+import org.slf4j.LoggerFactory
+import play.api.libs.json._
 
 case class Registration(
   deviceToken: DeviceToken,
@@ -11,5 +12,24 @@ case class Registration(
 )
 
 object Registration {
-  implicit val registrationJF: Format[Registration] = Json.format[Registration]
+  private val logger = LoggerFactory.getLogger(classOf[Registration])
+
+  implicit val registrationJF: Format[Registration] = {
+    val base = Json.format[Registration]
+    Format(
+      Reads { json =>
+        (json \ "topics").asOpt[JsArray].foreach { arr =>
+          arr.value.foreach { v =>
+            if (v.validate[Topic].isError) {
+              val topicType = (v \ "type").asOpt[String].getOrElse("unknown")
+              val topicName = (v \ "name").asOpt[String].getOrElse("unknown")
+              logger.warn(s"Invalid topic type=$topicType topic id=$topicName")
+            }
+          }
+        }
+        base.reads(json)
+      },
+      base
+    )
+  }
 }

--- a/common/src/main/scala/models/Registration.scala
+++ b/common/src/main/scala/models/Registration.scala
@@ -1,6 +1,6 @@
 package models
 
-import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import play.api.libs.json._
 
 case class Registration(
@@ -12,8 +12,6 @@ case class Registration(
 )
 
 object Registration {
-  private val logger = LoggerFactory.getLogger(classOf[Registration])
-
   implicit val registrationJF: Format[Registration] = {
     val base = Json.format[Registration]
     Format(
@@ -28,7 +26,7 @@ object Registration {
           }
         }
         if (invalid.nonEmpty)
-          logger.warn(s"Bad request: request contains invalid topic type(s). ${invalid.mkString(". ")}")
+          MDC.put("invalidTopics", invalid.mkString(". "))
         base.reads(json)
       },
       base

--- a/registration/app/registration/CustomErrorHandler.scala
+++ b/registration/app/registration/CustomErrorHandler.scala
@@ -14,7 +14,8 @@ class CustomErrorHandler(env: Environment, config: Configuration, sourceMapper: 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
   override def onBadRequest(request: RequestHeader, message: String): Future[Result] = {
     val debugInfo = request.headers.get("User-Agent")
-    logger.error(s"Bad request due to $message. User agent = $debugInfo")
+    if (!message.startsWith("Json validation error"))
+      logger.error(s"Bad request due to $message. User agent = $debugInfo")
     Future.successful(BadRequest("Bad request"))
   }
 }

--- a/registration/app/registration/CustomErrorHandler.scala
+++ b/registration/app/registration/CustomErrorHandler.scala
@@ -1,6 +1,6 @@
 package registration
 
-import org.slf4j.{Logger, LoggerFactory}
+import org.slf4j.{Logger, LoggerFactory, MDC}
 import play.api._
 import play.api.http.DefaultHttpErrorHandler
 import play.api.mvc.Results._
@@ -14,8 +14,13 @@ class CustomErrorHandler(env: Environment, config: Configuration, sourceMapper: 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
   override def onBadRequest(request: RequestHeader, message: String): Future[Result] = {
     val debugInfo = request.headers.get("User-Agent")
-    if (!message.startsWith("Json validation error"))
-      logger.error(s"Bad request due to $message. User agent = $debugInfo")
+    Option(MDC.get("invalidTopics")) match {
+      case Some(invalidTopics) =>
+        logger.warn(s"Bad request: request contains invalid topic type(s). $invalidTopics. User agent = $debugInfo")
+        MDC.remove("invalidTopics")
+      case None =>
+        logger.error(s"Bad request due to $message. User agent = $debugInfo")
+    }
     Future.successful(BadRequest("Bad request"))
   }
 }

--- a/registration/app/registration/services/LegacyRegistrationConverter.scala
+++ b/registration/app/registration/services/LegacyRegistrationConverter.scala
@@ -61,7 +61,7 @@ class LegacyRegistrationConverter extends RegistrationConverter[LegacyRegistrati
       topics <- request.preferences.topics.toList
       topic <- topics
       topicType <- TopicType.fromString(topic.`type`) orElse {
-        logger.error(s"Invalid topic type '${topic.`type`}' for topic id='${topic.name}'")
+        logger.warn(s"Invalid topic type=${topic.`type`} topic id=${topic.name}")
         None
       }
     } yield Topic(topicType, topic.name) // todo: check this

--- a/registration/app/registration/services/LegacyRegistrationConverter.scala
+++ b/registration/app/registration/services/LegacyRegistrationConverter.scala
@@ -5,8 +5,11 @@ import registration.models.LegacyTopic
 import models._
 import registration.models.LegacyRegistration
 import cats.syntax.all._
+import org.slf4j.LoggerFactory
 
 class LegacyRegistrationConverter extends RegistrationConverter[LegacyRegistration] {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
 
   def toRegistration(legacyRegistration: LegacyRegistration): Either[NotificationsError, Registration] = {
 
@@ -57,7 +60,10 @@ class LegacyRegistrationConverter extends RegistrationConverter[LegacyRegistrati
     val topics = for {
       topics <- request.preferences.topics.toList
       topic <- topics
-      topicType <- TopicType.fromString(topic.`type`)
+      topicType <- TopicType.fromString(topic.`type`) orElse {
+        logger.error(s"Invalid topic type '${topic.`type`}' for topic id='${topic.name}'")
+        None
+      }
     } yield Topic(topicType, topic.name) // todo: check this
 
     val matchTopics = for {


### PR DESCRIPTION
## What does this change?
Log invalid topic id and types that the registrations service receives to debug invalid registration requests

## How has this change been tested?
Deployed to CODE and sent a curl request to register an invalid topic and I can see it in the logs


## How can we measure success?
Can see the invalid topic id that is coming through

## Have we considered potential risks?
Just adding logging, no risks
