### PR TITLE
Update netty and aws sdk v2 versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ ThisBuild / scalacOptions ++= compilerOptions
 val playJsonVersion = "3.0.6"
 val specsVersion: String = "4.8.3"
 val awsSdkVersion: String = "1.12.797"
-val awsSdk2Version: String = "2.42.34"
+val awsSdk2Version: String = "2.54.13"
 val doobieVersion: String = "0.13.4"
 val catsVersion: String = "2.13.0"
 val okHttpVersion: String = "4.12.0"
@@ -49,7 +49,7 @@ val jacksonDatabind: String = "2.21.5"
 val jacksonScalaModule: String = "2.21.5"
 val simpleConfigurationVersion: String = "14.0.1"
 val googleOAuthClient: String = "1.39.0"
-val nettyVersion: String = "4.2.2.Final"
+val nettyVersion: String = "4.2.17.Final"
 val slf4jVersion: String = "1.7.36"
 val logbackVersion: String = "1.5.32"
 val scanamoVersion: String = "6.0.0"
@@ -302,7 +302,7 @@ lazy val commonEventBusPusher = project
   .dependsOn(apiModels  % "test->test", apiModels  % "compile->compile")
   .settings(Seq(
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "eventbridge" % "2.20.162"
+      "software.amazon.awssdk" % "eventbridge" % awsSdk2Version
     ),
   ))
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates Netty and AWS sdk v2 versions. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

- [x] all projects successfully deployed to CODE
- [x] new registration breaking news notification received on Android sim
- [x] new registration breaking news notification received on iOS debug app. 
- [x] code football match run


<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
