### PR TITLE
Trigger live activity update and push notifcation when an event is deleted (v2)

### DIFF
--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilder.scala
@@ -75,8 +75,9 @@ class MatchStatusLiveActivityPayloadBuilder {
       case _ => UpdateLiveActivityEvent
     }
 
-    // Deterministic ID used for deduplicating match events (matchId + eventId)
-    val derivedId = s"football-match-status/${matchInfo.id}/${triggeringEvent.eventId}"
+    // Deterministic ID used for deduplicating match events (matchId + eventId).
+    // Include isDeleted to ensure if a goal or dismissal is deleted by PA, an updated payload can be sent for that event.
+    val derivedId = s"football-match-status/${matchInfo.id}/${triggeringEvent.eventId}/${if (triggeringEvent.isDeleted) "deleted" else "active"}"
 
     LiveActivityPayload(
       id =

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -203,6 +203,7 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
     case FullTime(_) => "Full-Time"
     case d: Dismissal if d.isDeleted => "Red card overturned"
     case _:Dismissal => "Red card"
+    case p: PenaltyShootoutKick if p.isDeleted => "Penalty kick disallowed"
     case _:PenaltyShootoutKick  => "Penalty Kick"
     case _:PreMatch => "Kick off soon"
     case _: ExtraTimeToBePlayed => "Extra time to follow"

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -64,7 +64,7 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
      importance = importance(triggeringEvent),
      topic = topics,
      matchStatus = status,
-     eventId = UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
+     eventId = s"${triggeringEvent.eventId}/${if (triggeringEvent.isDeleted) "deleted" else "active"}", // used to calculated derivedID for deduplication processing.
      kickOffTimestamp = Some(matchInfo.date.toEpochSecond),
      lineupsAvailable = Some(matchInfo.lineupsAvailable),
      detailedMatchStatus = Some(MatchStatus.fromString(matchInfo.matchStatus).status),
@@ -101,7 +101,7 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
           topic = topics,
           matchStatus = status,
           detailedMatchStatus = Some("PENALTIES"),
-          eventId = UUID.nameUUIDFromBytes(triggeringEvent.eventId.getBytes).toString,
+          eventId = s"${triggeringEvent.eventId}/${if (triggeringEvent.isDeleted) "deleted" else "active"}", // used to calculated derivedID for deduplication processing.
           kickOffTimestamp = Some(matchInfo.date.toEpochSecond),
           lineupsAvailable = Some(matchInfo.lineupsAvailable),
           debug = false,
@@ -185,7 +185,9 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
     }
 
     triggeringEvent match {
+      case g: Goal if g.isDeleted => goalMsg(g) // overturned ("deleted") goals
       case g: Goal => goalMsg(g)
+      case dismissal: Dismissal if dismissal.isDeleted => dismissalMsg(dismissal) // overturned ("deleted") dismissals
       case dismissal: Dismissal => dismissalMsg(dismissal)
       case prematch: PreMatch => s"""${homeTeamName} v ${awayTeamName}"""
       case _ => s"""${homeTeamName} ${score.home}-${score.away} ${awayTeamName} ($matchStatus)"""
@@ -193,11 +195,13 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
   }
 
   private def eventTitle(fme: FootballMatchEvent): String = fme match {
+    case g: Goal if g.isDeleted => "No Goal!"
     case _: Goal => "Goal!"
     case HalfTime(_) => "Half-time"
     case KickOff(_) => "Kick-off!"
     case SecondHalf(_) => "Second-half start"
     case FullTime(_) => "Full-Time"
+    case d: Dismissal if d.isDeleted => "Red card overturned"
     case _:Dismissal => "Red card"
     case _:PenaltyShootoutKick  => "Penalty Kick"
     case _:PreMatch => "Kick off soon"

--- a/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -195,7 +195,7 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
   }
 
   private def eventTitle(fme: FootballMatchEvent): String = fme match {
-    case g: Goal if g.isDeleted => "No Goal!"
+    case g: Goal if g.isDeleted => "No goal!"
     case _: Goal => "Goal!"
     case HalfTime(_) => "Half-time"
     case KickOff(_) => "Kick-off!"

--- a/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -71,7 +71,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
           Topic(FootballMatch, "4011135")
         ),
         matchStatus = "1st",
-        eventId = "7e730fbe-b013-3a0e-89cb-12b46260d7be",
+        eventId = "0b706f4b-a698-3314-9a94-419e42c6e610/active",
         kickOffTimestamp = Some(1502477100L),
         lineupsAvailable = Some(true),
         detailedMatchStatus = Some("FIRST_HALF"),
@@ -123,7 +123,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
           Topic(FootballMatch, "4011135")
         ),
         matchStatus = "HT",
-        eventId = "bb346058-64d0-3ab1-9016-ea19d90837f0",
+        eventId = "71356d2a-bbfa-315c-9474-5cd89620e2cd/active",
         kickOffTimestamp = Some(1502477100L),
         lineupsAvailable = Some(true),
         detailedMatchStatus = Some("HALF_TIME"),
@@ -177,7 +177,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
           Topic(FootballMatch, "4011135")
         ),
         matchStatus = "2nd",
-        eventId = "a45dfca1-ead9-3d8c-bf83-c4966a737b05",
+        eventId = "c7d9686f-c833-3d97-b73f-2ef41de359f8/active",
         kickOffTimestamp = Some(1502477100L),
         lineupsAvailable = Some(true),
         detailedMatchStatus = Some("SECOND_HALF"),
@@ -230,7 +230,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
           Topic(FootballMatch, "4011135")
         ),
         matchStatus = "FT",
-        eventId = "d59c9939-8199-3b8b-ad63-16aa020c1a73",
+        eventId = "c9fbf84c-37f6-3326-bab5-72749f354c3b/active",
         kickOffTimestamp = Some(1502477100L),
         lineupsAvailable = Some(true),
         detailedMatchStatus = Some("FULL_TIME"),
@@ -282,7 +282,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
           Topic(FootballMatch, "4011135")
         ),
         matchStatus = "1st",
-        eventId = "1c8d67f9-0f32-342a-8543-aa3e21ee7da4",
+        eventId = "23572205/active",
         kickOffTimestamp = Some(1502477100L),
         lineupsAvailable = Some(true),
         detailedMatchStatus = Some("FIRST_HALF"),
@@ -326,7 +326,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv)
           Topic(FootballMatch, "4011135")
         ),
         matchStatus = "1st",
-        eventId = "7c92d6ca-9f20-398f-9510-eb4c179fb5ae",
+        eventId = "25990905/active",
         kickOffTimestamp = Some(1502477100L),
         lineupsAvailable = Some(true),
         detailedMatchStatus = Some("FIRST_HALF"),

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
@@ -97,7 +97,7 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
       contentState.awayTeam.penaltyScore mustEqual Some(PenaltyShootoutState(0, 0, 0))
     }
 
-    "Ensure a deleted event payload has the same UUID so is not duplicated sent" in new MatchEventsContext {
+    "Ensure a deleted event payload has a unique UUID so a correction payload is triggered" in new MatchEventsContext {
       val resultActive = builder.build(
         baseGoal.copy(eventId = "event-id"),
         matchInfo.copy(round = Round("1", Some("League"))),

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusLiveActivityPayloadBuilderSpec.scala
@@ -10,18 +10,17 @@ import pa.{Competition, MatchDay, MatchDayTeam, Round, Stage, Venue}
 import java.time.ZonedDateTime
 import java.util.UUID
 
-// todo add more tests
 class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
 
   "A MatchStatusLiveActivityPayloadBuilder" should {
 
     "Build a LiveActivityPayload for a goal event" in new MatchEventsContext {
-      val result = builder.build(baseGoal, matchInfo, List.empty, Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"))
+      val result = builder.build(baseGoal.copy(eventId = "event-id"), matchInfo, List.empty, Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"))
 
       result.eventType mustEqual UpdateLiveActivityEvent
       result.liveActivityType mustEqual FootballLiveActivity
       result.liveActivityID mustEqual "some-match-id"
-      result.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/".getBytes)
+      result.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/event-id/active".getBytes)
 
       val contentState = result.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState]
       contentState.homeTeam.name mustEqual "Liverpool"
@@ -49,7 +48,7 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
       result.eventType mustEqual UpdateLiveActivityEvent
       result.liveActivityType mustEqual FootballLiveActivity
       result.liveActivityID mustEqual "some-match-id"
-      result.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/".getBytes)
+      result.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id//active".getBytes)
 
       val contentState = result.broadcastContentStateData.get.asInstanceOf[FootballMatchContentState]
       contentState.competition.name mustEqual "FA Cup"
@@ -99,20 +98,23 @@ class MatchStatusLiveActivityPayloadBuilderSpec extends Specification {
     }
 
     "Ensure a deleted event payload has the same UUID so is not duplicated sent" in new MatchEventsContext {
-      val result1 = builder.build(
-        baseGoal.copy(eventId = "event-1"),
+      val resultActive = builder.build(
+        baseGoal.copy(eventId = "event-id"),
         matchInfo.copy(round = Round("1", Some("League"))),
         List.empty,
         Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
       )
-      val result2 = builder.build(
-        baseGoal.copy(eventId = "event-1", isDeleted = true),
+      val resultDeleted = builder.build(
+        baseGoal.copy(eventId = "event-id", isDeleted = true),
         matchInfo.copy(round = Round("1", Some("League"))),
         List.empty,
         Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
       )
-      result1.id mustEqual (result2.id)
+
+      resultActive.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/event-id/active".getBytes)
+      resultDeleted.id mustEqual UUID.nameUUIDFromBytes("football-match-status/some-match-id/event-id/deleted".getBytes)
     }
+
 
   }
 

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -40,7 +40,7 @@ class MatchStatusNotificationBuilderSpec extends Specification {
         articleUri = Some(new URI("http://localhost/items/football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")),
         importance = Major,
         topic = List(Topic(TopicTypes.FootballTeam, "1"), Topic(TopicTypes.FootballTeam, "2"), Topic(TopicTypes.FootballMatch, "some-match-id")),
-        eventId = UUID.nameUUIDFromBytes("".getBytes).toString,
+        eventId = "/active",
         matchStatus = "1st",
         kickOffTimestamp = Some(ZonedDateTime.parse("2000-01-01T00:00:00Z").toEpochSecond),
         lineupsAvailable = Some(false),
@@ -205,7 +205,7 @@ class MatchStatusNotificationBuilderSpec extends Specification {
       notification.awayTeamPenalties shouldEqual Some(PenaltyShootoutState(0, 0, 0))
     }
 
-    "Ensure a deleted event payload has the same UUID so is not duplicated sent" in new MatchEventsContext {
+    "Ensure a deleted event payload has a unique UUID so a correction push notification payload is triggered" in new MatchEventsContext {
       val result1 = builder.build(
         baseGoal.copy(eventId = "event-1"),
         matchInfo.copy(round = Round("1", Some("League"))),
@@ -218,7 +218,78 @@ class MatchStatusNotificationBuilderSpec extends Specification {
         List.empty,
         Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
       )
-      result1.id mustEqual (result2.id)
+      result1.asInstanceOf[FootballMatchStatusPayload].eventId mustEqual "event-1/active"
+      result2.asInstanceOf[FootballMatchStatusPayload].eventId mustEqual "event-1/deleted"
+      result1.id must not equalTo result2.id
+    }
+
+    "Send an appropriate payload for a Goal" in new MatchEventsContext {
+      val notification = builder.build(
+        baseGoal,
+        matchInfo,
+        List.empty,
+        Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
+      ).asInstanceOf[FootballMatchStatusPayload]
+
+      notification.title shouldEqual Some("Goal!")
+      notification.message shouldEqual Some("Liverpool 1-0 Plymouth (1st)\nSteve 5min")
+      notification.homeTeamScore shouldEqual 1
+      notification.homeTeamMessage shouldEqual "Steve 5'"
+      notification.awayTeamScore shouldEqual 0
+      notification.awayTeamMessage shouldEqual " "
+    }
+
+    "Send an appropriate payload for a disallowed Goal" in new MatchEventsContext {
+      val notification = builder.build(
+        baseGoal.copy(isDeleted = true),
+        matchInfo,
+        List.empty,
+        Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
+      ).asInstanceOf[FootballMatchStatusPayload]
+
+      notification.title shouldEqual Some("No Goal!")
+      notification.message shouldEqual Some("Liverpool 0-0 Plymouth (1st)\nSteve 5min")
+      notification.homeTeamScore shouldEqual 0
+      notification.homeTeamMessage shouldEqual " "
+      notification.awayTeamScore shouldEqual 0
+      notification.awayTeamMessage shouldEqual " "
+    }
+
+    "send and appropriate payload for a Dismissal" in new MatchEventsContext {
+      val notification = builder.build(
+        Dismissal("event-1", "Player One", home, 20, None),
+        matchInfo,
+        List.empty,
+        Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
+      ).asInstanceOf[FootballMatchStatusPayload]
+
+      notification.title shouldEqual Some("Red card")
+      notification.message shouldEqual Some("Liverpool 0-0 Plymouth (1st)\nPlayer One (Liverpool) 20min")
+      notification.homeTeamScore shouldEqual 0
+      notification.homeTeamMessage shouldEqual "Red card: Player One 20'"
+      notification.homeTeamRedCards shouldEqual 1
+      notification.awayTeamScore shouldEqual 0
+      notification.awayTeamMessage shouldEqual " "
+      notification.awayTeamRedCards shouldEqual 0
+    }
+
+
+    "send and appropriate payload for a disallowed Dismissal" in new MatchEventsContext {
+      val notification = builder.build(
+        Dismissal("event-1", "Player One", home, 20, None, isDeleted = true),
+        matchInfo,
+        List.empty,
+        Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
+      ).asInstanceOf[FootballMatchStatusPayload]
+
+      notification.title shouldEqual Some("Red card overturned")
+      notification.message shouldEqual Some("Liverpool 0-0 Plymouth (1st)\nPlayer One (Liverpool) 20min")
+      notification.homeTeamScore shouldEqual 0
+      notification.homeTeamMessage shouldEqual " "
+      notification.homeTeamRedCards shouldEqual 0
+      notification.awayTeamScore shouldEqual 0
+      notification.awayTeamMessage shouldEqual " "
+      notification.awayTeamRedCards shouldEqual 0
     }
 
   }

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -247,7 +247,7 @@ class MatchStatusNotificationBuilderSpec extends Specification {
         Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
       ).asInstanceOf[FootballMatchStatusPayload]
 
-      notification.title shouldEqual Some("No Goal!")
+      notification.title shouldEqual Some("No goal!")
       notification.message shouldEqual Some("Liverpool 0-0 Plymouth (1st)\nSteve 5min")
       notification.homeTeamScore shouldEqual 0
       notification.homeTeamMessage shouldEqual " "

--- a/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
+++ b/football/src/test/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilderSpec.scala
@@ -292,6 +292,24 @@ class MatchStatusNotificationBuilderSpec extends Specification {
       notification.awayTeamRedCards shouldEqual 0
     }
 
+    "send and appropriate payload for a disallowed penalty shootout kick" in new MatchEventsContext {
+      val notification = builder.build(
+        PenaltyShootoutKick(ScoredShootoutResult, "Player One", home, away, 20, "event-d", isDeleted = true),
+        matchInfo,
+        List.empty,
+        Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live")
+      ).asInstanceOf[FootballPenaltyShootoutPayload]
+
+      notification.title shouldEqual Some("Penalty kick disallowed")
+      notification.message shouldEqual Some("Liverpool 0-0 Plymouth (1st)")
+      notification.homeTeamScore shouldEqual 0
+      notification.homeTeamMessage shouldEqual " "
+      notification.homeTeamRedCards shouldEqual 0
+      notification.awayTeamScore shouldEqual 0
+      notification.awayTeamMessage shouldEqual " "
+      notification.awayTeamRedCards shouldEqual 0
+    }
+
   }
 
   trait MatchEventsContext extends Scope {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->


Replaces #1870 skipping the refactor to try to make the notification builder more dry. 

Every polling cycling, the football lambda fetched the complete list of events for a match. It iterates over all those events, and generates a notification and live acvtivity payload for every "triggering" event, eg. a goal or a dismissal, as well as "synthetic" events we append like "half-time". 

A UUID is generated for each event (`derivedId`  on the trait). This is then used to deduplicate and NOT send payloads for events we have already seen. 

By updated the payload ID string used to generated the deduplication UUID to include `active/deleted` we can trigger a new payload to be sent when a "goal" event is subsequently deleted.  

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

Match 4553194 replayed on CODE
- [x] Football time machine archived data verified to becapturing status
- [x] Android simulater - Received alerts including VAR correction for goal event at (16')
- [x] Push notification payloads table - goal and goal correction alert sent. 
- [x] Team message: "Thierry Correia 16'" not included in correction payload.
- [x] Payload title/message - updated to No Goal!  and Red card overturned. 
- [x] iOS debug - Received live activity updates including VAR correction for goal event at (16')
- [x] LA payloads table - exepect goal and goal correction alert sent. 





**Original Goal Alert on old Android/iOS:**
```
   "title" : "Goal!",
  "message" : "Venezia 1-0 Lecce (1st)\nThierry Correia 16min"
  "homeTeamMessage" : "Thierry Correia 16'",
```
**Goal Correction Alert within 3minutes**
```
"title" : "No Goal!",
  "message" : "Venezia 0-0 Lecce (1st)\nThierry Correia 16min",
  "homeTeamMessage" : " ",

```

Dimissisal alerts will say `"Red card overturned"



<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
