### PR TITLE
Remove midnight KO filtering on World Cup matches 

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -135,7 +135,7 @@ class FootballData(
   private val competitionsAllowingMidnightKO = Set(
     "700", // FIFA World Cup
   )
-  private[lib] def isMidnight(matchDay: MatchDay): Boolean = {
+  private[lib] def isFakeMidnightKO(matchDay: MatchDay): Boolean = {
     val isAllowlisted = matchDay.competition.exists(c => competitionsAllowingMidnightKO.contains(c.id))
     !isAllowlisted && matchDay.date.toLocalTime == LocalTime.MIDNIGHT
   }
@@ -163,7 +163,7 @@ class FootballData(
       matchesInSupportedCompetitions
         .filter(inProgress)
         .filter(paProvideAlerts)
-        .filterNot(isMidnight)
+        .filterNot(isFakeMidnightKO)
     }
   }
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -1,6 +1,6 @@
 package com.gu.mobile.notifications.football.lib
 
-import java.time.{LocalDate, ZonedDateTime}
+import java.time.{LocalDate, LocalTime, ZonedDateTime}
 import com.gu.mobile.notifications.football.{Configuration, Logging}
 import com.gu.mobile.notifications.football.models.RawMatchData
 import org.joda.time.DateTime
@@ -124,20 +124,25 @@ class FootballData(
       .getOrElse(false) // Shouldn't ever happen
   }
 
+
+  /**
+   * PA give 00:00 as the start time when they don't actually know the kickoff time yet,
+   * so those matches are unusable and should be filtered out. Competitions in
+   * `midnightExemptCompetitions` are excluded from this check because a 00:00 kickoff can be
+   * genuine for them (e.g. the World Cup, whose schedule spans multiple time zones and is
+   * published months in advance).
+   */
+  private val midnightExemptCompetitions = Set(
+    "700", // FIFA World Cup
+  )
+  private[lib] def isMidnight(matchDay: MatchDay): Boolean = {
+    val isExempt = matchDay.competition.exists(c => midnightExemptCompetitions.contains(c.id))
+    !isExempt && matchDay.date.toLocalTime == LocalTime.MIDNIGHT
+  }
+
   def matchIdsInProgress(dateTime: ZonedDateTime): Future[List[MatchDay]] = {
     def inProgress(m: MatchDay): Boolean =
       m.date.minusHours(2).isBefore(dateTime) && m.date.plusHours(4).isAfter(dateTime)
-
-    // unfortunately PA provide 00:00 as start date when they don't have the start date
-    // so we can't do anything with these matches, unless the competition is
-    // in the exemption list below, where a 00:00 kickoff is likely to be genuine
-    // (e.g. World Cup which happens in different time zones and publishes its schedule months in advance)
-    def isMidnight(matchDay: MatchDay): Boolean = {
-      val localDate = matchDay.date.toLocalTime
-      val exemptionList = List("700" /* FIFA World Cup */)
-      val isExempt = matchDay.competition.exists(c => exemptionList.contains(c.id))
-      !isExempt && localDate.getHour() == 0 && localDate.getMinute() == 0
-    }
 
     logger.info(s"Retrieving matches on or around $dateTime from PA")
     for {

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -129,10 +129,14 @@ class FootballData(
       m.date.minusHours(2).isBefore(dateTime) && m.date.plusHours(4).isAfter(dateTime)
 
     // unfortunately PA provide 00:00 as start date when they don't have the start date
-    // so we can't do anything with these matches
+    // so we can't do anything with these matches, unless the competition is
+    // in the exemption list below, where a 00:00 kickoff is likely to be genuine
+    // (e.g. World Cup which happens in different time zones and publishes its schedule months in advance)
     def isMidnight(matchDay: MatchDay): Boolean = {
       val localDate = matchDay.date.toLocalTime
-      localDate.getHour() == 0 && localDate.getMinute() == 0
+      val exemptionList = List("700" /* FIFA World Cup */)
+      val isExempt = matchDay.competition.exists(c => exemptionList.contains(c.id))
+      !isExempt && localDate.getHour() == 0 && localDate.getMinute() == 0
     }
 
     logger.info(s"Retrieving matches on or around $dateTime from PA")

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -128,16 +128,16 @@ class FootballData(
   /**
    * PA give 00:00 as the start time when they don't actually know the kickoff time yet,
    * so those matches are unusable and should be filtered out. Competitions in
-   * `midnightExemptCompetitions` are excluded from this check because a 00:00 kickoff can be
+   * `competitionsAllowingMidnightKO` are excluded from this check because a 00:00 kickoff can be
    * genuine for them (e.g. the World Cup, whose schedule spans multiple time zones and is
    * published months in advance).
    */
-  private val midnightExemptCompetitions = Set(
+  private val competitionsAllowingMidnightKO = Set(
     "700", // FIFA World Cup
   )
   private[lib] def isMidnight(matchDay: MatchDay): Boolean = {
-    val isExempt = matchDay.competition.exists(c => midnightExemptCompetitions.contains(c.id))
-    !isExempt && matchDay.date.toLocalTime == LocalTime.MIDNIGHT
+    val isAllowlisted = matchDay.competition.exists(c => competitionsAllowingMidnightKO.contains(c.id))
+    !isAllowlisted && matchDay.date.toLocalTime == LocalTime.MIDNIGHT
   }
 
   def matchIdsInProgress(dateTime: ZonedDateTime): Future[List[MatchDay]] = {

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -134,6 +134,8 @@ class FootballData(
    */
   private val competitionsAllowingMidnightKO = Set(
     "700", // FIFA World Cup
+    "701", // FIFA World Cup qualifying
+    "714", // Copa America
   )
   private[lib] def isFakeMidnightKO(matchDay: MatchDay): Boolean = {
     val isAllowlisted = matchDay.competition.exists(c => competitionsAllowingMidnightKO.contains(c.id))

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/FootballDataSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/FootballDataSpec.scala
@@ -177,4 +177,24 @@ class FootballDataSpec extends Specification {
       footballData.paProvideAlerts(matchWith("303", roundNumber = "Final")) must beTrue
     }
   }
+
+  "isMidnight" should {
+
+    val footballData = new FootballData(null, null, null, "test")
+
+    "return true for a non-exempt competition kicking off at 00:00" in new FootballDataScope {
+      val m = matchDayWithCompetition("100").copy(date = ZonedDateTime.parse("2026-05-18T00:00:00Z"))
+      footballData.isMidnight(m) must beTrue
+    }
+
+    "return false for a non-exempt competition kicking off at a non-midnight time" in new FootballDataScope {
+      val m = matchDayWithCompetition("100").copy(date = ZonedDateTime.parse("2026-05-18T15:00:00Z"))
+      footballData.isMidnight(m) must beFalse
+    }
+
+    "return false for the World Cup (700) kicking off at 00:00" in new FootballDataScope {
+      val m = matchDayWithCompetition("700").copy(date = ZonedDateTime.parse("2026-05-18T00:00:00Z"))
+      footballData.isMidnight(m) must beFalse
+    }
+  }
 }

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/FootballDataSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/FootballDataSpec.scala
@@ -184,17 +184,17 @@ class FootballDataSpec extends Specification {
 
     "return true for a non-exempt competition kicking off at 00:00" in new FootballDataScope {
       val m = matchDayWithCompetition("100").copy(date = ZonedDateTime.parse("2026-05-18T00:00:00Z"))
-      footballData.isMidnight(m) must beTrue
+      footballData.isFakeMidnightKO(m) must beTrue
     }
 
     "return false for a non-exempt competition kicking off at a non-midnight time" in new FootballDataScope {
       val m = matchDayWithCompetition("100").copy(date = ZonedDateTime.parse("2026-05-18T15:00:00Z"))
-      footballData.isMidnight(m) must beFalse
+      footballData.isFakeMidnightKO(m) must beFalse
     }
 
     "return false for the World Cup (700) kicking off at 00:00" in new FootballDataScope {
       val m = matchDayWithCompetition("700").copy(date = ZonedDateTime.parse("2026-05-18T00:00:00Z"))
-      footballData.isMidnight(m) must beFalse
+      footballData.isFakeMidnightKO(m) must beFalse
     }
   }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- No live activities or push notifications were generated for Portugal vs Croatia which was scheduled for July 3, 2026 00:00 (midnight) kick off. 
- This is because we have a logic to filter out matches with 00:00 KO because PA feed sometimes uses 00:00 as a placeholder for when it doesn't know a match's kickoff time yet. PA does not have an alternative field that can be used reliably for confirmed vs estimated KO time.
- Competitions like World Cup have matches that span multiple time zones, and they publish their schedule months in advance, so midnight kickoffs are likely to be genuine.
- So this PR adds an allowlist so midnight KOs for listed competitions are no longer filtered out.

## How has this change been tested?
- Deployed to CODE and used football time machine to set the clock to around the Portugal vs Croatia match
- Tested that the match no longer gets filtered out and generates notification successfully

Android notification
<img width="420" height="213" alt="image" src="https://github.com/user-attachments/assets/1d7c5141-48ad-4ae9-b358-158946b9f81d" />

Logs
<img width="960" height="216" alt="image" src="https://github.com/user-attachments/assets/0a8a4b91-d949-4ff1-8622-61e7836ef174" />


