### PR TITLE
Point CODE football to the live PA data

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -75,13 +75,14 @@ object Lambda extends Logging {
   lazy val liveActivityHandler = new LiveActivityHandler(configuration, dynamoDBClient, liveActivitiesTableName)
 
   def getZonedDateTime(): ZonedDateTime = {
-    val zonedDateTime = if (configuration.stage == "CODE") {
-      val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
-      val json = Json.parse(Source.fromInputStream(is).mkString)
-      ZonedDateTime.parse((json \ "currentDate").as[String])
-    } else {
-      ZonedDateTime.now()
-    }
+    // val zonedDateTime = if (configuration.stage == "CODE") {
+    //   val is = URI.create("https://hdjq4n85yi.execute-api.eu-west-1.amazonaws.com/Prod/getTime").toURL.openStream()
+    //   val json = Json.parse(Source.fromInputStream(is).mkString)
+    //   ZonedDateTime.parse((json \ "currentDate").as[String])
+    // } else {
+    //   ZonedDateTime.now()
+    // }
+    val zonedDateTime = ZonedDateTime.now()
     logger.info(s"Using date time: $zonedDateTime")
     zonedDateTime
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Temporarily override the CODE football to point to the live PA data so that the android devs can follow tonight's football matches to debug some templates issues
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
