### PR TITLE
Migrate Football Lambda to AWS sdk v2  and Scanamo to 6.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -309,10 +309,11 @@ lazy val football = lambda("football", "football")
   .settings(
     resolvers += "Guardian GitHub Releases" at "https://guardian.github.com/maven/repo-releases",
     libraryDependencies ++= Seq(
-      "org.scanamo" %% "scanamo" % "1.0.0-M12-1",
-      "org.scanamo" %% "scanamo-testkit" % "1.0.0-M12-1" % "test",
+      "org.scanamo" %% "scanamo" % "6.0.0",
+      "org.scanamo" %% "scanamo-testkit" % "6.0.0" % "test",
       "com.gu" %% "content-api-client-default" % "35.0.0",
-      "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
+      "software.amazon.awssdk" % "dynamodb" % awsSdk2Version,
+      "software.amazon.awssdk" % "s3" % awsSdk2Version,
       "com.gu" %% "pa-client" % paClientVersion,
       "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
       "org.specs2" %% "specs2-core" % specsVersion % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ val googleOAuthClient: String = "1.39.0"
 val nettyVersion: String = "4.2.2.Final"
 val slf4jVersion: String = "1.7.36"
 val logbackVersion: String = "1.5.32"
+val scanamoVersion: String = "6.0.0"
 
 val standardSettings = Seq[Setting[_]](
   // We should remove this when all transitive dependencies use the same version of scala-xml
@@ -309,8 +310,8 @@ lazy val football = lambda("football", "football")
   .settings(
     resolvers += "Guardian GitHub Releases" at "https://guardian.github.com/maven/repo-releases",
     libraryDependencies ++= Seq(
-      "org.scanamo" %% "scanamo" % "6.0.0",
-      "org.scanamo" %% "scanamo-testkit" % "6.0.0" % "test",
+      "org.scanamo" %% "scanamo" % scanamoVersion,
+      "org.scanamo" %% "scanamo-testkit" % scanamoVersion % "test",
       "com.gu" %% "content-api-client-default" % "35.0.0",
       "software.amazon.awssdk" % "dynamodb" % awsSdk2Version,
       "software.amazon.awssdk" % "s3" % awsSdk2Version,
@@ -475,8 +476,8 @@ lazy val liveactivities = lambda("liveactivities", "liveactivities", Some("com.g
       "software.amazon.awssdk" % "eventbridge" % "2.20.162",
       "software.amazon.awssdk" % "cloudwatch" % awsSdk2Version,
       "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
-      "org.scanamo" %% "scanamo" % "6.0.0",
-      "org.scanamo" %% "scanamo-testkit" % "6.0.0" % "test"
+      "org.scanamo" %% "scanamo" % scanamoVersion,
+      "org.scanamo" %% "scanamo-testkit" % scanamoVersion % "test"
     ),
     excludeDependencies ++= Seq(
       ExclusionRule("org.playframework", "play-ahc-ws_2.13"),

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Configuration.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Configuration.scala
@@ -1,7 +1,5 @@
 package com.gu.mobile.notifications.football
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
 import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
 import com.typesafe.config.Config
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain => AwsCredentialsProviderChainV2, DefaultCredentialsProvider => DefaultCredentialsProviderV2, ProfileCredentialsProvider => ProfileCredentialsProviderV2}
@@ -9,14 +7,9 @@ import com.gu.conf.{ConfigurationLoader, SSMConfigurationLocation}
 
 class Configuration extends Logging {
 
-  val credentials = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider("mobile"),
-    DefaultAWSCredentialsProviderChain.getInstance()
-  )
-
-  val credentialsv2 = AwsCredentialsProviderChainV2.of(
+  val credentials = AwsCredentialsProviderChainV2.of(
     ProfileCredentialsProviderV2.builder.profileName("mobile").build,
-    DefaultCredentialsProviderV2.create
+    DefaultCredentialsProviderV2.builder.build()
   )
 
   val appName = Option(System.getenv("App")).getOrElse(sys.error("No app name set. Lambda will not run"))
@@ -27,12 +20,12 @@ class Configuration extends Logging {
       case Some(_) => DevIdentity(appName)
       case None =>
         AppIdentity
-          .whoAmI(defaultAppName = appName, credentialsv2)
+          .whoAmI(defaultAppName = appName, credentials)
           .getOrElse(DevIdentity(appName))
     }
-    
-    logger.info(s"Detected AppIdentity: ${identity}")
-    ConfigurationLoader.load(identity = identity, credentials = credentialsv2) {
+
+    logger.info(s"Detected AppIdentity: $identity")
+    ConfigurationLoader.load(identity = identity, credentials = credentials) {
       case AwsIdentity(app, stack, stage, region) =>
         val path = s"/$app/$stage/$stack"
         logger.info(s"Attempting to retrieve config from: $path")

--- a/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -3,9 +3,11 @@ package com.gu.mobile.notifications.football
 import java.net.URI
 import java.time.ZonedDateTime
 import java.util.concurrent.TimeUnit
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder}
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.s3.S3Client
+
+
 import com.gu.contentapi.client.GuardianContentClient
 import com.gu.mobile.liveactivities.event.bus.LiveActivityPusher
 import com.gu.mobile.notifications.football.lib.{ArticleSearcher, DynamoDistinctCheck, DynamoMatchLiveActivity, DynamoMatchNotification, EventConsumer, EventFilter, FootballData, LiveActivityEventConsumer, NotificationHttpProvider, NotificationSender, NotificationsApiClient, PACompetition, PaFootballClient, S3DataStore, SyntheticMatchEventGenerator}
@@ -23,7 +25,6 @@ import com.gu.mobile.notifications.football.models.MatchDataWithArticle
 
 import scala.concurrent.Future
 import org.scanamo.generic.auto._
-import pa.Competition
 
 object Lambda extends Logging {
 
@@ -43,11 +44,12 @@ object Lambda extends Logging {
     new PaFootballClient(configuration.paApiKey, configuration.paHost)
   }
 
-  lazy val dynamoDBClient: AmazonDynamoDBAsync = {
+  lazy val dynamoDBClient: DynamoDbAsyncClient = {
     logger.debug("Creating dynamo db client")
-    AmazonDynamoDBAsyncClientBuilder.standard()
-      .withCredentials(configuration.credentials)
-      .withRegion(Regions.EU_WEST_1)
+    DynamoDbAsyncClient
+      .builder()
+      .credentialsProvider(configuration.credentials)
+      .region(Region.EU_WEST_1)
       .build()
   }
 
@@ -59,9 +61,10 @@ object Lambda extends Logging {
 
   val apiClient = new NotificationsApiClient(configuration)
 
-  lazy val s3Client: AmazonS3 = AmazonS3ClientBuilder.standard
-    .withRegion(Regions.EU_WEST_1)
-    .withCredentials(configuration.credentials)
+  lazy val s3Client: S3Client = S3Client
+    .builder()
+    .credentialsProvider(configuration.credentials)
+    .region(Region.EU_WEST_1)
     .build()
 
   lazy val competitionsDataStore = new S3DataStore[PACompetition](s3Client, paDataBucket)
@@ -130,7 +133,7 @@ object Lambda extends Logging {
   }
 }
 
-class NotificationHandler(configuration: Configuration, apiClient: NotificationsApiClient, dynamoDBClient: AmazonDynamoDBAsync, tableName: String) extends Logging {
+class NotificationHandler(configuration: Configuration, apiClient: NotificationsApiClient, dynamoDBClient: DynamoDbAsyncClient, tableName: String) extends Logging {
 
   lazy val notificationSender = new NotificationSender(apiClient)
 
@@ -155,7 +158,7 @@ class NotificationHandler(configuration: Configuration, apiClient: Notifications
   }
 }
 
-class LiveActivityHandler(configuration: Configuration, dynamoDBClient: AmazonDynamoDBAsync, tableName: String) extends Logging {
+class LiveActivityHandler(configuration: Configuration, dynamoDBClient: DynamoDbAsyncClient, tableName: String) extends Logging {
 
   private val eventBusName =
     s"liveactivities-eventbus-${configuration.stage}"

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoDistinctCheck.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/DynamoDistinctCheck.scala
@@ -1,7 +1,7 @@
 package com.gu.mobile.notifications.football.lib
 
 import scala.concurrent.{ExecutionContext, Future}
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import com.gu.mobile.notifications.client.models.{FootballMatchStatusPayload, Payload}
 import org.scanamo.{DynamoFormat, ScanamoAsync, Table}
 import DynamoDistinctCheck.{Distinct, DistinctStatus, Duplicate, Unknown}
@@ -57,7 +57,7 @@ object DynamoDistinctCheck {
 }
 
 class DynamoDistinctCheck[A <: Payload, D: DynamoFormat](
-  client: AmazonDynamoDBAsync,
+  client: DynamoDbAsyncClient,
   val tableName: String,
   partitionKeyName: String,
   toDynamoModel: A => D
@@ -69,7 +69,7 @@ class DynamoDistinctCheck[A <: Payload, D: DynamoFormat](
     lazy val scanamoAsync: ScanamoAsync = ScanamoAsync(client)
     lazy val notificationsTable = Table[D](tableName)
 
-   scanamoAsync.exec(notificationsTable.get(partitionKeyName -> item.id.toString)).map {
+   scanamoAsync.exec(notificationsTable.get(partitionKeyName === item.id.toString)).map {
       case Some(Right(_)) => true
       case _ => false
     } recover {
@@ -86,7 +86,7 @@ class DynamoDistinctCheck[A <: Payload, D: DynamoFormat](
     lazy val notificationsTable = Table[D](tableName)
     val dynamoPayload = toDynamoModel(item)
 
-    val putResult = scanamoAsync.exec(notificationsTable.given(not(attributeExists(partitionKeyName))).put(dynamoPayload))
+    val putResult = scanamoAsync.exec(notificationsTable.when(attributeNotExists(partitionKeyName)).put(dynamoPayload))
     putResult map {
       case Right(_) =>
         logger.info(s"Distinct event ${item.id} written to dynamodb $tableName")

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -3,7 +3,6 @@ package com.gu.mobile.notifications.football.lib
 import java.time.{LocalDate, LocalTime, ZonedDateTime}
 import com.gu.mobile.notifications.football.{Configuration, Logging}
 import com.gu.mobile.notifications.football.models.RawMatchData
-import org.joda.time.DateTime
 import pa.MatchDay
 import play.api.libs.json.{Format, Json}
 
@@ -12,7 +11,6 @@ import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
-case class EndedMatch(matchId: String, startTime: DateTime)
 
 case class PACompetition(
     id: String,

--- a/football/src/main/scala/com/gu/mobile/notifications/football/lib/S3DataStore.scala
+++ b/football/src/main/scala/com/gu/mobile/notifications/football/lib/S3DataStore.scala
@@ -1,15 +1,14 @@
 package com.gu.mobile.notifications.football.lib
 
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.S3Object
-import com.amazonaws.util.IOUtils
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import com.gu.mobile.notifications.football.Logging
 import play.api.libs.json.{Format, JsError, JsSuccess, Json}
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
-class S3DataStore[T](s3Client: AmazonS3, bucketName: String) extends Logging {
+class S3DataStore[T](s3Client: S3Client, bucketName: String) extends Logging {
   def fetch(path: String)(implicit format: Format[T]) : Future[List[T]] = {
     Try(parseS3Object(path)) match {
       case Success(list) => Future.successful(list)
@@ -20,7 +19,7 @@ class S3DataStore[T](s3Client: AmazonS3, bucketName: String) extends Logging {
   }
 
   private def parseS3Object(path: String)(implicit format: Format[T]) : List[T] = {
-    Json.fromJson[List[T]](Json.parse(asString(s3Client.getObject(bucketName, path)))) match {
+    Json.fromJson[List[T]](Json.parse(getObjectAsString(path))) match {
       case JsSuccess(list, __) =>
         logger.debug(s"Got ${list.length} items from s3 $bucketName, path $path")
         list
@@ -31,13 +30,11 @@ class S3DataStore[T](s3Client: AmazonS3, bucketName: String) extends Logging {
     }
   }
 
-  private def asString(s3Object: S3Object): String = {
-    val s3ObjectContent = s3Object.getObjectContent
-    try {
-      IOUtils.toString(s3ObjectContent)
-    }
-    finally {
-      s3ObjectContent.close()
-    }
+  private def getObjectAsString(path: String): String = {
+    val request = GetObjectRequest.builder()
+      .bucket(bucketName)
+      .key(path)
+      .build()
+    s3Client.getObjectAsBytes(request).asUtf8String()
   }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Maintenance work to migrate repo to AWS sdk v2.  Older Scanamo was not compatible with v1. 

Only the Football lambda has been migrated in this PR. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

- [x] deploy Football lambda to CODE and check football match played back successfully. 
  - dynamo tables recorded payloads as expected. 
  - Android and iOS debug received live activities/notifications

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
