### PR TITLE
VAR reversals 1: Add global secondary index to live activities payload table

### DIFF
--- a/cdk/lib/__snapshots__/footballnotificationslambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/footballnotificationslambda.test.ts.snap
@@ -151,8 +151,34 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for CODE 1`]
             "AttributeName": "id",
             "AttributeType": "S",
           },
+          {
+            "AttributeName": "liveActivityID",
+            "AttributeType": "S",
+          },
+          {
+            "AttributeName": "ttl",
+            "AttributeType": "N",
+          },
         ],
         "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [
+          {
+            "IndexName": "lastPayload-index",
+            "KeySchema": [
+              {
+                "AttributeName": "liveActivityID",
+                "KeyType": "HASH",
+              },
+              {
+                "AttributeName": "ttl",
+                "KeyType": "RANGE",
+              },
+            ],
+            "Projection": {
+              "ProjectionType": "ALL",
+            },
+          },
+        ],
         "KeySchema": [
           {
             "AttributeName": "id",
@@ -967,8 +993,34 @@ exports[`The FootballNotificationsLambda stack matches the snapshot for PROD 1`]
             "AttributeName": "id",
             "AttributeType": "S",
           },
+          {
+            "AttributeName": "liveActivityID",
+            "AttributeType": "S",
+          },
+          {
+            "AttributeName": "ttl",
+            "AttributeType": "N",
+          },
         ],
         "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [
+          {
+            "IndexName": "lastPayload-index",
+            "KeySchema": [
+              {
+                "AttributeName": "liveActivityID",
+                "KeyType": "HASH",
+              },
+              {
+                "AttributeName": "ttl",
+                "KeyType": "RANGE",
+              },
+            ],
+            "Projection": {
+              "ProjectionType": "ALL",
+            },
+          },
+        ],
         "KeySchema": [
           {
             "AttributeName": "id",

--- a/cdk/lib/footballnotificationslambda.ts
+++ b/cdk/lib/footballnotificationslambda.ts
@@ -10,7 +10,12 @@ import {
 	TreatMissingData,
 	Unit,
 } from 'aws-cdk-lib/aws-cloudwatch';
-import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
+import {
+	AttributeType,
+	BillingMode,
+	ProjectionType,
+	Table,
+} from 'aws-cdk-lib/aws-dynamodb';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
@@ -71,8 +76,8 @@ export class FootballNotificationsLambda extends GuStack {
 			}),
 		);
 
+		// DynamoDB Push Notifications Table
 		const dynamoTableName = `${stack}-football-notifications-${stage}`;
-
 		const dynamoTable = new Table(this, 'DynamoTable', {
 			tableName: dynamoTableName,
 			partitionKey: { name: 'notificationId', type: AttributeType.STRING },
@@ -85,13 +90,11 @@ export class FootballNotificationsLambda extends GuStack {
 			logicalId: 'DynamoTable',
 			reason: 'Retaining a stateful resource previously defined in YAML',
 		});
-
 		Tags.of(dynamoTable).add('devx-backup-enabled', 'true');
 
-		// Live Activities DynamoDB Table
+		// DynamoDB Live Activities Payloads Table
 		const liveActivitiesAppName = 'liveactivities';
 		const liveActivitiesDynamoTableName = `${stack}-${liveActivitiesAppName}-payload-${stage}`;
-
 		const liveActivitiesDynamoTable = new Table(
 			this,
 			'LiveActivitiesDynamoTable',
@@ -103,6 +106,14 @@ export class FootballNotificationsLambda extends GuStack {
 			},
 		);
 		Tags.of(liveActivitiesDynamoTable).add('devx-backup-enabled', 'true');
+
+		// GSI is used to determine if an untracked state change event has occurred, ie. goal was overruled.
+		liveActivitiesDynamoTable.addGlobalSecondaryIndex({
+			indexName: 'lastPayload-index',
+			partitionKey: { name: 'liveActivityID', type: AttributeType.STRING },
+			sortKey: { name: 'ttl', type: AttributeType.NUMBER },
+			projectionType: ProjectionType.ALL,
+		});
 
 		footballnotificationslambda.addToRolePolicy(
 			new PolicyStatement({


### PR DESCRIPTION
Followed by #1862.

This PR to create GSI must be merged first. 

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a Global Secondary Index to the live activities payload table
* primary key match id 
* sort key by ttl (we can use ttl as a proxy for created date to find the most recent payload sent for a given match id.)

` ttl = (System.currentTimeMillis() / 1000) + (14 * 24 * 3600)`

This PR needs to be deployed in isolation for the creation of the GSI. 

The live activities Payload table is billed on demand, so AWS will handle capacity when the GSI first rolled out. Subsequent writes to the main table will also update the GSI simultaneously. 

I don't think it is strictly neccessary to check the notifications payload table and diff in two places - if we decided we need a GSI on the push notifications table, this is provisioned so either A/ needs to be converted to on demand or B/ provisioned capacity reviewed as writing to GSI consumes write units. The initial creation of the GSI may also require a temp increase in provisioned capacity. 

Both tables a relatively small so it should be safe to use `Projection.ALL` on the GSI

*mobile-notifications-liveactivities-PROD - 79 items - Table size 28.4 kilobytes
*mobile-notifications-football-notifications-PROD - 784 items - Table size 1 megabyte


## Why?

Introduction of VAR in football matches means key events such as a goal or red card can be reversed. This is not captured in the incoming PA data; the overruled event simply disappears from the match event timeline. In practice this means LiveActivities and updated Android push notifications display the wrong score until a subsequent "triggering event" emits a new update.

We plan to diff the incoming football data and insert a `state-change` synthetic event to trigger an update to capture these otherwise invisible changes. 

<img width="853" height="404" alt="image" src="https://github.com/user-attachments/assets/c5d89123-ff83-45b9-a956-995267dbfe52" />



<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

Deployed to CODE, new index built as expected. 
Index is queriable via the AWS console. 

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
