### PR TITLE
Trigger live activity update when event is deleted.

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -75,8 +75,9 @@ class MatchStatusLiveActivityPayloadBuilder {
       case _ => UpdateLiveActivityEvent
     }
 
-    // Deterministic ID used for deduplicating match events (matchId + eventId)
-    val derivedId = s"football-match-status/${matchInfo.id}/${triggeringEvent.eventId}"
+    // Deterministic ID used for deduplicating match events (matchId + eventId).
+    // Include isDeleted to ensure if a goal or dismissal is deleted by PA, an updated payload can be sent for that event.
+    val derivedId = s"football-match-status/${matchInfo.id}/${triggeringEvent.eventId}/${if (triggeringEvent.isDeleted) "deleted" else "active"}"
 
     LiveActivityPayload(
       id =

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
@@ -10,18 +10,17 @@ import pa.{Competition, MatchDay, MatchDayTeam, Round, Stage, Venue}
 import java.time.ZonedDateTime
 import java.util.UUID
 
-// todo add more tests
 class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
 
   "A MatchStatusLiveActivityPayloadBuilder" should {
 
     "Build a LiveActivityPayload for a goal event" in new MatchEventsContext {
-      val result = builder.build(baseGoal, matchInfo, List.empty, Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"))
+      val result = builder.build(baseGoal.copy(eventId = "event-id"), matchInfo, List.empty, Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"))
 
       result.eventType mustEqual UpdateLiveActivityEvent
       result.liveActivityType mustEqual FootballLiveActivity
       result.liveActivityID mustEqual "some-match-id"
-      result.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/".getBytes)
+      result.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/event-id/active".getBytes)
 
       val contentState = result.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState]
       contentState.homeTeam.name mustEqual "Liverpool"
@@ -49,7 +48,7 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
       result.eventType mustEqual UpdateLiveActivityEvent
       result.liveActivityType mustEqual FootballLiveActivity
       result.liveActivityID mustEqual "some-match-id"
-      result.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/".getBytes)
+      result.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id//active".getBytes)
 
       val contentState = result.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState]
       contentState.competition.name mustEqual "FA Cup"
@@ -70,21 +69,24 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
       contentState.awayTeam.score mustEqual 0
     }
 
-    "Ensure a deleted event payload has the same UUID so is not duplicated sent" in new MatchEventsContext {
-      val result1 = builder.build(
-        baseGoal.copy(eventId = "event-1"),
+    "Ensure a deleted event has a unique UUID so new payload can be triggered" in new MatchEventsContext {
+      val resultActive = builder.build(
+        baseGoal.copy(eventId = "event-id"),
         matchInfo.copy(round = Round("1", Some("League"))),
         List.empty,
         Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
       )
-      val result2 = builder.build(
-        baseGoal.copy(eventId = "event-1", isDeleted = true),
+      val resultDeleted = builder.build(
+        baseGoal.copy(eventId = "event-id", isDeleted = true),
         matchInfo.copy(round = Round("1", Some("League"))),
         List.empty,
         Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
       )
-      result1.id mustEqual (result2.id)
+
+      resultActive.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/event-id/active".getBytes)
+      resultDeleted.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/event-id/deleted".getBytes)
     }
+
 
   }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Closed in favour of #1870

Draft
Only fixed for live activities. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

Needs to be CODE tested once PA change is out. 

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
