### PR TITLE
Fix log level for PA match status fallback

### DIFF
--- a/registration/app/registration/auditor/FootballMatchAuditor.scala
+++ b/registration/app/registration/auditor/FootballMatchAuditor.scala
@@ -44,7 +44,7 @@ case class FootballMatchAuditor(client: PaClient)(implicit ec: ExecutionContext)
       case _ => false
     } recover {
       case _ =>
-        logger.error(s"Unable to determine match status of $matchId.  Assuming that it is in the future")
+        logger.warn(s"Unable to determine match status of $matchId.  Assuming that it is in the future")
         false
     }
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
<img width="1095" height="355" alt="image" src="https://github.com/user-attachments/assets/1d3b3dea-2398-469c-901a-b284578c84fb" />

This gets logged if we can't reach PA to check the match status, which is a very common condition since we fetch d+1's matches when we poll PA. This isn't an error condition and it creates a lot of noise in the logs which I find misleading so change the log status from error to warn. 