### PR TITLE
Add `GuFastlyLogsIamRole` to enable Fastly logging to S3 aws-mobile-event-logs

### DIFF
--- a/cdk/lib/__snapshots__/report.test.ts.snap
+++ b/cdk/lib/__snapshots__/report.test.ts.snap
@@ -31,6 +31,9 @@ exports[`The Report stack matches the snapshot for CODE 1`] = `
       "GuRiffRaffDeploymentIdParameter",
       "GuCname",
       "GuScheduledLambda",
+      "GuFastlyCustomerIdParameter",
+      "GuFastlyLogsIamRole",
+      "GuPutS3ObjectsPolicy",
       "GuScheduledLambda",
     ],
     "gu:cdk:version": "TEST",
@@ -62,6 +65,11 @@ exports[`The Report stack matches the snapshot for CODE 1`] = `
       ],
       "Default": "/account/services/artifact.bucket.n10n",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "FastlyCustomerId": {
+      "Default": "/account/external/fastly/customer.id",
+      "Description": "SSM parameter containing the Fastly Customer ID. Can be obtained from https://manage.fastly.com/account/company by an admin",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "LoggingStreamName": {
@@ -805,6 +813,95 @@ exports[`The Report stack matches the snapshot for CODE 1`] = `
         "Roles": [
           {
             "Ref": "InstanceRoleReport42223080",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuFastlyLogsIamRoleE2DAFAB3": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "sts:ExternalId": {
+                    "Ref": "FastlyCustomerId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::717331877981:root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "report",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "GuFastlyLogsIamRolePolicy5BF3CDCA": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "EventConsumerBucketE6EE7609",
+                    },
+                    "/fastly/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuFastlyLogsIamRolePolicy5BF3CDCA",
+        "Roles": [
+          {
+            "Ref": "GuFastlyLogsIamRoleE2DAFAB3",
           },
         ],
       },
@@ -1989,6 +2086,9 @@ exports[`The Report stack matches the snapshot for PROD 1`] = `
       "GuRiffRaffDeploymentIdParameter",
       "GuCname",
       "GuScheduledLambda",
+      "GuFastlyCustomerIdParameter",
+      "GuFastlyLogsIamRole",
+      "GuPutS3ObjectsPolicy",
       "GuScheduledLambda",
     ],
     "gu:cdk:version": "TEST",
@@ -2020,6 +2120,11 @@ exports[`The Report stack matches the snapshot for PROD 1`] = `
       ],
       "Default": "/account/services/artifact.bucket.n10n",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "FastlyCustomerId": {
+      "Default": "/account/external/fastly/customer.id",
+      "Description": "SSM parameter containing the Fastly Customer ID. Can be obtained from https://manage.fastly.com/account/company by an admin",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "LoggingStreamName": {
@@ -2763,6 +2868,95 @@ exports[`The Report stack matches the snapshot for PROD 1`] = `
         "Roles": [
           {
             "Ref": "InstanceRoleReport42223080",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuFastlyLogsIamRoleE2DAFAB3": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "sts:ExternalId": {
+                    "Ref": "FastlyCustomerId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::717331877981:root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "report",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "GuFastlyLogsIamRolePolicy5BF3CDCA": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "EventConsumerBucketE6EE7609",
+                    },
+                    "/fastly/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuFastlyLogsIamRolePolicy5BF3CDCA",
+        "Roles": [
+          {
+            "Ref": "GuFastlyLogsIamRoleE2DAFAB3",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/report.test.ts.snap
+++ b/cdk/lib/__snapshots__/report.test.ts.snap
@@ -890,7 +890,7 @@ exports[`The Report stack matches the snapshot for CODE 1`] = `
                     {
                       "Ref": "EventConsumerBucketE6EE7609",
                     },
-                    "/fastly/test/*",
+                    "/fastly/role-test/*",
                   ],
                 ],
               },
@@ -2945,7 +2945,7 @@ exports[`The Report stack matches the snapshot for PROD 1`] = `
                     {
                       "Ref": "EventConsumerBucketE6EE7609",
                     },
-                    "/fastly/test/*",
+                    "/fastly/role-test/*",
                   ],
                 ],
               },

--- a/cdk/lib/__snapshots__/report.test.ts.snap
+++ b/cdk/lib/__snapshots__/report.test.ts.snap
@@ -890,7 +890,7 @@ exports[`The Report stack matches the snapshot for CODE 1`] = `
                     {
                       "Ref": "EventConsumerBucketE6EE7609",
                     },
-                    "/fastly/role-test/*",
+                    "/fastly/*",
                   ],
                 ],
               },
@@ -2945,7 +2945,7 @@ exports[`The Report stack matches the snapshot for PROD 1`] = `
                     {
                       "Ref": "EventConsumerBucketE6EE7609",
                     },
-                    "/fastly/role-test/*",
+                    "/fastly/*",
                   ],
                 ],
               },

--- a/cdk/lib/__snapshots__/report.test.ts.snap
+++ b/cdk/lib/__snapshots__/report.test.ts.snap
@@ -890,7 +890,7 @@ exports[`The Report stack matches the snapshot for CODE 1`] = `
                     {
                       "Ref": "EventConsumerBucketE6EE7609",
                     },
-                    "/fastly/*",
+                    "/fastly/test/*",
                   ],
                 ],
               },
@@ -2945,7 +2945,7 @@ exports[`The Report stack matches the snapshot for PROD 1`] = `
                     {
                       "Ref": "EventConsumerBucketE6EE7609",
                     },
-                    "/fastly/*",
+                    "/fastly/test/*",
                   ],
                 ],
               },

--- a/cdk/lib/report.ts
+++ b/cdk/lib/report.ts
@@ -216,7 +216,7 @@ export class Report extends GuStack {
 
 		new GuFastlyLogsIamRole(this, {
 			bucketName: eventLogsBucket.bucketName,
-			path: 'fastly/role-test/*',
+			path: 'fastly/*',
 		});
 
 		const eventConsumerApp = 'eventconsumer';

--- a/cdk/lib/report.ts
+++ b/cdk/lib/report.ts
@@ -216,7 +216,7 @@ export class Report extends GuStack {
 
 		new GuFastlyLogsIamRole(this, {
 			bucketName: eventLogsBucket.bucketName,
-			path: 'fastly/*',
+			path: 'fastly/test/*',
 		});
 
 		const eventConsumerApp = 'eventconsumer';

--- a/cdk/lib/report.ts
+++ b/cdk/lib/report.ts
@@ -216,7 +216,7 @@ export class Report extends GuStack {
 
 		new GuFastlyLogsIamRole(this, {
 			bucketName: eventLogsBucket.bucketName,
-			path: 'fastly/test/*',
+			path: 'fastly/role-test/*',
 		});
 
 		const eventConsumerApp = 'eventconsumer';

--- a/cdk/lib/report.ts
+++ b/cdk/lib/report.ts
@@ -4,7 +4,10 @@ import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuDynamoTable } from '@guardian/cdk/lib/constructs/dynamodb';
-import { GuAllowPolicy } from '@guardian/cdk/lib/constructs/iam';
+import {
+	GuAllowPolicy,
+	GuFastlyLogsIamRole,
+} from '@guardian/cdk/lib/constructs/iam';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
@@ -209,6 +212,11 @@ export class Report extends GuStack {
 			bucketName: `aws-mobile-event-logs-${stage.toLowerCase()}`,
 			removalPolicy: RemovalPolicy.RETAIN,
 			lifecycleRules: [{ expiration: Duration.days(21), enabled: true }],
+		});
+
+		new GuFastlyLogsIamRole(this, {
+			bucketName: eventLogsBucket.bucketName,
+			path: 'fastly/*',
 		});
 
 		const eventConsumerApp = 'eventconsumer';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Currently we use AWS Keys to enable Fastly to write logs to the S3 aws-mobile-event-logs bucket but Fastly now supports using an IAM role for this, which is more secure. This PR creates a new IAM role for Fastly using the gu-cdk construct `GuFastlyLogsIamRole`.


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
## How has this change been tested?
I've tested on CODE and verified that Fastly successfully writes to the aws-mobile-event-logs-code bucket using the IAM role.
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?
Deprecate the AWS Fastly keys (fastly-events)
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
