### PR TITLE
VAR reversals 2: add football match diffing to generate a synth state change event

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsy
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.gu.contentapi.client.GuardianContentClient
 import com.gu.mobile.liveactivities.event.bus.LiveActivityPusher
-import com.gu.mobile.notifications.football.lib.{ArticleSearcher, DynamoDistinctCheck, DynamoMatchLiveActivity, DynamoMatchNotification, EventConsumer, EventFilter, FootballData, LiveActivityEventConsumer, NotificationHttpProvider, NotificationSender, NotificationsApiClient, PACompetition, PaFootballClient, S3DataStore, SyntheticMatchEventGenerator}
+import com.gu.mobile.notifications.football.lib.{ArticleSearcher, DynamoDistinctCheck, DynamoMatchLiveActivity, DynamoMatchNotification, DynamoPayloadStateCheck, EventConsumer, EventFilter, FootballData, LiveActivityEventConsumer, NotificationHttpProvider, NotificationSender, NotificationsApiClient, PACompetition, PaFootballClient, S3DataStore, SyntheticMatchEventGenerator}
 import com.gu.mobile.notifications.football.notificationbuilders.{MatchStatusLiveActivityPayloadBuilder, MatchStatusNotificationBuilder}
 import play.api.libs.json.Json
 
@@ -53,6 +53,7 @@ object Lambda extends Logging {
 
   lazy val capiClient = GuardianContentClient(configuration.capiApiKey)
 
+  lazy val payloadStateCheck = new DynamoPayloadStateCheck(dynamoDBClient, liveActivitiesTableName)
   lazy val syntheticMatchEventGenerator = new SyntheticMatchEventGenerator(getZonedDateTime)
 
   lazy val notificationHttpProvider = new NotificationHttpProvider()
@@ -66,7 +67,7 @@ object Lambda extends Logging {
 
   lazy val competitionsDataStore = new S3DataStore[PACompetition](s3Client, paDataBucket)
 
-  lazy val footballData = new FootballData(paFootballClient, syntheticMatchEventGenerator, competitionsDataStore, configuration.stage)
+  lazy val footballData = new FootballData(paFootballClient, syntheticMatchEventGenerator, competitionsDataStore, payloadStateCheck, configuration.stage)
 
   lazy val articleSearcher = new ArticleSearcher(capiClient)
 
@@ -130,6 +131,7 @@ object Lambda extends Logging {
   }
 }
 
+// TODO handle match state changes
 class NotificationHandler(configuration: Configuration, apiClient: NotificationsApiClient, dynamoDBClient: AmazonDynamoDBAsync, tableName: String) extends Logging {
 
   lazy val notificationSender = new NotificationSender(apiClient)

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoPayloadStateCheck.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoPayloadStateCheck.scala
@@ -39,7 +39,7 @@ class DynamoPayloadStateCheck(client: AmazonDynamoDBAsync, tableName: String) ex
 
   // articleUrl is only added to the payload after isMatchStateIdentical is called, so we must ignore it.
   private def ignoringArticleUrl(a: FootballMatchContentState, b: FootballMatchContentState): Boolean =
-    a.copy(articleUrl = None) == b.copy(articleUrl = None) // ensure articleURL is None for both at the point of comparison
+    a.copy(articleUrl = None, currentMinute = None) == b.copy(articleUrl = None, currentMinute = None) // these are calculated outside of state generation
 
   // The stored `payload` column is the JSON-serialised LiveActivityPayload; the match state we diff
   // against is its `broadcastContentStateData` subfield.

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoPayloadStateCheck.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoPayloadStateCheck.scala
@@ -1,0 +1,50 @@
+package com.gu.mobile.notifications.football.lib
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
+import com.gu.mobile.notifications.client.models.liveActitivites.{FootballMatchContentState, LiveActivityPayload}
+import com.gu.mobile.notifications.football.Logging
+import org.scanamo.{ScanamoAsync, Table}
+import play.api.libs.json.Json
+
+import scala.concurrent.{ExecutionContext, Future}
+
+// This is used to pre-diff the state in FootballData fetcher to determine if state-change synthetic event should be generated.
+// It is not used to determine if a notification should be sent, that is handled by DynamoDistinctCheck.
+// Both classes read the same table data.
+class DynamoPayloadStateCheck(client: AmazonDynamoDBAsync, tableName: String) extends Logging {
+
+  def isMatchStateIdentical(id: String, state: FootballMatchContentState)(implicit ec: ExecutionContext): Future[Boolean] = {
+    import org.scanamo.generic.auto._
+    import org.scanamo.syntax._
+
+    val scanamoAsync: ScanamoAsync = ScanamoAsync(client)
+    val payloadTable = Table[DynamoMatchLiveActivity](tableName)
+    val lastPayloadIndex = payloadTable.index("lastPayload-index") // only live activities payload table has an index.
+
+    val gsiQuery = lastPayloadIndex.descending.limit(1).query("liveActivityID" -> id)
+
+    scanamoAsync.exec(gsiQuery).map { rows =>
+      isIdenticalToLatest(rows.collect { case Right(row) => row }, state)
+    } recover {
+      case e =>
+        logger.error(s"Failure while checking for dynamodb GSI for match state $tableName: ${e.getMessage}.")
+        false // todo should this be true - do we want to generate a synthetic state-change event if we can't check the latest state?
+    }
+  }
+
+  private[lib] def isIdenticalToLatest(rows: List[DynamoMatchLiveActivity], state: FootballMatchContentState): Boolean =
+    rows.headOption
+      .flatMap(row => footballStateFromPayload(row.payload))
+      .forall(latest => ignoringArticleUrl(latest, state))
+
+  // articleUrl is only added to the payload after isMatchStateIdentical is called, so we must ignore it.
+  private def ignoringArticleUrl(a: FootballMatchContentState, b: FootballMatchContentState): Boolean =
+    a.copy(articleUrl = None) == b.copy(articleUrl = None) // ensure articleURL is None for both at the point of comparison
+
+  // The stored `payload` column is the JSON-serialised LiveActivityPayload; the match state we diff
+  // against is its `broadcastContentStateData` subfield.
+  private[lib] def footballStateFromPayload(payloadJson: String): Option[FootballMatchContentState] =
+    Json.parse(payloadJson).as[LiveActivityPayload].broadcastContentStateData.collect {
+      case footballState: FootballMatchContentState => footballState
+    }
+}

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
@@ -24,7 +24,6 @@ class EventConsumer(
     /** We have added synthetic events for live activities which we don't want
       * to generate push notifications for, so we filter those out here.
       */
-    // todo can we capture these strings in union type?
     val liveActivityEventTypes =
       List(
         // additional synthetic live activity life cycle events
@@ -35,7 +34,8 @@ class EventConsumer(
         "resumed",
         "abandoned",
         "cancelled",
-        "postponed"
+        "postponed",
+        "state-change" // todo
       )
 
     val filteredMatchData = matchData.copy(allEvents =
@@ -84,6 +84,7 @@ class LiveActivityEventConsumer(
     val duplicatePhaseEventTypes =
       List(
         "full-time", // only send "end-live-activity" synthetic event
+        "state-change" // todo
       )
 
     val filteredMatchData =

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -1,18 +1,18 @@
 package com.gu.mobile.notifications.football.lib
 
+import com.gu.mobile.notifications.client.models.liveActitivites.LiveActivityPayload
+
 import java.time.{LocalDate, LocalTime, ZonedDateTime}
-import com.gu.mobile.notifications.football.{Configuration, Logging}
-import com.gu.mobile.notifications.football.models.RawMatchData
-import org.joda.time.DateTime
-import pa.MatchDay
+import com.gu.mobile.notifications.football.Logging
+import com.gu.mobile.notifications.football.models.{FootballMatchEvent, RawMatchData}
+import com.gu.mobile.notifications.football.notificationbuilders.MatchStatusLiveActivityPayloadBuilder
+import pa.{MatchDay, MatchEvent}
 import play.api.libs.json.{Format, Json}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
-
-case class EndedMatch(matchId: String, startTime: DateTime)
 
 case class PACompetition(
     id: String,
@@ -31,6 +31,7 @@ class FootballData(
     paClient: PaFootballClient,
     syntheticEvents: SyntheticMatchEventGenerator,
     competitionsDataStore: S3DataStore[PACompetition],
+    payloadStateCheck: DynamoPayloadStateCheck,
     stage: String,
 ) extends Logging {
 
@@ -169,10 +170,22 @@ class FootballData(
     }
   }
 
-  private def processMatch(matchDay: MatchDay): Future[Option[RawMatchData]] = {
+  private def appendSyntheticEvents(matchDay: MatchDay, events: List[MatchEvent], stateChange: Boolean)(syntheticMatchEventGenerator: SyntheticMatchEventGenerator): Future[(MatchDay, List[MatchEvent])] = {
+    val eventsWithSyntheticEvents = syntheticMatchEventGenerator.generate(events, matchDay.id, matchDay, stateChange )
+    Future.successful((matchDay, eventsWithSyntheticEvents))
+  }
+
+  // Process individual match
+  private[lib] def processMatch(matchDay: MatchDay): Future[Option[RawMatchData]] = {
     val matchData = for {
-      (matchDay, events) <- paClient.eventsForMatch(matchDay, syntheticEvents)
-    } yield Some(RawMatchData(matchDay, events))
+      // fetch current PA events timeline for match
+      (_, events) <- paClient.eventsForMatch(matchDay)
+      // check if the current match state is identical to the last known payload state sent.
+      stateChange <- isFootballMatchStateIdentical(matchDay, events).map(!_)
+      // add synthetic events to the PA events timeline, if any are generated.
+      // a state change synth even will be generated for every update, but we filter out the superfluous ones in the EventConsumer.
+      (_, eventsWithSyntheticEvents) <- appendSyntheticEvents(matchDay, events, stateChange)(syntheticEvents)
+    } yield Some(RawMatchData(matchDay, eventsWithSyntheticEvents))
 
     matchData.recover { case NonFatal(exception) =>
       logger.error(s"Failed to process match ${matchDay.id}: ${exception.getMessage}", exception)
@@ -180,4 +193,35 @@ class FootballData(
     }
   }
 
+  private[lib] def isFootballMatchStateIdentical(matchDay: MatchDay, events: List[pa.MatchEvent]): Future[Boolean] = {
+    val payloadBuilder = new MatchStatusLiveActivityPayloadBuilder()
+    val toFootballEvent = FootballMatchEvent.fromPaMatchEvent(matchDay.homeTeam, matchDay.awayTeam) _
+
+    events.reverse match {
+      case latestEvent :: previousEvents =>
+        toFootballEvent(latestEvent) match {
+          case Some(triggeringEvent) =>
+            val footballMatchState = payloadBuilder.buildFootballContentState(
+              triggeringEvent = triggeringEvent,
+              matchInfo = matchDay,
+              previousEvents = previousEvents.reverse.flatMap(toFootballEvent),
+              articleId = None,
+            )
+
+            payloadStateCheck
+              .isMatchStateIdentical(matchDay.id, footballMatchState)
+              .recover { case NonFatal(exception) =>
+                logger.error(s"Error checking for for identical football match state ${matchDay.id}: ${exception.getMessage}")
+                true // assume identical
+              }
+
+          case None =>
+            // latest event couldn't be converted to a FootballMatchEvent
+            Future.successful(true)
+        }
+
+      case Nil =>
+        Future.successful(true) // assume identical
+    }
+  }
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -197,31 +197,20 @@ class FootballData(
     val payloadBuilder = new MatchStatusLiveActivityPayloadBuilder()
     val toFootballEvent = FootballMatchEvent.fromPaMatchEvent(matchDay.homeTeam, matchDay.awayTeam) _
 
-    events.reverse match {
-      case latestEvent :: previousEvents =>
-        toFootballEvent(latestEvent) match {
-          case Some(triggeringEvent) =>
-            val footballMatchState = payloadBuilder.buildFootballContentState(
-              triggeringEvent = triggeringEvent,
-              matchInfo = matchDay,
-              previousEvents = previousEvents.reverse.flatMap(toFootballEvent),
-              articleId = None,
-            )
-
-            payloadStateCheck
-              .isMatchStateIdentical(matchDay.id, footballMatchState)
-              .recover { case NonFatal(exception) =>
-                logger.error(s"Error checking for for identical football match state ${matchDay.id}: ${exception.getMessage}")
-                true // assume identical
-              }
-
-          case None =>
-            // latest event couldn't be converted to a FootballMatchEvent
-            Future.successful(true)
+    if (events.isEmpty) Future.successful(true) // no stage change before a match has started.
+    else {
+      val footballMatchState = payloadBuilder.buildFootballContentState(
+        currentMinute = None,
+        matchInfo = matchDay,
+        allEvents = events.flatMap(toFootballEvent),
+        articleId = None,
+      )
+      payloadStateCheck
+        .isMatchStateIdentical(matchDay.id, footballMatchState)
+        .recover { case NonFatal(exception) =>
+          logger.error(s"Error checking for for identical football match state ${matchDay.id}: ${exception.getMessage}")
+          true // assume identical // todo confirm this behaviour is desired.
         }
-
-      case Nil =>
-        Future.successful(true) // assume identical
     }
   }
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/PaFootballClient.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/PaFootballClient.scala
@@ -52,10 +52,10 @@ class PaFootballClient(override val apiKey: String, apiBase: String) extends PaC
     Future.reduceLeft(days.map { day => matchDay(day).recover { case _ => List.empty } })(_ ++ _)
   }
 
-  def eventsForMatch(matchDay: MatchDay, syntheticMatchEventGenerator: SyntheticMatchEventGenerator)(implicit ec: ExecutionContext): Future[(MatchDay, List[MatchEvent])] =
+  def eventsForMatch(matchDay: MatchDay)(implicit ec: ExecutionContext): Future[(MatchDay, List[MatchEvent])] =
     for {
       events <- matchEvents(matchDay.id).map(_.toList.flatMap(_.events))
     } yield {
-      (matchDay, syntheticMatchEventGenerator.generate(events, matchDay.id, matchDay))
+      (matchDay, events)
     }
 }

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -3,22 +3,22 @@ package com.gu.mobile.notifications.football.lib
 import java.util.UUID
 import pa.{MatchDay, MatchEvent}
 
-import java.time.{Instant, ZoneId, ZonedDateTime}
+import java.time.ZonedDateTime
 
 // Synthetic events create a timeline event for a match status change, that can be processed by the EventConsumer
 // and transformed into a NotificationPayload and/or LiveActivityPayload for broadcasting.
 
 class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
 
-  def generate(events: List[MatchEvent], id: String, matchDay: MatchDay): List[MatchEvent] = {
+  def generate(events: List[MatchEvent], id: String, matchDay: MatchDay, stateChange: Boolean): List[MatchEvent] = {
     // Live activity synthetic events are appended at the end, but when they are first generated, no other timeline events exist and duplicate events are filtered so this should not matter.
-    events.map(enhanceTimelineEvents(id)) ++ generators.flatMap(_.apply(matchDay, events)) // order is important here
+    events.map(enhanceTimelineEvents(id)) ++ generators.flatMap(_.apply(matchDay, events, stateChange)) // order is important here
   }
 
-  private type MatchEventGenerator = (MatchDay, List[pa.MatchEvent]) => Option[MatchEvent]
+  private type MatchEventGenerator = (MatchDay, List[pa.MatchEvent], Boolean) => Option[MatchEvent]
 
   // generate a push notification 20 minutes before the scheduled kick off
-  private val preMatch: MatchEventGenerator = { (matchDay: MatchDay, _) =>
+  private val preMatch: MatchEventGenerator = { (matchDay: MatchDay, _, _) =>
     if (koWithin20Minutes(matchDay.date.toEpochSecond)) Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/pre-match".getBytes).toString),
       eventType = "pre-match"
@@ -26,7 +26,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val fullTime: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val fullTime: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.result) Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/full-time".getBytes).toString),
       eventType = "full-time"
@@ -34,7 +34,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val halfTime: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val halfTime: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "HT") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/half-time".getBytes).toString),
       eventType = "half-time"
@@ -42,7 +42,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val secondHalf: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val secondHalf: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "SHS") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/second-half".getBytes).toString),
       eventType = "second-half"
@@ -52,7 +52,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
 
 
   // LIVE ACTIVITIES
-  private val suspended: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val suspended: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "Suspended") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/suspended".getBytes).toString),
       eventType = "suspended"
@@ -60,7 +60,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val resumed: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val resumed: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "Resumed") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/resumed".getBytes).toString),
       eventType = "resumed"
@@ -68,7 +68,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val abandoned: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val abandoned: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "Abandoned") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/abandoned".getBytes).toString),
       eventType = "abandoned"
@@ -76,7 +76,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val postponed: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val postponed: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "Postponed") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/postponed".getBytes).toString),
       eventType = "postponed"
@@ -84,7 +84,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val cancelled: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val cancelled: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "Cancelled") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/cancelled".getBytes).toString),
       eventType = "cancelled"
@@ -93,7 +93,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
   }
 
   // match statuses synthetic events needed for live activities
-  private val extraTimeToBePlayed: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val extraTimeToBePlayed: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "FTET") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/extra-time-to-be-played".getBytes).toString),
       eventType = "extra-time-to-be-played"
@@ -101,7 +101,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val extraTimeFirstHalf: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val extraTimeFirstHalf: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "ETS") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/extra-time-first-half".getBytes).toString),
       eventType = "extra-time-first-half"
@@ -109,7 +109,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val extraTimeHalfTime: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val extraTimeHalfTime: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "ETHT") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/extra-time-half-time".getBytes).toString),
       eventType = "extra-time-half-time"
@@ -117,7 +117,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val extraTimeSecondHalf: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val extraTimeSecondHalf: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "ETSHS") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/extra-time-second-half".getBytes).toString),
       eventType = "extra-time-second-half"
@@ -125,7 +125,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val penaltiesToBePlayed: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val penaltiesToBePlayed: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "FTPT" || matchDay.matchStatus == "ETFTPT") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/penalties-to-be-played".getBytes).toString),
       eventType = "penalties-to-be-played"
@@ -133,7 +133,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     else None
   }
 
-  private val penalties: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val penalties: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.matchStatus == "PT") Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/penalties".getBytes).toString),
       eventType = "penalties"
@@ -147,7 +147,7 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
   def koWithinTwoHours(ko: Long): Boolean = now >= ko - 7200 && now < ko - 1200
   def koWithin20Minutes(ko: Long): Boolean = now >= ko - 1200 && now < ko
 
-  private val createChannel: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val createChannel: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (koWithinTwoHours(matchDay.date.toEpochSecond)) {
       Some(emptyMatchEvent.copy(
         id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/create-channel".getBytes).toString),
@@ -157,8 +157,8 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     } else None
   }
 
-  // sent to push notification service to trigger live activity start (not to the  liveactivities service)
-  private val startLiveActivity: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  // sent to push notification service to trigger live activity start (not to the liveactivities service)
+  private val startLiveActivity: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (koWithin20Minutes(matchDay.date.toEpochSecond)) Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/start-live-activity".getBytes).toString),
       eventType = "start-live-activity"
@@ -167,12 +167,30 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
   }
 
   // Note: matches may be abandoned after kick off - this is handled in the liveActivityPayloadBuilder
-  private val endLiveActivity: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent]) =>
+  private val endLiveActivity: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], _) =>
     if (matchDay.result && !matchDay.liveMatch) Some(emptyMatchEvent.copy(
       id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/end-live-activity".getBytes).toString),
       eventType = "end-live-activity"
     ))
     else None
+  }
+
+  // Note: VAR introduces the possibility of goal or red card event reversals. The original event disappears from PA match event list data once reversed,
+  // so we must instead calculate if the match state has changed every polling cycle and generate a synthetic 'stateChangeEvent' to trigger
+  // an update or push notification if required.
+  private val stateChangeEvent: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], stateChange) =>
+    if (stateChange) {
+      matchEvents.reverse match {
+        case latestEvent :: _ =>
+          Some(emptyMatchEvent.copy(
+            // TODO is pa eventime unique enough to generate a UUID?
+            id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/state-change/${latestEvent.eventTime}".getBytes).toString),
+            eventType = "state-change"
+          ))
+
+        case Nil => None
+      }
+    } else None
   }
 
   private val generators: List[MatchEventGenerator] = List(
@@ -193,7 +211,9 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
     cancelled,
     createChannel,
     startLiveActivity,
-    endLiveActivity)
+    endLiveActivity,
+    stateChangeEvent
+  )
 
   private def emptyMatchEvent = MatchEvent(
     id = None,

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGenerator.scala
@@ -178,18 +178,12 @@ class SyntheticMatchEventGenerator(getCurrentTime: () => ZonedDateTime) {
   // Note: VAR introduces the possibility of goal or red card event reversals. The original event disappears from PA match event list data once reversed,
   // so we must instead calculate if the match state has changed every polling cycle and generate a synthetic 'stateChangeEvent' to trigger
   // an update or push notification if required.
-  private val stateChangeEvent: MatchEventGenerator = { (matchDay: MatchDay, matchEvents: List[pa.MatchEvent], stateChange) =>
+  private val stateChangeEvent: MatchEventGenerator = { (matchDay: MatchDay, _, stateChange: Boolean) =>
     if (stateChange) {
-      matchEvents.reverse match {
-        case latestEvent :: _ =>
           Some(emptyMatchEvent.copy(
-            // TODO is pa eventime unique enough to generate a UUID?
-            id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/state-change/${latestEvent.eventTime}".getBytes).toString),
+            id = Some(UUID.nameUUIDFromBytes(s"football-match/${matchDay.id}/state-change/${System.currentTimeMillis()}".getBytes).toString),
             eventType = "state-change"
           ))
-
-        case Nil => None
-      }
     } else None
   }
 

--- a/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/models/MatchEvents.scala
@@ -15,7 +15,8 @@ object FootballMatchEvent {
     MatchPhaseEvent.fromEvent(event) orElse
       Goal.fromEvent(homeTeam, awayTeam)(event) orElse
       Dismissal.fromEvent(homeTeam,awayTeam)(event) orElse
-      PenaltyShootoutKick.fromEvent(homeTeam, awayTeam)(event)
+      PenaltyShootoutKick.fromEvent(homeTeam, awayTeam)(event) orElse
+      MatchStateChangeEvent.fromEvent(event)
 }
 
 object Score {
@@ -171,6 +172,19 @@ object PenaltyShootoutScore {
 case class PenaltyShootoutScore(homeScored: Int = 0, homeMissed: Int = 0, homeSaved: Int = 0, awayScored: Int = 0, awayMissed: Int = 0, awaySaved: Int = 0)
 
 
+// This is used to identify when VAR has been used to overturn
+// other match events such as goals or red cards, so we can send
+// a correction push notification or broadcast update.
+case class MatchStateChangeEvent(eventId: String) extends FootballMatchEvent
+object MatchStateChangeEvent {
+  def fromEvent(event: pa.MatchEvent): Option[MatchStateChangeEvent] = {
+    val eventId = event.id.getOrElse("")
+    condOpt(event.eventType) {
+      case "state-change" => MatchStateChangeEvent(eventId)
+    }
+  }
+}
+
 trait MatchPhaseEvent extends FootballMatchEvent {
   val currentMinute: Option[Int] = None
 }
@@ -199,11 +213,11 @@ object MatchPhaseEvent {
       case "create-channel"                               => CreateChannel(eventId)
       case "start-live-activity"                          => StartLiveActivity(eventId)
       case "end-live-activity"                            => EndLiveActivity(eventId)
-
     }
   }
 }
 
+// standard Match phase events
 case class PreMatch(eventId: String) extends MatchPhaseEvent
 case class KickOff(eventId: String) extends MatchPhaseEvent
 case class FullTime(eventId: String) extends MatchPhaseEvent

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -10,13 +10,12 @@ import java.util.{Date, UUID}
 class MatchStatusLiveActivityPayloadBuilder {
 
   def buildFootballContentState(
-      triggeringEvent: FootballMatchEvent,
+                                 currentMinute: Option[Int],
       matchInfo: MatchDay,
-      previousEvents: List[FootballMatchEvent],
+                                 allEvents: List[FootballMatchEvent],
       articleId: Option[String]
   ): FootballMatchContentState = {
 
-    val allEvents = triggeringEvent :: previousEvents
     val goals = allEvents.collect { case g: Goal => g }
     val score = Score.fromGoals(matchInfo.homeTeam, matchInfo.awayTeam, goals)
     val dismissals = allEvents.collect { case d: Dismissal => d }
@@ -24,13 +23,6 @@ class MatchStatusLiveActivityPayloadBuilder {
     val penaltyShootoutKicks = allEvents.collect { case psr: PenaltyShootoutKick => psr }
     val penaltyShootoutScore = PenaltyShootoutScore.fromPenaltyShootoutKicks(matchInfo.homeTeam, matchInfo.awayTeam, penaltyShootoutKicks)
 
-    val currentMinute: Option[Int] = triggeringEvent match {
-      case d:Dismissal => Some(d.minute)
-      case g:Goal => Some(g.minute)
-      case p: PenaltyShootoutKick => Some(p.minute)
-      case phase: MatchPhaseEvent => phase.currentMinute
-      case _ => None
-    }
 
     def transformTeamName(name: String): String = name.replace(" Ladies", "")
 
@@ -76,7 +68,17 @@ class MatchStatusLiveActivityPayloadBuilder {
       articleId: Option[String]
   ): LiveActivityPayload = {
 
-    val contentState = buildFootballContentState(triggeringEvent, matchInfo, previousEvents, articleId)
+    val allEvents = triggeringEvent :: previousEvents
+
+    val currentMinute: Option[Int] = triggeringEvent match {
+      case d: Dismissal => Some(d.minute)
+      case g: Goal => Some(g.minute)
+      case p: PenaltyShootoutKick => Some(p.minute)
+      case phase: MatchPhaseEvent => phase.currentMinute
+      case _ => None
+    }
+
+    val contentState = buildFootballContentState(currentMinute, matchInfo, allEvents, articleId)
 
     // certain type of triggering match event types will trigger different live activity event type.
     val liveActivityEventType = triggeringEvent match {

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -9,12 +9,12 @@ import java.util.{Date, UUID}
 
 class MatchStatusLiveActivityPayloadBuilder {
 
-  def build(
+  def buildFootballContentState(
       triggeringEvent: FootballMatchEvent,
       matchInfo: MatchDay,
       previousEvents: List[FootballMatchEvent],
       articleId: Option[String]
-  ): LiveActivityPayload = {
+  ): FootballMatchContentState = {
 
     val allEvents = triggeringEvent :: previousEvents
     val goals = allEvents.collect { case g: Goal => g }
@@ -32,7 +32,9 @@ class MatchStatusLiveActivityPayloadBuilder {
       case _ => None
     }
 
-    val contentState = FootballMatchContentState(
+    def transformTeamName(name: String): String = name.replace(" Ladies", "")
+
+    FootballMatchContentState(
       matchStatus = MatchStatus.fromString(matchInfo.matchStatus),
       kickOffTimestamp = matchInfo.date.toEpochSecond, // included date and time
       homeTeam = TeamState(
@@ -65,6 +67,16 @@ class MatchStatusLiveActivityPayloadBuilder {
       articleUrl = articleId.map(id => new URI(s"http://www.theguardian.com/$id").toString),
       matchInfoUrl = new URI(s"http://www.theguardian.com/football/match/${matchInfo.id}").toString
     )
+  }
+
+  def build(
+      triggeringEvent: FootballMatchEvent,
+      matchInfo: MatchDay,
+      previousEvents: List[FootballMatchEvent],
+      articleId: Option[String]
+  ): LiveActivityPayload = {
+
+    val contentState = buildFootballContentState(triggeringEvent, matchInfo, previousEvents, articleId)
 
     // certain type of triggering match event types will trigger different live activity event type.
     val liveActivityEventType = triggeringEvent match {
@@ -93,6 +105,5 @@ class MatchStatusLiveActivityPayloadBuilder {
 
   }
 
-  def transformTeamName(name: String): String = name.replace(" Ladies", "")
 
 }

--- a/football/src/test/resources/20170811_statechange.xml
+++ b/football/src/test/resources/20170811_statechange.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<matches>
+    <match matchID="4011135" date="11/08/2017" koTime="19:45">
+        <competition competitionID="100" seasonID="4578">Premier League 17/18</competition>
+        <stage stageNumber="1" stageType="League"/>
+        <round roundNumber="1">League</round>
+        <leg>1</leg>
+        <liveMatch>Yes</liveMatch>
+        <result>No</result>
+        <previewAvailable>No</previewAvailable>
+        <reportAvailable>No</reportAvailable>
+        <lineupsAvailable>Yes</lineupsAvailable>
+        <matchStatus>SHS</matchStatus>
+        <attendance>59387</attendance>
+        <referee refereeID="100924">Mike Dean</referee>
+        <venue venueID="69">Emirates Stadium</venue>
+        <homeTeam teamID="1006">
+            <teamName>Arsenal</teamName>
+            <score>4</score>
+            <htScore>2</htScore>
+            <aggregateScore/>
+            <scorers>
+                <![CDATA[Alexandre Lacazette (2),Danny Welbeck (45 +1:55),Aaron Ramsey (83),Olivier Giroud (85)]]></scorers>
+        </homeTeam>
+        <awayTeam teamID="29">
+            <teamName>Leicester</teamName>
+            <score>3</score>
+            <htScore>2</htScore>
+            <aggregateScore/>
+            <scorers><![CDATA[Shinji Okazaki (5),Jamie Vardy (29),Jamie Vardy (56)]]></scorers>
+        </awayTeam>
+        <comments/>
+    </match>
+</matches>

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/DynamoPayloadStateCheckSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/DynamoPayloadStateCheckSpec.scala
@@ -1,0 +1,92 @@
+package com.gu.mobile.notifications.football.lib
+
+import com.gu.mobile.notifications.client.models.liveActitivites._
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+
+import java.util.UUID
+
+class DynamoPayloadStateCheckSpec extends Specification {
+
+  val stateChecker = new DynamoPayloadStateCheck(null, "test-table")
+
+  def footballState(
+    homeScore: Int = 0,
+    awayScore: Int = 0,
+    homeRedCards: Int = 0,
+    awayRedCards: Int = 0,
+    matchStatus: MatchStatus = FirstHalf,
+    articleUrl: Option[String] = None,
+  ): FootballMatchContentState =
+    FootballMatchContentState(
+      matchStatus = matchStatus,
+      kickOffTimestamp = 0L,
+      homeTeam = TeamState(id = "1", name = "Arsenal", score = homeScore, redCards = homeRedCards),
+      awayTeam = TeamState(id = "2", name = "Chelsea", score = awayScore, redCards = awayRedCards),
+      competition = Competition(id = "100", name = "Premier League"),
+      articleUrl = articleUrl,
+      matchInfoUrl = "https://www.theguardian.com/football/match/1",
+    )
+
+  // Build the `payload` column exactly as production does: the JSON-serialised LiveActivityPayload.
+  def payloadJson(state: Option[ContentState], eventType: LiveActivityEventType = UpdateLiveActivityEvent): String = {
+    val payload = LiveActivityPayload(
+      id = UUID.randomUUID(),
+      eventType = eventType,
+      liveActivityType = FootballLiveActivity,
+      liveActivityID = "match-1",
+      dynamoStoreData = None,
+      broadcastContentStateData = state,
+      eventTimestamp = 0L,
+    )
+    Json.prettyPrint(Json.toJson(payload))
+  }
+
+  def row(state: Option[ContentState], ttl: Long): DynamoMatchLiveActivity =
+    DynamoMatchLiveActivity(
+      id = UUID.randomUUID().toString,
+      liveActivityID = "match-1",
+      payload = payloadJson(state),
+      ttl = ttl,
+    )
+
+  "footballStateFromPayload" should {
+    "extract the football content state from a serialised payload (round-trips through JSON)" in {
+      val state = footballState(homeScore = 1)
+      stateChecker.footballStateFromPayload(payloadJson(Some(state))) must beSome(state)
+    }
+
+    "return None when the payload carries no broadcast content state" in {
+      stateChecker.footballStateFromPayload(payloadJson(None, eventType = CreateChannelEvent)) must beNone
+    }
+  }
+
+  "isMatchStateIdentical(isIdenticalToLatest) decision logic " should {
+    "assume identical when there is no previously stored payload for the match (first match payload)" in {
+      stateChecker.isIdenticalToLatest(Nil, footballState()) must beTrue
+    }
+
+    "return true when the latest payload state equals the provided state" in {
+      val state = footballState(homeScore = 1, homeRedCards = 1)
+      stateChecker.isIdenticalToLatest(List(row(Some(state), ttl = 10)), state) must beTrue
+    }
+
+    "return false when the latest payload state differs (e.g. a new goal)" in {
+      val latest = footballState(homeScore = 1)
+      val current = footballState(homeScore = 2)
+      stateChecker.isIdenticalToLatest(List(row(Some(latest), ttl = 10)), current) must beFalse
+    }
+
+    "ignore articleUrl differences (treated as identical)" in {
+      val stored = footballState(homeScore = 1, articleUrl = None)
+      val current = footballState(homeScore = 1, articleUrl = Some("https://www.theguardian.com/football/article"))
+      stateChecker.isIdenticalToLatest(List(row(Some(stored), ttl = 10)), current) must beTrue
+    }
+
+    "still detect a real change when articleUrl also differs" in {
+      val stored = footballState(homeScore = 1, articleUrl = None)
+      val current = footballState(homeScore = 2, articleUrl = Some("https://www.theguardian.com/football/article"))
+      stateChecker.isIdenticalToLatest(List(row(Some(stored), ttl = 10)), current) must beFalse
+    }
+  }
+}

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -707,7 +707,8 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
       new SyntheticMatchEventGenerator(() => ZonedDateTime.now()).generate(
         rawEvents,
         "4011135",
-        matchDay
+        matchDay,
+        false
       )
 
     def matchData = MatchDataWithArticle(
@@ -729,7 +730,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
 
     def eventsLA: List[MatchEvent] =
       new SyntheticMatchEventGenerator(() => ZonedDateTime.now())
-        .generate(rawEventsLA, "4484328", matchDayLA)
+        .generate(rawEventsLA, "4484328", matchDayLA, false)
 
     def matchDataLA = MatchDataWithArticle(
       matchDayLA,

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/FootballDataSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/FootballDataSpec.scala
@@ -1,12 +1,16 @@
 package com.gu.mobile.notifications.football.lib
 
+import com.gu.mobile.notifications.client.models.liveActitivites.FootballMatchContentState
+import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import pa.{Competition, MatchDay, MatchDayTeam, Round, Stage}
 
 import java.time.ZonedDateTime
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
 
-class FootballDataSpec extends Specification {
+class FootballDataSpec extends Specification with Mockito {
 
   trait FootballDataScope extends Scope {
     val home = MatchDayTeam("1", "Arsenal", None, None, None, None)
@@ -62,7 +66,7 @@ class FootballDataSpec extends Specification {
 
   "competitionIsSupported" should {
 
-    val footballData = new FootballData(null, null, null, "test") // pass mocks or nulls as needed
+    val footballData = new FootballData(null, null, null, null, "test") // pass mocks or nulls as needed
 
     "return a match when its competition is in the supported list" in new FootballDataScope {
       val matches = List(matchDayWithCompetition("100"))
@@ -105,7 +109,7 @@ class FootballDataSpec extends Specification {
 
   "paProvideAlerts" should {
 
-    val footballData = new FootballData(null, null, null, "test")
+    val footballData = new FootballData(null, null, null, null, "test")
 
     def matchWith(competitionId: String, homeId: String = "1", awayId: String = "2", roundNumber: String = "5"): MatchDay =
       MatchDay(
@@ -180,7 +184,7 @@ class FootballDataSpec extends Specification {
 
   "isMidnight" should {
 
-    val footballData = new FootballData(null, null, null, "test")
+    val footballData = new FootballData(null, null, null, null, "test")
 
     "return true for a non-exempt competition kicking off at 00:00" in new FootballDataScope {
       val m = matchDayWithCompetition("100").copy(date = ZonedDateTime.parse("2026-05-18T00:00:00Z"))
@@ -195,6 +199,60 @@ class FootballDataSpec extends Specification {
     "return false for the World Cup (700) kicking off at 00:00" in new FootballDataScope {
       val m = matchDayWithCompetition("700").copy(date = ZonedDateTime.parse("2026-05-18T00:00:00Z"))
       footballData.isFakeMidnightKO(m) must beFalse
+    }
+  }
+
+  "isFootballMatchStateIdentical" should {
+
+    trait StateScope extends FootballDataScope {
+      val payloadStateDiffer: DynamoPayloadStateCheck = mock[DynamoPayloadStateCheck]
+      val footballData = new FootballData(null, null, null, payloadStateDiffer, "test")
+
+      def paEvent(eventType: String, matchTime: Option[String] = None, eventTime: Option[String] = None): pa.MatchEvent =
+        pa.MatchEvent(
+          id = Some("event-1"),
+          teamID = None,
+          eventType = eventType,
+          matchTime = matchTime,
+          eventTime = eventTime,
+          addedTime = None,
+          players = List.empty,
+          reason = None,
+          how = None,
+          whereFrom = None,
+          whereTo = None,
+          distance = None,
+          outcome = None
+        )
+
+      // A timeline event at 0:00 is converted to a KickOff FootballMatchEvent
+      val triggeringEvent: pa.MatchEvent = paEvent("timeline", matchTime = Some("0:00"), eventTime = Some("0"))
+    }
+
+    "return true when the differ reports the state is identical" in new StateScope {
+      payloadStateDiffer.isMatchStateIdentical(any[String], any[FootballMatchContentState])(any[ExecutionContext]) returns Future.successful(true)
+      Await.result(footballData.isFootballMatchStateIdentical(matchDayWithCompetition("100"), List(triggeringEvent)), 5.seconds) must beTrue
+    }
+
+    "return false when the differ reports the state has changed" in new StateScope {
+      payloadStateDiffer.isMatchStateIdentical(any[String], any[FootballMatchContentState])(any[ExecutionContext]) returns Future.successful(false)
+      Await.result(footballData.isFootballMatchStateIdentical(matchDayWithCompetition("100"), List(triggeringEvent)), 5.seconds) must beFalse
+    }
+
+    "return true (assume identical) when there are no events" in new StateScope {
+      Await.result(footballData.isFootballMatchStateIdentical(matchDayWithCompetition("100"), List.empty), 5.seconds) must beTrue
+      there was no(payloadStateDiffer).isMatchStateIdentical(any[String], any[FootballMatchContentState])(any[ExecutionContext])
+    }
+
+    "return true (assume identical) when the latest event cannot be converted to a football event" in new StateScope {
+      val unconvertibleEvent = paEvent("unknown-event-type")
+      Await.result(footballData.isFootballMatchStateIdentical(matchDayWithCompetition("100"), List(unconvertibleEvent)), 5.seconds) must beTrue
+      there was no(payloadStateDiffer).isMatchStateIdentical(any[String], any[FootballMatchContentState])(any[ExecutionContext])
+    }
+
+    "return true (assume identical) when the differ check fails" in new StateScope {
+      payloadStateDiffer.isMatchStateIdentical(any[String], any[FootballMatchContentState])(any[ExecutionContext]) returns Future.failed(new RuntimeException("dynamo down"))
+      Await.result(footballData.isFootballMatchStateIdentical(matchDayWithCompetition("100"), List(triggeringEvent)), 5.seconds) must beTrue
     }
   }
 }

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/FootballDataSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/FootballDataSpec.scala
@@ -4,11 +4,12 @@ import com.gu.mobile.notifications.client.models.liveActitivites.FootballMatchCo
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import pa.{Competition, MatchDay, MatchDayTeam, Round, Stage}
+import pa.{Competition, MatchDay, MatchDayTeam, MatchEvent, Parser, Round, Stage}
 
 import java.time.ZonedDateTime
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.io.Source
 
 class FootballDataSpec extends Specification with Mockito {
 
@@ -244,15 +245,58 @@ class FootballDataSpec extends Specification with Mockito {
       there was no(payloadStateDiffer).isMatchStateIdentical(any[String], any[FootballMatchContentState])(any[ExecutionContext])
     }
 
-    "return true (assume identical) when the latest event cannot be converted to a football event" in new StateScope {
-      val unconvertibleEvent = paEvent("unknown-event-type")
-      Await.result(footballData.isFootballMatchStateIdentical(matchDayWithCompetition("100"), List(unconvertibleEvent)), 5.seconds) must beTrue
-      there was no(payloadStateDiffer).isMatchStateIdentical(any[String], any[FootballMatchContentState])(any[ExecutionContext])
-    }
-
     "return true (assume identical) when the differ check fails" in new StateScope {
       payloadStateDiffer.isMatchStateIdentical(any[String], any[FootballMatchContentState])(any[ExecutionContext]) returns Future.failed(new RuntimeException("dynamo down"))
       Await.result(footballData.isFootballMatchStateIdentical(matchDayWithCompetition("100"), List(triggeringEvent)), 5.seconds) must beTrue
+    }
+  }
+
+  trait ProcessMatchScope extends Scope {
+    implicit val ec: ExecutionContext = ExecutionContext.global
+
+    private def loadFile(file: String): String = {
+      val stream = this.getClass.getClassLoader.getResourceAsStream(file)
+      Source.fromInputStream(stream).mkString
+    }
+
+    val matchDay: MatchDay = Parser.parseMatchDay(loadFile("20170811_statechange.xml")).head
+    val rawEvents: List[MatchEvent] = Parser.parseMatchEvents(loadFile("match-event-feed.xml")).get.events
+
+    val paClient: PaFootballClient = mock[PaFootballClient]
+    paClient.eventsForMatch(any[MatchDay])(any[ExecutionContext]) returns Future.successful((matchDay, rawEvents))
+
+    val syntheticEvents = new SyntheticMatchEventGenerator(() => ZonedDateTime.now())
+
+    def eventTypesFrom(stateIsIdentical: Boolean): List[String] = {
+      val payloadStateCheck = mock[DynamoPayloadStateCheck]
+      payloadStateCheck.isMatchStateIdentical(any[String], any[FootballMatchContentState])(
+        any[ExecutionContext],
+      ) returns Future.successful(stateIsIdentical)
+
+      val footballData = new FootballData(paClient, syntheticEvents, null, payloadStateCheck, "TEST")
+      val result = Await.result(footballData.processMatch(matchDay), 5.seconds)
+      result.toList.flatMap(_.allEvents).map(_.eventType)
+    }
+  }
+
+  "processMatch synthetic state-change event" should {
+
+    "add a state-change synthetic event when the match state has changed" in new ProcessMatchScope {
+      eventTypesFrom(stateIsIdentical = false) must contain("state-change")
+    }
+
+    "not add a state-change synthetic event when the match state is identical" in new ProcessMatchScope {
+      eventTypesFrom(stateIsIdentical = true) must not(contain("state-change"))
+    }
+
+    "not add a state-change synthetic event when the state check errors (assume identical)" in new ProcessMatchScope {
+      val payloadStateCheck = mock[DynamoPayloadStateCheck]
+      payloadStateCheck.isMatchStateIdentical(any[String], any[FootballMatchContentState])(any[ExecutionContext]) returns Future.failed(new RuntimeException("dynamo down"))
+
+      val footballData = new FootballData(paClient, syntheticEvents, null, payloadStateCheck, "TEST")
+      val eventTypes = Await.result(footballData.processMatch(matchDay), 5.seconds).toList.flatMap(_.allEvents).map(_.eventType)
+
+      eventTypes must not(contain("state-change"))
     }
   }
 }

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/SyntheticMatchEventGeneratorSpec.scala
@@ -57,79 +57,79 @@ class SyntheticMatchEventGeneratorSpec extends Specification {
   "A SyntheticMatchEvent generator" should {
     "Add id to first timeline event" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo) mustEqual List(timelineEvent.copy(id = Some(kickoffId)))
+      generator.generate(List(timelineEvent), "match-id", matchInfo, stateChange = false) mustEqual List(timelineEvent.copy(id = Some(kickoffId)))
     }
     "Add half-time event if status is HT" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "HT")).drop(1).head.eventType mustEqual "half-time"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "HT"), stateChange = false).drop(1).head.eventType mustEqual "half-time"
     }
     "Add second-half event if status is SHS" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "SHS")).drop(1).head.eventType mustEqual "second-half"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "SHS"), stateChange = false).drop(1).head.eventType mustEqual "second-half"
     }
     "Add full-time event if match is result" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(result = true, liveMatch = true)).drop(1).head.eventType mustEqual "full-time"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(result = true, liveMatch = true), stateChange = false).drop(1).head.eventType mustEqual "full-time"
     }
 
     "Add extra time event if status is ETS" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETS")).drop(1).head.eventType mustEqual "extra-time-first-half"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETS"), stateChange = false).drop(1).head.eventType mustEqual "extra-time-first-half"
     }
 
     "Add extra time half time event if status is ETHT" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETHT")).drop(1).head.eventType mustEqual "extra-time-half-time"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETHT"), stateChange = false).drop(1).head.eventType mustEqual "extra-time-half-time"
     }
 
     "Add extra time second half event if status is ETSHS" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETSHS")).drop(1).head.eventType mustEqual "extra-time-second-half"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETSHS"), stateChange = false).drop(1).head.eventType mustEqual "extra-time-second-half"
     }
 
     "Add penalty shootout event if status is PT" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "PT")).drop(1).head.eventType mustEqual "penalties"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "PT"), stateChange = false).drop(1).head.eventType mustEqual "penalties"
     }
 
     "Add extra-time-to-be-played event if status is FTET" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "FTET")).drop(1).head.eventType mustEqual "extra-time-to-be-played"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "FTET"), stateChange = false).drop(1).head.eventType mustEqual "extra-time-to-be-played"
     }
 
     "Add penalties-to-be-played event if status is FTPT" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "FTPT")).drop(1).head.eventType mustEqual "penalties-to-be-played"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "FTPT"), stateChange = false).drop(1).head.eventType mustEqual "penalties-to-be-played"
     }
 
     "Add penalties-to-be-played event if status is ETFTPT" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETFTPT")).drop(1).head.eventType mustEqual "penalties-to-be-played"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "ETFTPT"), stateChange = false).drop(1).head.eventType mustEqual "penalties-to-be-played"
     }
 
     "Add suspended event if status is Suspended" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Suspended")).drop(1).head.eventType mustEqual "suspended"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Suspended"), stateChange = false).drop(1).head.eventType mustEqual "suspended"
     }
 
     "Add resumed event if status is Resumed" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Resumed")).drop(1).head.eventType mustEqual "resumed"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Resumed"), stateChange = false).drop(1).head.eventType mustEqual "resumed"
     }
 
     "Add abandoned event if status is Abandoned" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Abandoned")).drop(1).head.eventType mustEqual "abandoned"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Abandoned"), stateChange = false).drop(1).head.eventType mustEqual "abandoned"
     }
 
     "Add postponed event if status is Postponed" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Postponed")).drop(1).head.eventType mustEqual "postponed"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Postponed"), stateChange = false).drop(1).head.eventType mustEqual "postponed"
     }
 
     "Add cancelled event if status is Cancelled" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Cancelled")).drop(1).head.eventType mustEqual "cancelled"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(matchStatus = "Cancelled"), stateChange = false).drop(1).head.eventType mustEqual "cancelled"
     }
 
   }
@@ -137,28 +137,43 @@ class SyntheticMatchEventGeneratorSpec extends Specification {
   "A SyntheticMatchEvent generator supporting Live Activities" should {
     "Add a createChannel event if match kick off is within 2 hrs" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusHours(1))).head.eventType mustEqual "create-channel"
+      generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusHours(1)), stateChange = false).head.eventType mustEqual "create-channel"
     }
 
     "Add a startLiveActivity event if match kick off is within 20min" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusMinutes(15))).map(_.eventType) must contain("start-live-activity")
+      generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusMinutes(15)), stateChange = false).map(_.eventType) must contain("start-live-activity")
     }
 
     "Add id to first timeline event" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(date = ZonedDateTime.now())) mustEqual List(timelineEvent.copy(id = Some(kickoffId)))
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(date = ZonedDateTime.now()), stateChange = false) mustEqual List(timelineEvent.copy(id = Some(kickoffId)))
     }
 
     "Add an endLiveActivity event if match info contains result" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(result = true, liveMatch = false)).reverse.head.eventType mustEqual "end-live-activity"
+      generator.generate(List(timelineEvent), "match-id", matchInfo.copy(result = true, liveMatch = false), stateChange = false).reverse.head.eventType mustEqual "end-live-activity"
     }
 
     "Add a pre-match event if match kick off is within 20min" in new TestScope {
       val generator = new SyntheticMatchEventGenerator(currentTime)
-      val events = generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusMinutes(15)))
+      val events = generator.generate(List(), "match-id", matchInfo.copy(date = ZonedDateTime.now.plusMinutes(15)), stateChange = false)
       events.map(_.eventType) must contain("pre-match")
     }
+  }
+
+  "A SyntheticMatchEvent generator supporting StateChangeEvents" should {
+    "Create a state-change event when a state change has occurred" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator(currentTime)
+      val events = generator.generate(List(timelineEvent), "match-id", matchInfo, stateChange = true)
+      events.map(_.eventType) must contain("state-change")
+    }
+
+    "Not create a state-change event when no state change has occurred" in new TestScope {
+      val generator = new SyntheticMatchEventGenerator(currentTime)
+      val events = generator.generate(List(timelineEvent), "match-id", matchInfo, stateChange = false)
+      events.map(_.eventType) must not contain("state-change")
+    }
+
   }
 }

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
@@ -1,8 +1,8 @@
 package com.gu.mobile.notifications.football.notificationbuilders
 
-import com.gu.mobile.notifications.client.models.DefaultGoalType
-import com.gu.mobile.notifications.client.models.liveActitivites.{FirstHalf, FootballLiveActivity, FootballMatchContentState, LiveActivityPayload, TeamState, UpdateLiveActivityEvent, Competition => LACompetition}
-import com.gu.mobile.notifications.football.models.Goal
+import com.gu.mobile.notifications.client.models.{DefaultGoalType, ScoredShootoutResult}
+import com.gu.mobile.notifications.client.models.liveActitivites.{CreateChannelEvent, EndLiveActivityEvent, FirstHalf, FootballLiveActivity, FootballMatchContentState, LiveActivityPayload, TeamState, UpdateLiveActivityEvent, Competition => LACompetition}
+import com.gu.mobile.notifications.football.models.{Abandoned, Cancelled, CreateChannel, Dismissal, EndLiveActivity, Goal, HalfTime, PenaltyShootoutKick}
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import pa.{Competition, MatchDay, MatchDayTeam, Round, Stage, Venue}
@@ -10,7 +10,6 @@ import pa.{Competition, MatchDay, MatchDayTeam, Round, Stage, Venue}
 import java.time.ZonedDateTime
 import java.util.UUID
 
-// todo add more tests
 class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
 
   "A MatchStatusLiveActivityPayloadBuilder" should {
@@ -56,10 +55,67 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
       contentState.competition.round mustEqual None
     }
 
+    "map an Abandoned trigger to an EndLiveActivityEvent" in new MatchEventsContext {
+      builder.build(Abandoned("e1"), matchInfo, List.empty, None).eventType mustEqual EndLiveActivityEvent
+    }
+
+    "map a Cancelled trigger to an EndLiveActivityEvent" in new MatchEventsContext {
+      builder.build(Cancelled("e1"), matchInfo, List.empty, None).eventType mustEqual EndLiveActivityEvent
+    }
+
+    "map a CreateChannel trigger to a CreateChannelEvent" in new MatchEventsContext {
+      builder.build(CreateChannel("e1"), matchInfo, List.empty, None).eventType mustEqual CreateChannelEvent
+    }
+
+    "map an EndLiveActivity trigger to an EndLiveActivityEvent" in new MatchEventsContext {
+      builder.build(EndLiveActivity("e1"), matchInfo, List.empty, None).eventType mustEqual EndLiveActivityEvent
+    }
+
+    "map any other trigger (e.g. a goal) to an UpdateLiveActivityEvent" in new MatchEventsContext {
+      builder.build(baseGoal, matchInfo, List.empty, None).eventType mustEqual UpdateLiveActivityEvent
+    }
+
+    "derive currentMinute from a Goal trigger" in new MatchEventsContext {
+      contentStateOf(builder.build(baseGoal, matchInfo, List.empty, None)).currentMinute mustEqual Some(5)
+    }
+
+    "derive currentMinute from a Dismissal trigger" in new MatchEventsContext {
+      val dismissal = Dismissal("e1", "Sent Off", home, 34, None)
+      contentStateOf(builder.build(dismissal, matchInfo, List.empty, None)).currentMinute mustEqual Some(34)
+    }
+
+    "derive currentMinute from a PenaltyShootoutKick trigger" in new MatchEventsContext {
+      val kick = PenaltyShootoutKick(ScoredShootoutResult, "Taker", home, away, 120, "e1")
+      contentStateOf(builder.build(kick, matchInfo, List.empty, None)).currentMinute mustEqual Some(120)
+    }
+
+    "have no currentMinute for a match-phase trigger" in new MatchEventsContext {
+      contentStateOf(builder.build(HalfTime("e1"), matchInfo, List.empty, None)).currentMinute mustEqual None
+    }
+
+    "aggregate goals and red cards across the triggering and previous events" in new MatchEventsContext {
+      val homeGoal2 = Goal(DefaultGoalType, "Mo", home, away, 20, None, "g2")
+      val awayGoal = Goal(DefaultGoalType, "Striker", away, home, 30, None, "g3")
+      val homeRedCard = Dismissal("d1", "Sent Off", home, 40, None)
+
+      val contentState = contentStateOf(builder.build(baseGoal, matchInfo, List(homeGoal2, awayGoal, homeRedCard), None))
+
+      contentState.homeTeam.score mustEqual 2 // baseGoal + homeGoal2
+      contentState.awayTeam.score mustEqual 1 // awayGoal
+      contentState.homeTeam.redCards mustEqual 1
+      contentState.awayTeam.redCards mustEqual 0
+      contentState.homeTeam.penaltyScore mustEqual None
+      contentState.awayTeam.penaltyScore mustEqual None
+    }
+
   }
 
   trait MatchEventsContext extends Scope {
     val builder = new MatchStatusLiveActivityPayloadBuilder()
+
+    def contentStateOf(payload: LiveActivityPayload): FootballMatchContentState =
+      payload.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState]
+
     val home = MatchDayTeam("1", "Liverpool", None, None, None, None)
     val away = MatchDayTeam("2", "Plymouth", None, None, None, None)
     val baseGoal = Goal(DefaultGoalType, "Steve", home, away, 5, None, "")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

#### Do not merge. Incorporated into #1862 

## What does this change?

This PR adds football match state diffing at the point the football Lambda fetches PA data. If a state change is detected, a synthetic `state-change` event is generated. We filter out those events from being processed by the two `EventConsumer` classes, so it should be safe to release this PR. There will be a subsequent PR to process and dedupe state change events in the event consumers.  

Draft. 

Implements left side of this diagram:

<img width="853" height="404" alt="image" src="https://github.com/user-attachments/assets/c5d89123-ff83-45b9-a956-995267dbfe52" />


## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
