### PR TITLE
Set up registrations metrics dashboard

### DIFF
--- a/cdk/lib/__snapshots__/registration.test.ts.snap
+++ b/cdk/lib/__snapshots__/registration.test.ts.snap
@@ -889,6 +889,80 @@ exports[`The Registration stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "RegistrationDashboard6EA9DE21": {
+      "Properties": {
+        "DashboardBody": {
+          "Fn::Join": [
+            "",
+            [
+              "{"widgets":[{"type":"metric","width":16,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Registration Insertions (Successful vs Failed)","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["Notifications/CODE/registration","SuccessfulRegistrationInsertion",{"color":"#2ca02c","label":"Successful","period":60,"stat":"Sum"}],["Notifications/CODE/registration","FailedRegistrationInsertion",{"color":"#d62728","label":"Failed","period":60,"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":3,"x":16,"y":0,"properties":{"view":"singleValue","title":"Failed Insertions (last 1h)","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","sparkline":true,"metrics":[["Notifications/CODE/registration","FailedRegistrationInsertion",{"color":"#d62728","label":"Failed","period":3600,"stat":"Sum"}]]}},{"type":"metric","width":12,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Registration Insertion Latency (ms)","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["Notifications/CODE/registration","RegistrationInsertionLatency",{"label":"Average","period":60}],["Notifications/CODE/registration","RegistrationInsertionLatency",{"label":"p99","period":60,"stat":"p99"}]],"yAxis":{}}},{"type":"metric","width":12,"height":6,"x":12,"y":6,"properties":{"view":"timeSeries","title":"ASG CPU Utilization (%)","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/EC2","CPUUtilization","AutoScalingGroupName","",
+              {
+                "Ref": "AutoScalingGroupRegistrationASG07AD2A4F",
+              },
+              ""]],"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"ALB Requests vs 5XX Errors","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/ApplicationELB","RequestCount","LoadBalancer","",
+              {
+                "Fn::GetAtt": [
+                  "LoadBalancerRegistration79F7817E",
+                  "LoadBalancerFullName",
+                ],
+              },
+              "",{"period":60,"stat":"Sum"}],["AWS/ApplicationELB","HTTPCode_Target_5XX_Count","LoadBalancer","",
+              {
+                "Fn::GetAtt": [
+                  "LoadBalancerRegistration79F7817E",
+                  "LoadBalancerFullName",
+                ],
+              },
+              "",{"period":60,"stat":"Sum","yAxis":"right"}]],"yAxis":{}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "mobile-notifications-registration-CODE",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "registration",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
     "SsmSshPolicy4CFC977E": {
       "Properties": {
         "PolicyDocument": {
@@ -2143,6 +2217,80 @@ exports[`The Registration stack matches the snapshot for PROD 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "RegistrationDashboard6EA9DE21": {
+      "Properties": {
+        "DashboardBody": {
+          "Fn::Join": [
+            "",
+            [
+              "{"widgets":[{"type":"metric","width":16,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Registration Insertions (Successful vs Failed)","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["Notifications/PROD/registration","SuccessfulRegistrationInsertion",{"color":"#2ca02c","label":"Successful","period":60,"stat":"Sum"}],["Notifications/PROD/registration","FailedRegistrationInsertion",{"color":"#d62728","label":"Failed","period":60,"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":8,"height":3,"x":16,"y":0,"properties":{"view":"singleValue","title":"Failed Insertions (last 1h)","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","sparkline":true,"metrics":[["Notifications/PROD/registration","FailedRegistrationInsertion",{"color":"#d62728","label":"Failed","period":3600,"stat":"Sum"}]]}},{"type":"metric","width":12,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Registration Insertion Latency (ms)","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["Notifications/PROD/registration","RegistrationInsertionLatency",{"label":"Average","period":60}],["Notifications/PROD/registration","RegistrationInsertionLatency",{"label":"p99","period":60,"stat":"p99"}]],"yAxis":{}}},{"type":"metric","width":12,"height":6,"x":12,"y":6,"properties":{"view":"timeSeries","title":"ASG CPU Utilization (%)","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/EC2","CPUUtilization","AutoScalingGroupName","",
+              {
+                "Ref": "AutoScalingGroupRegistrationASG07AD2A4F",
+              },
+              ""]],"yAxis":{}}},{"type":"metric","width":24,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"ALB Requests vs 5XX Errors","region":"",
+              {
+                "Ref": "AWS::Region",
+              },
+              "","metrics":[["AWS/ApplicationELB","RequestCount","LoadBalancer","",
+              {
+                "Fn::GetAtt": [
+                  "LoadBalancerRegistration79F7817E",
+                  "LoadBalancerFullName",
+                ],
+              },
+              "",{"period":60,"stat":"Sum"}],["AWS/ApplicationELB","HTTPCode_Target_5XX_Count","LoadBalancer","",
+              {
+                "Fn::GetAtt": [
+                  "LoadBalancerRegistration79F7817E",
+                  "LoadBalancerFullName",
+                ],
+              },
+              "",{"period":60,"stat":"Sum","yAxis":"right"}]],"yAxis":{}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "mobile-notifications-registration-PROD",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "registration",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/mobile-n10n",
+          },
+          {
+            "Key": "Stack",
+            "Value": "mobile-notifications",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
     },
     "SsmSshPolicy4CFC977E": {
       "Properties": {

--- a/cdk/lib/registration.ts
+++ b/cdk/lib/registration.ts
@@ -189,7 +189,9 @@ export class Registration extends GuStack {
 		const asgCpuUtilization = new Metric({
 			namespace: 'AWS/EC2',
 			metricName: 'CPUUtilization',
-			dimensionsMap: { AutoScalingGroupName: autoScalingGroup.autoScalingGroupName },
+			dimensionsMap: {
+				AutoScalingGroupName: autoScalingGroup.autoScalingGroupName,
+			},
 			statistic: 'Average',
 			period: Duration.minutes(5),
 		});

--- a/cdk/lib/registration.ts
+++ b/cdk/lib/registration.ts
@@ -7,7 +7,12 @@ import { GuAllowPolicy } from '@guardian/cdk/lib/constructs/iam';
 import { Duration } from 'aws-cdk-lib';
 import type { App } from 'aws-cdk-lib';
 import {
+	Color,
 	ComparisonOperator,
+	Dashboard,
+	GraphWidget,
+	Metric,
+	SingleValueWidget,
 	TreatMissingData,
 } from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
@@ -153,6 +158,92 @@ export class Registration extends GuStack {
 
 			alarm.addAlarmAction(snsAction);
 			alarm.addOkAction(snsAction);
+		});
+
+		const registrationMetricNamespace = `Notifications/${stage}/${app}`;
+
+		const failedInsertions = new Metric({
+			namespace: registrationMetricNamespace,
+			metricName: 'FailedRegistrationInsertion',
+			statistic: 'Sum',
+			period: Duration.minutes(1),
+			color: Color.RED,
+			label: 'Failed',
+		});
+
+		const successfulInsertions = new Metric({
+			namespace: registrationMetricNamespace,
+			metricName: 'SuccessfulRegistrationInsertion',
+			statistic: 'Sum',
+			period: Duration.minutes(1),
+			color: Color.GREEN,
+			label: 'Successful',
+		});
+
+		const insertionLatency = new Metric({
+			namespace: registrationMetricNamespace,
+			metricName: 'RegistrationInsertionLatency',
+			period: Duration.minutes(1),
+		});
+
+		const asgCpuUtilization = new Metric({
+			namespace: 'AWS/EC2',
+			metricName: 'CPUUtilization',
+			dimensionsMap: { AutoScalingGroupName: autoScalingGroup.autoScalingGroupName },
+			statistic: 'Average',
+			period: Duration.minutes(5),
+		});
+
+		new Dashboard(this, 'RegistrationDashboard', {
+			dashboardName: `mobile-notifications-registration-${stage}`,
+			widgets: [
+				[
+					new GraphWidget({
+						title: 'Registration Insertions (Successful vs Failed)',
+						left: [successfulInsertions, failedInsertions],
+						width: 16,
+					}),
+					new SingleValueWidget({
+						title: 'Failed Insertions (last 1h)',
+						metrics: [failedInsertions.with({ period: Duration.hours(1) })],
+						width: 8,
+						sparkline: true,
+					}),
+				],
+				[
+					new GraphWidget({
+						title: 'Registration Insertion Latency (ms)',
+						left: [
+							insertionLatency.with({ statistic: 'Average', label: 'Average' }),
+							insertionLatency.with({ statistic: 'p99', label: 'p99' }),
+						],
+						width: 12,
+					}),
+					new GraphWidget({
+						title: 'ASG CPU Utilization (%)',
+						left: [asgCpuUtilization],
+						width: 12,
+					}),
+				],
+				[
+					new GraphWidget({
+						title: 'ALB Requests vs 5XX Errors',
+						left: [
+							loadBalancer.metrics.requestCount({
+								period: Duration.minutes(1),
+								statistic: 'Sum',
+							}),
+						],
+						right: [
+							loadBalancer.metrics.httpCodeTarget(
+								HttpCodeTarget.TARGET_5XX_COUNT,
+								{ period: Duration.minutes(1), statistic: 'Sum' },
+							),
+						],
+						width: 24,
+					}),
+				],
+			],
 		});
 
 		adjustCloudformationParameters(this);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
