### PR TITLE
Log all topics contained in a registration request with an invalid topic type

### DIFF
--- a/common/src/main/scala/models/Registration.scala
+++ b/common/src/main/scala/models/Registration.scala
@@ -16,17 +16,21 @@ object Registration {
     val base = Json.format[Registration]
     Format(
       Reads { json =>
+        def topicSummary(v: JsValue): String = {
+          val t = (v \ "type").asOpt[String].getOrElse("unknown")
+          val n = (v \ "name").asOpt[String].getOrElse("unknown")
+          s"$t (id=$n)"
+        }
+        val all = (json \ "topics").asOpt[JsArray].toSeq.flatMap(_.value.map(topicSummary))
         val invalid = (json \ "topics").asOpt[JsArray].toSeq.flatMap { arr =>
           arr.value.flatMap { v =>
-            if (v.validate[Topic].isError) {
-              val topicType = (v \ "type").asOpt[String].getOrElse("unknown")
-              val topicName = (v \ "name").asOpt[String].getOrElse("unknown")
-              Some(s"Topic Type=$topicType (Topic Id=$topicName)")
-            } else None
+            if (v.validate[Topic].isError) Some(topicSummary(v)) else None
           }
         }
-        if (invalid.nonEmpty)
-          MDC.put("invalidTopics", invalid.mkString(". "))
+        if (invalid.nonEmpty) {
+          MDC.put("invalidTopics", invalid.mkString(", "))
+          if (all.nonEmpty) MDC.put("allTopics", all.mkString(", "))
+        }
         base.reads(json)
       },
       base

--- a/common/src/main/scala/models/Registration.scala
+++ b/common/src/main/scala/models/Registration.scala
@@ -18,15 +18,17 @@ object Registration {
     val base = Json.format[Registration]
     Format(
       Reads { json =>
-        (json \ "topics").asOpt[JsArray].foreach { arr =>
-          arr.value.foreach { v =>
+        val invalid = (json \ "topics").asOpt[JsArray].toSeq.flatMap { arr =>
+          arr.value.flatMap { v =>
             if (v.validate[Topic].isError) {
               val topicType = (v \ "type").asOpt[String].getOrElse("unknown")
               val topicName = (v \ "name").asOpt[String].getOrElse("unknown")
-              logger.warn(s"Invalid topic type=$topicType topic id=$topicName")
-            }
+              Some(s"Topic Type=$topicType (Topic Id=$topicName)")
+            } else None
           }
         }
+        if (invalid.nonEmpty)
+          logger.warn(s"Bad request: request contains invalid topic type(s). ${invalid.mkString(". ")}")
         base.reads(json)
       },
       base

--- a/common/src/main/scala/models/Registration.scala
+++ b/common/src/main/scala/models/Registration.scala
@@ -1,6 +1,7 @@
 package models
 
-import play.api.libs.json.{Format, Json}
+import org.slf4j.LoggerFactory
+import play.api.libs.json._
 
 case class Registration(
   deviceToken: DeviceToken,
@@ -11,5 +12,24 @@ case class Registration(
 )
 
 object Registration {
-  implicit val registrationJF: Format[Registration] = Json.format[Registration]
+  private val logger = LoggerFactory.getLogger(classOf[Registration])
+
+  implicit val registrationJF: Format[Registration] = {
+    val base = Json.format[Registration]
+    Format(
+      Reads { json =>
+        (json \ "topics").asOpt[JsArray].foreach { arr =>
+          arr.value.foreach { v =>
+            if (v.validate[Topic].isError) {
+              val topicType = (v \ "type").asOpt[String].getOrElse("unknown")
+              val topicName = (v \ "name").asOpt[String].getOrElse("unknown")
+              logger.warn(s"Invalid topic type=$topicType topic id=$topicName")
+            }
+          }
+        }
+        base.reads(json)
+      },
+      base
+    )
+  }
 }

--- a/common/src/main/scala/models/Registration.scala
+++ b/common/src/main/scala/models/Registration.scala
@@ -1,6 +1,6 @@
 package models
 
-import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import play.api.libs.json._
 
 case class Registration(
@@ -12,8 +12,6 @@ case class Registration(
 )
 
 object Registration {
-  private val logger = LoggerFactory.getLogger(classOf[Registration])
-
   implicit val registrationJF: Format[Registration] = {
     val base = Json.format[Registration]
     Format(
@@ -28,7 +26,7 @@ object Registration {
           }
         }
         if (invalid.nonEmpty)
-          logger.warn(s"Bad request: request contains invalid topic type(s). ${invalid.mkString(". ")}")
+          MDC.put("invalidTopics", invalid.mkString(". "))
         base.reads(json)
       },
       base

--- a/registration/app/registration/CustomErrorHandler.scala
+++ b/registration/app/registration/CustomErrorHandler.scala
@@ -16,8 +16,10 @@ class CustomErrorHandler(env: Environment, config: Configuration, sourceMapper: 
     val debugInfo = request.headers.get("User-Agent")
     Option(MDC.get("invalidTopics")) match {
       case Some(invalidTopics) =>
-        logger.warn(s"Bad request: request contains invalid topic type(s). $invalidTopics. User agent = $debugInfo")
+        val allTopics = Option(MDC.get("allTopics")).getOrElse("")
+        logger.warn(s"Bad request: invalid topic type(s): [$invalidTopics]. All topics: [$allTopics]. User agent: $debugInfo")
         MDC.remove("invalidTopics")
+        MDC.remove("allTopics")
       case None =>
         logger.error(s"Bad request due to $message. User agent = $debugInfo")
     }

--- a/registration/app/registration/CustomErrorHandler.scala
+++ b/registration/app/registration/CustomErrorHandler.scala
@@ -14,7 +14,8 @@ class CustomErrorHandler(env: Environment, config: Configuration, sourceMapper: 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
   override def onBadRequest(request: RequestHeader, message: String): Future[Result] = {
     val debugInfo = request.headers.get("User-Agent")
-    logger.error(s"Bad request due to $message. User agent = $debugInfo")
+    if (!message.startsWith("Json validation error"))
+      logger.error(s"Bad request due to $message. User agent = $debugInfo")
     Future.successful(BadRequest("Bad request"))
   }
 }

--- a/registration/app/registration/CustomErrorHandler.scala
+++ b/registration/app/registration/CustomErrorHandler.scala
@@ -1,6 +1,6 @@
 package registration
 
-import org.slf4j.{Logger, LoggerFactory}
+import org.slf4j.{Logger, LoggerFactory, MDC}
 import play.api._
 import play.api.http.DefaultHttpErrorHandler
 import play.api.mvc.Results._
@@ -14,8 +14,13 @@ class CustomErrorHandler(env: Environment, config: Configuration, sourceMapper: 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
   override def onBadRequest(request: RequestHeader, message: String): Future[Result] = {
     val debugInfo = request.headers.get("User-Agent")
-    if (!message.startsWith("Json validation error"))
-      logger.error(s"Bad request due to $message. User agent = $debugInfo")
+    Option(MDC.get("invalidTopics")) match {
+      case Some(invalidTopics) =>
+        logger.warn(s"Bad request: request contains invalid topic type(s). $invalidTopics. User agent = $debugInfo")
+        MDC.remove("invalidTopics")
+      case None =>
+        logger.error(s"Bad request due to $message. User agent = $debugInfo")
+    }
     Future.successful(BadRequest("Bad request"))
   }
 }

--- a/registration/app/registration/CustomErrorHandler.scala
+++ b/registration/app/registration/CustomErrorHandler.scala
@@ -14,14 +14,17 @@ class CustomErrorHandler(env: Environment, config: Configuration, sourceMapper: 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
   override def onBadRequest(request: RequestHeader, message: String): Future[Result] = {
     val debugInfo = request.headers.get("User-Agent")
-    Option(MDC.get("invalidTopics")) match {
-      case Some(invalidTopics) =>
-        val allTopics = Option(MDC.get("allTopics")).getOrElse("")
-        logger.warn(s"Bad request: invalid topic type(s): [$invalidTopics]. All topics: [$allTopics]. User agent: $debugInfo")
-        MDC.remove("invalidTopics")
-        MDC.remove("allTopics")
-      case None =>
-        logger.error(s"Bad request due to $message. User agent = $debugInfo")
+    try {
+      Option(MDC.get("invalidTopics")) match {
+        case Some(invalidTopics) =>
+          val allTopics = Option(MDC.get("allTopics")).getOrElse("")
+          logger.warn(s"Bad request: invalid topic type(s): [$invalidTopics]. All topics: [$allTopics]. User agent: ${debugInfo.getOrElse("unknown")}")
+        case None =>
+          logger.error(s"Bad request due to $message. User agent: ${debugInfo.getOrElse("unknown")}")
+      }
+    } finally {
+      MDC.remove("invalidTopics")
+      MDC.remove("allTopics")
     }
     Future.successful(BadRequest("Bad request"))
   }

--- a/registration/app/registration/services/LegacyRegistrationConverter.scala
+++ b/registration/app/registration/services/LegacyRegistrationConverter.scala
@@ -61,7 +61,7 @@ class LegacyRegistrationConverter extends RegistrationConverter[LegacyRegistrati
       topics <- request.preferences.topics.toList
       topic <- topics
       topicType <- TopicType.fromString(topic.`type`) orElse {
-        logger.error(s"Invalid topic type '${topic.`type`}' for topic id='${topic.name}'")
+        logger.warn(s"Invalid topic type=${topic.`type`} topic id=${topic.name}")
         None
       }
     } yield Topic(topicType, topic.name) // todo: check this

--- a/registration/app/registration/services/LegacyRegistrationConverter.scala
+++ b/registration/app/registration/services/LegacyRegistrationConverter.scala
@@ -5,8 +5,11 @@ import registration.models.LegacyTopic
 import models._
 import registration.models.LegacyRegistration
 import cats.syntax.all._
+import org.slf4j.LoggerFactory
 
 class LegacyRegistrationConverter extends RegistrationConverter[LegacyRegistration] {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
 
   def toRegistration(legacyRegistration: LegacyRegistration): Either[NotificationsError, Registration] = {
 
@@ -57,7 +60,10 @@ class LegacyRegistrationConverter extends RegistrationConverter[LegacyRegistrati
     val topics = for {
       topics <- request.preferences.topics.toList
       topic <- topics
-      topicType <- TopicType.fromString(topic.`type`)
+      topicType <- TopicType.fromString(topic.`type`) orElse {
+        logger.error(s"Invalid topic type '${topic.`type`}' for topic id='${topic.name}'")
+        None
+      }
     } yield Topic(topicType, topic.name) // todo: check this
 
     val matchTopics = for {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The registrations service is receiving requests with invalid topic types (e.g. "tag") which means devices won't subscribe to those topics. This may be the culprit for recent user reports of missing notifications for football. To investigate, we now log all topic types and IDs in the request alongside the invalid ones, so we can see the full picture of what the client is sending.

I've used MDC to combine JSON parsing (where invalid topic details are known) and the error handler (where the user agent is available) into a single log line.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE and sent a test request to the registration CODE

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/40151b44-cdc4-48df-976c-dce5d2fdf983" />

