### PR TITLE
Add description to eventbus rules

### DIFF
--- a/cdk/lib/__snapshots__/liveactivities.test.ts.snap
+++ b/cdk/lib/__snapshots__/liveactivities.test.ts.snap
@@ -52,6 +52,7 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
     },
     "BroadcastRule3D75643B": {
       "Properties": {
+        "Description": "Route broadcast update/end events from football to broadcast lambda",
         "EventBusName": {
           "Ref": "EventsD32975C2",
         },
@@ -229,6 +230,7 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
     },
     "ChannelRule421C2920": {
       "Properties": {
+        "Description": "Route channel create/delete events from football to channel manager lambda",
         "EventBusName": {
           "Ref": "EventsD32975C2",
         },
@@ -320,6 +322,7 @@ exports[`The LiveActivities stack matches the snapshot for CODE 1`] = `
     },
     "InitialBroadcastRule538D106F": {
       "Properties": {
+        "Description": "Route initial broadcast update event from channel manager to broadcast lambda",
         "EventBusName": {
           "Ref": "EventsD32975C2",
         },

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -253,6 +253,7 @@ export class LiveActivities extends GuStack {
 				detailType: ['channel-create', 'channel-delete'],
 			},
 			targets: [new LambdaFunction(channelLambda)],
+      description: "Route channel create/delete events from football to channel manager lambda",
 		});
 
 		new Rule(this, 'BroadcastRule', {
@@ -262,6 +263,7 @@ export class LiveActivities extends GuStack {
 				detailType: ['broadcast-update', 'broadcast-end'],
 			},
 			targets: [new LambdaFunction(broadcastLambda)],
+      description: "Route broadcast update/end events from football to broadcast lambda",
 		});
 
 		new Rule(this, 'InitialBroadcastRule', {
@@ -271,6 +273,7 @@ export class LiveActivities extends GuStack {
 				detailType: ['broadcast-update'],
 			},
 			targets: [new LambdaFunction(broadcastLambda)],
+      description: "Route initial broadcast update event from channel manager to broadcast lambda",
 		});
 	}
 }

--- a/cdk/lib/liveactivities.ts
+++ b/cdk/lib/liveactivities.ts
@@ -253,7 +253,8 @@ export class LiveActivities extends GuStack {
 				detailType: ['channel-create', 'channel-delete'],
 			},
 			targets: [new LambdaFunction(channelLambda)],
-      description: "Route channel create/delete events from football to channel manager lambda",
+			description:
+				'Route channel create/delete events from football to channel manager lambda',
 		});
 
 		new Rule(this, 'BroadcastRule', {
@@ -263,7 +264,8 @@ export class LiveActivities extends GuStack {
 				detailType: ['broadcast-update', 'broadcast-end'],
 			},
 			targets: [new LambdaFunction(broadcastLambda)],
-      description: "Route broadcast update/end events from football to broadcast lambda",
+			description:
+				'Route broadcast update/end events from football to broadcast lambda',
 		});
 
 		new Rule(this, 'InitialBroadcastRule', {
@@ -273,7 +275,8 @@ export class LiveActivities extends GuStack {
 				detailType: ['broadcast-update'],
 			},
 			targets: [new LambdaFunction(broadcastLambda)],
-      description: "Route initial broadcast update event from channel manager to broadcast lambda",
+			description:
+				'Route initial broadcast update event from channel manager to broadcast lambda',
 		});
 	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add descriptions to the eventbus rules so they are easy to understand at a glance in the aws UI. 

<img width="166" height="469" alt="image" src="https://github.com/user-attachments/assets/3fc450c7-21ad-4fdb-804e-4c308343ea80" />


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
