### PR TITLE
Logs and comment clean up

### DIFF
--- a/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
+++ b/api-models/src/main/scala/com/gu/mobile.notifications.client/models/liveActitivites/BroadcastContentState.scala
@@ -79,7 +79,7 @@ object MatchStatus {
 
     // edge cases
     ("Suspended", Suspended), // Match has been Suspended.
-    ("Resumed", Resumed), // Match has been Resumed. // todo can match phase be determined by match minute?
+    ("Resumed", Resumed), // Match has been Resumed.
     ("Abandoned", Abandoned), // Match has been Abandoned.
     ("Postponed", Postponed), // A Match has been Postponed.
     ("Cancelled", Cancelled) // A Match has been Cancelled.

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -12,7 +12,6 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
 
   def generate(events: List[MatchEvent], id: String, matchDay: MatchDay): List[MatchEvent] = {
     // Live activity synthetic events are appended at the end, but when they are first generated, no other timeline events exist and duplicate events are filtered so this should not matter.
-    // todo This needs to be verified e2e
     events.map(enhanceTimelineEvents(id)) ++ generators.flatMap(_.apply(matchDay, events)) // order is important here
   }
 
@@ -167,8 +166,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  // Note: matches may be abandoned after kick off with no result, in which case rely on "stale-date" to end the activity (4hrs)
-  // todo: add end conditions for Abandoned and cancelled?
+  // Note: matches may be abandoned after kick off - this is handled in the liveActivityPayloadBuilder
   private val endLiveActivity: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
     if (matchDay.result && !matchDay.liveMatch) Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/end-live-activity".getBytes).toString),

--- a/liveactivities/src/main/scala/com/gu/liveactivities/models/BroadcastPayloads.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/models/BroadcastPayloads.scala
@@ -128,11 +128,6 @@ object BroadcastBody extends Logging {
   ): BroadcastBody = {
     val now = System.currentTimeMillis() / 1000
 
-    // todo clean up once timings are verified e2e
-    logger.info(
-      s"Creating BroadcastBody ${if (shouldEndBroadcast) "END"} with dismissal timestamp from: ${now}"
-    )
-
     val apsEvent: BroadcastApsEvent =
       if (shouldEndBroadcast) {
         BroadcastEndAps(

--- a/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
+++ b/liveactivities/src/main/scala/com/gu/liveactivities/service/LiveActivityChannelRepository.scala
@@ -115,11 +115,6 @@ class LiveActivityChannelRepository(client: DynamoDbAsyncClient, tableName: Stri
 
         result.flatMap {
           case Right(_) =>
-            logger.info(
-              s"Updated live activity DB mapping id $id with updates: ${
-                ups.map(exp => s"${exp.attributes.names} = ${exp.attributes.values}").toString()
-              }"
-            )
             Future.successful(())
           case Left(ex) =>
             val errorMsg = s"Error updating live activity mapping for id $id - ${DynamoReadError.describe(ex)}"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Deletes out of date todo comments and logs originally added for debugging. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
