### PR TITLE
Bump `tar@npm` 

### DIFF
--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -7501,15 +7501,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.2":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/b6bb420550ef50ef23356018155e956cd83282c97b6128d8d5cfe5740c57582d806a244b2ef0bf686a74ce526babe8b8b9061527623e935e850008d86d838929
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- Re-resolves the transitive tar dependency in `cdk/yarn.lock` from 7.5.11 to 7.5.22 to address https://github.com/advisories/GHSA-23hp-3jrh-7fpw. 
- tar is pulled in via jest → jest-haste-map → optional fsevents → node-gyp. The existing ^7.5.2 range already permitted the patched version (7.5.18+); the lockfile just hadn't been re-resolved since March. No package.json changes.

## How has this change been tested?
tar is just a dev-install tool so is not used by the application code so CI checks should be sufficient