### PR TITLE
Generate push notifications for additional match phases including extra time and penalties

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
@@ -30,13 +30,6 @@ class EventConsumer(
         // additional synthetic live activity life cycle events
         "create-channel",
         "end-live-activity",
-        // additional synthetic match phase events for live activities
-        "extra-time-to-be-played",
-        "extra-time-first-half",
-        "extra-time-half-time",
-        "extra-time-second-half",
-        "penalties-to-be-played",
-        "penalties",
         "suspended",
         "resumed",
         "abandoned",

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
@@ -30,6 +30,7 @@ class EventConsumer(
         // additional synthetic live activity life cycle events
         "create-channel",
         "end-live-activity",
+        // additional synthetic match phase events for live activities
         "suspended",
         "resumed",
         "abandoned",

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -201,11 +201,11 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
     case _:Dismissal => "Red card"
     case _:PenaltyShootoutKick  => "Penalty Kick"
     case _:PreMatch => "Kick off soon"
-    case _: ExtraTimeToBePlayed => "Extra time to be played"
+    case _: ExtraTimeToBePlayed => "Extra time to follow"
     case _: ExtraTimeFirstHalf => "Extra time: first half"
     case _: ExtraTimeHalfTime => "Extra time: half-time"
     case _: ExtraTimeSecondHalf => "Extra time: second half"
-    case _: PenaltiesToBePlayed => "Penalties to be played"
+    case _: PenaltiesToBePlayed => "Penalties to follow"
     case _: Penalties => "Penalties"
     case _ => "The Guardian"
   }
@@ -230,8 +230,8 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
 
     ("FTET", "ET"), // Full Time, Extra Time it to be played.
     ("ETS", "ET"), // Extra Time has Started.
-    ("ETHT", "ETHT"), // Extra Time Half Time has been called.
-    ("ETSHS", "ETSHS"), // Extra Time, Second Half has Started.
+    ("ETHT", "ET"), // Extra Time Half Time has been called.
+    ("ETSHS", "ET"), // Extra Time, Second Half has Started.
 
     ("FTPT", "PT"), // Full Time, Penalties are To be played.
     ("PT", "PT"), // Penalty Shoot Out has started.

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import com.gu.mobile.notifications.client.models.Importance.{Importance, Major, Minor}
 import com.gu.mobile.notifications.client.models._
 import com.gu.mobile.notifications.client.models.liveActitivites.MatchStatus
-import com.gu.mobile.notifications.football.models.{Dismissal, FootballMatchEvent, FullTime, Goal, HalfTime, KickOff, PenaltyShootoutKick, PenaltyShootoutScore, PreMatch, RedCards, Score, SecondHalf, StartLiveActivity}
+import com.gu.mobile.notifications.football.models.{Dismissal, ExtraTimeFirstHalf, ExtraTimeHalfTime, ExtraTimeSecondHalf, ExtraTimeToBePlayed, FootballMatchEvent, FullTime, Goal, HalfTime, KickOff, Penalties, PenaltiesToBePlayed, PenaltyShootoutKick, PenaltyShootoutScore, PreMatch, RedCards, Score, SecondHalf, StartLiveActivity}
 import pa.{MatchDay, MatchDayTeam}
 
 import scala.PartialFunction.condOpt
@@ -201,6 +201,12 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
     case _:Dismissal => "Red card"
     case _:PenaltyShootoutKick  => "Penalty Kick"
     case _:PreMatch => "Kick off soon"
+    case _: ExtraTimeToBePlayed => "Extra time to be played"
+    case _: ExtraTimeFirstHalf => "Extra time: first half"
+    case _: ExtraTimeHalfTime => "Extra time: half-time"
+    case _: ExtraTimeSecondHalf => "Extra time: second half"
+    case _: PenaltiesToBePlayed => "Penalties to be played"
+    case _: Penalties => "Penalties"
     case _ => "The Guardian"
   }
 
@@ -224,11 +230,11 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
 
     ("FTET", "ET"), // Full Time, Extra Time it to be played.
     ("ETS", "ET"), // Extra Time has Started.
-    ("ETHT", "ET"), // Extra Time Half Time has been called.
-    ("ETSHS", "ET"), // Extra Time, Second Half has Started.
+    ("ETHT", "ETHT"), // Extra Time Half Time has been called.
+    ("ETSHS", "ETSHS"), // Extra Time, Second Half has Started.
 
     ("FTPT", "PT"), // Full Time, Penalties are To be played.
-    ("PT", "PT"), // Penalty ShooT Out has started.
+    ("PT", "PT"), // Penalty Shoot Out has started.
     ("ETFTPT", "PT"), // Extra Time, Full Time, Penalties are To be played.
 
     ("Suspended", "S"), // Match has been Suspended.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
PA doesn't send an explicit event when a goal is overturned (e.g. by VAR) - the score correction only becomes visible to us via the next event we happen to generate a notification for. We saw this cause ncorrect scores to be shown to users for extended periods during recent World Cup matches, since these phase-transition events (extra time starting, penalties starting, etc.) were previously filtered out entirely and generated no notifications.

This PR removes the filtering on these phase events so that we get more frequent "checkpoints" during a match (extra time, penalties) where a score correction can reach users, reducing howc long a stale/incorrect score can persist.

**Impact on old clients**: 
Android builds before May 20th 2026 (when the new live updates UI was released) cannot display the 'detailedMatchStatus' field (the field used for the additional phase events) and can only display the pre-existing 'matchStatus' field. 

This means that while they will receive notifications for the new match statuses e.g. extra time to be played / extra time 1st, 2nd half, their notification can only display "ET" or "PT".


## How has this change been tested?
Deployed to CODE and tested against recent World Cup matches


## Images
| New match status | Latest Android builds* | Old Android builds** |
|------------------|------------------------|----------------------|
| Extra time to be played | ![](https://github.com/user-attachments/assets/3e4b9d5c-dcd6-47e9-9be5-fe0690001eb4) | ![](https://github.com/user-attachments/assets/0c158f74-df0d-4629-b2ad-c9accfe81eee) |
| Extra time 1st half | ![](https://github.com/user-attachments/assets/dffb4752-9fef-4c28-a604-4932c4b2dd6b) | ![](https://github.com/user-attachments/assets/a5b36bae-3dc5-4da0-a48f-43522d87650e) |
| Extra time HT | ![](https://github.com/user-attachments/assets/f813efd4-1c59-41d1-a9c3-e3528dfa9d33) | ![](https://github.com/user-attachments/assets/a5b36bae-3dc5-4da0-a48f-43522d87650e) |
| Extra time 2nd half | ![](https://github.com/user-attachments/assets/4f10f773-6d53-45ce-bd9b-36140ba00202) | ![](https://github.com/user-attachments/assets/a5b36bae-3dc5-4da0-a48f-43522d87650e) |
| Penalties to be played | I didn't manage to screenshot it in time but confirmed with CODE DB record ![](https://github.com/user-attachments/assets/4c964f03-0681-4553-90f9-ed62f9634309) | ![](https://github.com/user-attachments/assets/7bd64d12-ddfc-408d-8a5f-e8e5938ea1f8) |
| Penalties | ![](https://github.com/user-attachments/assets/71df1bdf-4e07-4735-92a1-457ae0209bd1) | ![](https://github.com/user-attachments/assets/7bd64d12-ddfc-408d-8a5f-e8e5938ea1f8) |

\* Builds after May 20th 2026 when the new live updates UI was released.  
\** Builds before May 20th 2026.
